### PR TITLE
Migrate rc.d start/stop to posix_spawn rather than using system

### DIFF
--- a/libmport/service.c
+++ b/libmport/service.c
@@ -26,11 +26,22 @@
  * SUCH DAMAGE.
  */
 
-#include "mport.h"
-#include "mport_private.h"
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <spawn.h>
 #include <stdlib.h>
 #include <string.h>
-#include <libgen.h>
+#include <unistd.h>
+
+#include "mport.h"
+#include "mport_private.h"
+
+extern char **environ;
+
+static int run_service_cmd(mportInstance *mport, const char *rc_script, char *command);
 
 int 
 mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_action_t action) 
@@ -45,12 +56,12 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 	// don't turn off services if MPORT_GUI is set.  This can drop someone out of an X session.
 	// TODO: we should handle this with triggers eventually.
 	if (getenv("MPORT_GUI") != NULL)
-		return MPORT_OK;
+		return (MPORT_OK);
 
     // if handle rc scripts is disabled, we don't need to do anything
 	handle_rc_script = mport_setting_get(mport, MPORT_SETTING_HANDLE_RC_SCRIPTS);
 	if (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script))
-	    return MPORT_OK;
+	    return (MPORT_OK);
 	
 	/* stop any services that might exist; this replaces @stopdaemon */
 	if (mport_db_prepare(mport->db, &stmt,
@@ -70,15 +81,47 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 		service = basename((char *)rc_script);
 
 		if (action == SERVICE_START) {
-			if (mport_xsystem(mport, "/usr/sbin/service %s quietstart", service) != 0) {
+			if (run_service_cmd(mport, service, "quietstart") != 0) {
 				mport_call_msg_cb(mport, "Unable to start service %s\n", service);
 			}
 		} else if (action == SERVICE_STOP) {
-			if (mport_xsystem(mport, "/usr/sbin/service %s forcestop", service) != 0) {
+			if (run_service_cmd(mport, service, "forcestop") != 0) {
 				mport_call_msg_cb(mport, "Unable to stop service %s\n", service);
 			}
 		}	
 	}
 
-	return MPORT_OK;
+	return (MPORT_OK);
+}
+
+static int
+run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
+{
+	int error, pstat;
+	pid_t pid;
+	const char *argv[4];
+	char *service;
+
+	if (rc_script == NULL || command == NULL)
+		return (0);
+
+	argv[0] = "service";
+	argv[1] = rc_script;
+	argv[2] = command;
+	argv[3] = NULL;
+
+	service = basename((char *)rc_script);
+
+	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL, (char **)argv, environ)) != 0) {
+		errno = error;
+		mport_call_msg_cb(mport, "Unable to %s service %s\n", command, service);
+		return (-1);
+	}
+
+	while (waitpid(pid, &pstat, 0) == -1) {
+		if (errno != EINTR)
+			return (-1);
+	}
+
+	return (WEXITSTATUS(pstat));
 }

--- a/libmport/service.c
+++ b/libmport/service.c
@@ -46,7 +46,7 @@ static int run_service_cmd(mportInstance *mport, const char *rc_script, char *co
 int 
 mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_action_t action) 
 {
-    sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt;
 	int ret;
 	char *service;
 	const unsigned char *rc_script;
@@ -58,14 +58,14 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 	if (getenv("MPORT_GUI") != NULL)
 		return (MPORT_OK);
 
-    // if handle rc scripts is disabled, we don't need to do anything
+	// if handle rc scripts is disabled, we don't need to do anything
 	handle_rc_script = mport_setting_get(mport, MPORT_SETTING_HANDLE_RC_SCRIPTS);
 	if (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script))
 	    return (MPORT_OK);
 	
 	/* stop any services that might exist; this replaces @stopdaemon */
 	if (mport_db_prepare(mport->db, &stmt,
-		"select * from assets where data like '/usr/local/etc/rc.d/%%' and type=%i and pkg=%Q",
+		"select data from assets where data like '/usr/local/etc/rc.d/%%' and type=%i and pkg=%Q",
 		ASSET_FILE, pack->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
@@ -111,7 +111,6 @@ run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
 	argv[3] = NULL;
 
 	service = basename((char *)rc_script);
-
 	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL, (char **)argv, environ)) != 0) {
 		errno = error;
 		mport_call_msg_cb(mport, "Unable to %s service %s\n", command, service);
@@ -119,8 +118,9 @@ run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
 	}
 
 	while (waitpid(pid, &pstat, 0) == -1) {
-		if (errno != EINTR)
+		if (errno != EINTR) {
 			return (-1);
+		}
 	}
 
 	return (WEXITSTATUS(pstat));


### PR DESCRIPTION
Switches from mport_xsystem to posix_spawn to avoid shell execution and limit some security risk here. It's also faster.

While here, tune sql query to just return the field we need.  This also fixes a bug when the rc.d script is not named after pkgname.  (most of the time)