### PR TITLE
Fix: Free allocated memory after finish

### DIFF
--- a/libexec/mport.check-fake/mport.check-fake.c
+++ b/libexec/mport.check-fake/mport.check-fake.c
@@ -267,6 +267,7 @@ grep_file(const char *filename, const char *destdir)
 	if (ferror(file) != 0)
 		err(EX_IOERR, "Error reading %s", filename);
 	
+	regfree(&regex);
 	fclose(file);
 	return ret;
 }

--- a/libexec/mport.create/mport.create.c
+++ b/libexec/mport.create/mport.create.c
@@ -60,6 +60,10 @@ int main(int argc, char *argv[])
 	// we need this to know if the user customized the "target_os" configuration.
 	// the caveat is that the userland it was built against could be wrong.
 	if (mport_instance_init(mport, NULL, NULL, false) != MPORT_OK) {
+		mport_instance_free(mport);
+		mport_pkgmeta_free(pack);
+		mport_createextras_free(extra);
+		mport_assetlist_free(assetlist);
 		errx(EXIT_FAILURE, "%s", mport_err_string());
 	}
 
@@ -113,7 +117,7 @@ int main(int argc, char *argv[])
 				if (mport_parse_plistfile(fp, assetlist) != 0) {
 					warnx("Could not parse plist file '%s'.\n", optarg);
 					fclose(fp);
-					exit(1);
+					goto cleanup;
 				}
 				fclose(fp);
 
@@ -183,8 +187,15 @@ int main(int argc, char *argv[])
 
 	if (mport_create_primative(mport, assetlist, pack, extra) != MPORT_OK) {
 		warnx("%s", mport_err_string());
-		exit(EXIT_FAILURE);
+		goto cleanup;
 	}
+
+cleanup:
+	mport_instance_free(mport);
+	mport_pkgmeta_free(pack);
+	mport_createextras_free(extra);
+	mport_assetlist_free(assetlist);
+	exit(EXIT_FAILURE);
 
 	return 0;
 }

--- a/libexec/mport.delete/mport.delete.c
+++ b/libexec/mport.delete/mport.delete.c
@@ -90,17 +90,20 @@ int main(int argc, char *argv[]) {
 	if (mport_instance_init(mport, NULL, NULL, false) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
 		exit(EXIT_FAILURE);
 	}
 
 	if (mport_pkgmeta_search_master(mport, &packs, where, arg) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
 		exit(EXIT_FAILURE);
 	}
 
 	if (packs == NULL) {
 		warnx("No packages installed matching '%s'", arg);
+		mport_instance_free(mport);
 		exit(3);
 	}
 
@@ -108,12 +111,14 @@ int main(int argc, char *argv[]) {
 		if (mport_delete_primative(mport, *packs, force) != MPORT_OK) {
 			warnx("%s", mport_err_string());
 			mport_instance_free(mport);
+			mport_pkgmeta_vec_free(packs);
 			exit(EXIT_FAILURE);
 		}
 		packs++;
 	}
 
 	mport_instance_free(mport);
+	mport_pkgmeta_vec_free(packs);
 
 	return (0);
 }

