### PR TITLE
Fix segfault in mirror command

### DIFF
--- a/mport/mport.c
+++ b/mport/mport.c
@@ -293,11 +293,13 @@ main(int argc, char *argv[]) {
 			resultCode = configSet(mport, argv[2], argv[3]);
 		}
 	} else if (!strcmp(cmd, "mirror")) {
-		if (!strcmp(argv[1], "list")) {
-			loadIndex(mport);
-			printf("To set a mirror, use the following command:\n");
-			printf("mport set config mirror_region <country>\n\n");
-			resultCode = mport_index_print_mirror_list(mport);
+		if (argc > 2) {
+			if (!strcmp(argv[1], "list")) {
+				loadIndex(mport);
+				printf("To set a mirror, use the following command:\n");
+				printf("mport set config mirror_region <country>\n\n");
+				resultCode = mport_index_print_mirror_list(mport);
+			}
 		}
 	} else if (!strcmp(cmd, "cpe")) {
 		resultCode = cpeList(mport);


### PR DESCRIPTION
Without the `list` argument after `mirror` (`mport mirror`) cause a segment fault. Counting arguments and what passed should fix this.
![image](https://user-images.githubusercontent.com/71683721/202737458-af6aeb3d-f6dd-44e0-b493-cd5fe2611fde.png)