--- a/libexec/mport.fetch/mport.fetch.c
+++ b/libexec/mport.fetch/mport.fetch.c
@@ -93,6 +93,7 @@ main(int argc, char *argv[]) {
 
 	if (mport_index_lookup_pkgname(mport, argv[0], &indexEntries) != MPORT_OK) {
 		fprintf(stderr, "Error looking up package name %s: %d %s\n", argv[0], mport_err_code(), mport_err_string());
+		mport_instance_free(mport);
 		exit(mport_err_code());
 	}
 
@@ -108,6 +109,9 @@ main(int argc, char *argv[]) {
 			printf("Fetching %s\n", bundleFile);
 		if (mport_fetch_bundle(mport, directory == NULL ? MPORT_LOCAL_PKG_PATH: directory, bundleFile) != MPORT_OK) {
 			fprintf(stderr, "%s\n", mport_err_string());
+			free(bundleFile);
+			mport_instance_free(mport);
+			mport_index_entry_free_vec(indexEntries);
 			exit(mport_err_code());
 		}
 
@@ -115,6 +119,7 @@ main(int argc, char *argv[]) {
 	}
 
 	mport_instance_free(mport);
+	mport_index_entry_free_vec(indexEntries);
 
 	return (0);
 }

--- a/libexec/mport.info/mport.info.c
+++ b/libexec/mport.info/mport.info.c
@@ -89,6 +89,7 @@ main(int argc, char *argv[]) {
 
 	if (mport_instance_init(mport, NULL, NULL, false) != MPORT_OK) {
 		warnx("%s", mport_err_string());
+		mport_instance_free(mport);
 		exit(EXIT_FAILURE);
 	}
 

--- a/libexec/mport.list/mport.list.c
+++ b/libexec/mport.list/mport.list.c
@@ -115,6 +115,7 @@ main(int argc, char *argv[])
 	if (mport_pkgmeta_list(mport, &packs) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
 		exit(EXIT_FAILURE);
 	}
 	

--- a/libexec/mport.query/mport.query.c
+++ b/libexec/mport.query/mport.query.c
@@ -93,6 +93,7 @@ int main(int argc, char *argv[]) {
 	if (mport_pkgmeta_search_master(mport, &packs, where) != MPORT_OK) {
 		warnx("(where: %s): %s", where, mport_err_string());
 		mport_instance_free(mport);
+		free(where);
 		exit(EXIT_FAILURE);
 	}
 
@@ -100,6 +101,7 @@ int main(int argc, char *argv[]) {
 		if (!quiet)
 			warnx("No packages installed matching.");
 		mport_instance_free(mport);
+		free(where);
 		exit(3);
 	}
 
@@ -118,6 +120,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	mport_instance_free(mport);
+	free(where);
 
 	return 0;
 }

--- a/libexec/mport.update/mport.update.c
+++ b/libexec/mport.update/mport.update.c
@@ -74,6 +74,7 @@ int main(int argc, char *argv[]) {
 
 	if (mport_instance_init(mport, NULL, NULL, false) != MPORT_OK) {
 		warnx("%s", mport_err_string());
+		mport_instance_free(mport);
 		exit(EXIT_FAILURE);
 	}
 

--- a/libexec/mport.updepends/mport.updepends.c
+++ b/libexec/mport.updepends/mport.updepends.c
@@ -85,36 +85,49 @@ int main(int argc, char *argv[]) {
 
 	if (mport_instance_init(mport, NULL, NULL, false) != MPORT_OK) {
 		warnx("%s", mport_err_string());
+		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
+		mport_pkgmeta_vec_free(depends);
 		exit(1);
 	}
 
 	if (mport_pkgmeta_search_master(mport, &packs, where, arg) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
+		mport_pkgmeta_vec_free(depends);
 		exit(EXIT_FAILURE);
 	}
 
 	if (packs == NULL) {
 		warnx("No packages installed matching '%s'", arg);
 		mport_instance_free(mport);
+		if (depends != NULL)
+			mport_pkgmeta_vec_free(depends);
 		exit(3);
 	}
 
 	if (packs[1] != NULL) {
 		warnx("Ambiguous package identifier: %s", arg);
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
+		mport_pkgmeta_vec_free(depends);
 		exit(3);
 	}
 
 	if (mport_pkgmeta_get_updepends(mport, packs[0], &depends) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
+		mport_pkgmeta_vec_free(packs);
+		mport_pkgmeta_vec_free(depends);
 		exit(EXIT_FAILURE);
 	}
 
 	if (depends == NULL) {
 		/* no depends, nothing to print. */
 		mport_instance_free(mport);
+		if (packs != NULL)
+			mport_pkgmeta_vec_free(depends);
 		exit(EXIT_SUCCESS);
 	}
 


### PR DESCRIPTION
There are several exits where `mport` keeps the buffer in memory either on an error or when the program exit. 
Ths PR made changes to the following files.
```
1. mport.check-fake.c
2. mport.create.c
3. mport.delete.c
4. mport.fetch.c
5. mport.info.c
6. mport.list.c
7. mport.query.c
8. mport.update.c
9. mport.updepends.c
```
Patch file: [here](https://hastebin.com/giroduqoja.less)