### PR TITLE
Cut down on redundant database queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # mport
+
 MidnightBSD Package Manager
 
+## Building
+
+This project uses **BSD make** (bmake), not GNU make. On MidnightBSD, `make` is typically bmake.
+
+On Linux, install bmake and run:
+
+```sh
+bmake
+```
+
 ## Requirements
-Recent versions will run on MidnightBSD 3.0 and higher. 
+
+Recent versions will run on MidnightBSD 3.0 and higher.
 
 Depends on:
+
 * sqlite3
 * libarchive
 * bzip2
@@ -12,9 +25,10 @@ Depends on:
 * ucl
 
 Depends on included libs:
-external/tllist 
+external/tllist
 
 Versions prior to 2.1.0 also depended on
+
 * libdispatch
 * Blocksruntime
 
@@ -26,8 +40,8 @@ There was a breaking change in 2.1.6 in libmport with respect to mport_install a
 
 There was a breaking change in 2.6.0 in libmport which changed the mport_init function to use mportVerbosity rather than a boolean for quiet mode.
 
-mportVerbosity has three values currently: 
-MPORT_VQUIET, MPORT_VNORMAL, MPORT_VVERBOSE 
+mportVerbosity has three values currently:
+MPORT_VQUIET, MPORT_VNORMAL, MPORT_VVERBOSE
 
 There's also the new mport_verbosity function which translates quiet and verbose flags into the right value.
 
@@ -36,29 +50,39 @@ The last version that works with MidnightBSD 2.x is mport 2.6.5.
 ## Using mport
 
 In addition to the man page, you can also look at the BSD Magazine article on mport in the Feb 2012 issue.
-https://ia902902.us.archive.org/6/items/bsdmagazine/BSD_02_2012.pdf
+<https://ia902902.us.archive.org/6/items/bsdmagazine/BSD_02_2012.pdf>
 
 ### Quick and Dirty
 
 Installing a package named xorg:
 
-`mport install xorg`
+```sh
+mport install xorg
+```
 
 Deleting the xorg meta-package:
 
-`mport delete xorg`
+```sh
+mport delete xorg
+```
 
 Fetching the latest index
 
-`mport index`
+```sh
+mport index
+```
 
 Upgrading all packages
 
-`mport upgrade`
+```sh
+mport upgrade
+```
 
 Update a specific package (and its dependencies)
 
-`mport update xorg`
+```sh
+mport update xorg
+```
 
 ### Installing from package file
 
@@ -67,45 +91,69 @@ For example, installing a vim package that is already built locally
 `/usr/libexec/mport.install /usr/mports/Packages/amd64/All/vim-8.2.3394.mport` 
 
 ### Getting info on an installed package
-`mport info gmake`
 
-```
-gmake-4.3_2
+```sh
+mport info gmake
+
+gmake-4.4.1
 Name            : gmake
-Version         : 4.3_2
-Latest          : 4.3_2
+Version         : 4.4.1
+Latest          : 4.4.1
 Licenses        : gpl3
 Origin          : devel/gmake
 Flavor          : 
-OS              : 3.0
-CPE             : cpe:2.3:a:gnu:make:4.3:::::midnightbsd3:x64:2
-PURL            : pkg:mport/midnightbsd/gmake@4.3_2?arch=amd64&osrel=3.0
+OS              : 4.0
+CPE             : cpe:2.3:a:gnu:make:4.4.1:::::midnightbsd4:x64:0
+PURL            : pkg:generic/gmake@4.4.1?arch=amd64&distro=midnightbsd-4.0
 Locked          : no
 Prime           : yes
 Shared library  : no
 Deprecated      : no
 Expiration Date : 
-Install Date    : Tue Mar 28 17:51:14 2023
+Install Date    : Sat Jan 17 16:33:59 2026
 Comment         : GNU version of 'make' utility
+Annotations     :
+                       MidnightBSD_version:        �␦
+                       build_timestamp:        2026-01-17
+                       bundle_format_version:        6
+                       os_release:        4.0
 Options         : 
 Type            : Application
+Flat Size       : 2.1 MiB
 Description     :
+
 ```
+
 ### Security-related commands
 
-`mport audit`
+```sh
+mport audit
+```
+
 Displays vulnerable packages based on their CPE identifiers using the NVD data provided by https://sec.midnightbsd.org
 
-`mport audit -r`
+```sh
+mport audit -r
+```
+
 Prints out vulnerable packages and a list of packages depending on that one.
 
-`mport -q audit`
+```sh
+mport -q audit
+```
+
 Prints out vulnerable package name and version with no descriptions or details
 
-`mport cpe`
+```sh
+mport cpe
+```
+
 Lists all CPE info on installed packages
 
-`mport verify`
+```sh
+mport verify
+```
+
 Runs a checksum on all installed files from packages against data from time of installation to see if files have been modified.
 
 ### Known Bugs

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -61,7 +61,7 @@ struct ohash {
 #define MPORT_MASTER_VERSION 14
 #define MPORT_BUNDLE_VERSION 6
 #define MPORT_BUNDLE_VERSION_STR "6"
-#define MPORT_VERSION "2.7.5"
+#define MPORT_VERSION "2.7.6"
 
 #define MPORT_SETTING_MIRROR_REGION "mirror_region"
 #define MPORT_SETTING_TARGET_OS "target_os"
@@ -180,7 +180,7 @@ int mport_bundle_read_install_pkg(mportInstance *, mportBundleRead *, mportPacka
 int mport_bundle_read_update_pkg(mportInstance *, mportBundleRead *, mportPackageMeta *);
 
 int mport_install_depends(mportInstance *, const char *, const char *, mportAutomatic);
-int mport_update_down(mportInstance *, mportPackageMeta *, struct ohash_info *, struct ohash *);
+int mport_update_down(mportInstance *, mportPackageMeta *, struct ohash_info *, struct ohash *, struct ohash *);
 
 /* version compare functions */
 void mport_version_cmp_sqlite(sqlite3_context *, int, sqlite3_value **);

--- a/libmport/upgrade.c
+++ b/libmport/upgrade.c
@@ -61,6 +61,18 @@ efree(void *p, size_t s1, void *data){
 	free(p);
 }
 
+/* Cache structure for index check results */
+typedef struct {
+	int result;  /* 0 = no update, 1 = update available, 2 = origin match */
+	bool cached;
+} index_check_cache_t;
+
+/* Cache structure for moved lookup results */
+typedef struct {
+	mportIndexMovedEntry **entries;
+	bool cached;
+} moved_lookup_cache_t;
+
 MPORT_PUBLIC_API int
 mport_upgrade(mportInstance *mport) {
 	mportPackageMeta **packs, **packs_orig = NULL;
@@ -68,7 +80,10 @@ mport_upgrade(mportInstance *mport) {
 	int updated = 0;
 #if defined(__MidnightBSD__)
 	struct ohash_info info = { 0, NULL, ecalloc, efree, NULL };
-	struct ohash h;
+	struct ohash h;  /* Tracks processed packages */
+	struct ohash_info cache_info = { 0, NULL, ecalloc, efree, NULL };
+	struct ohash index_cache;  /* Caches index_check results */
+	struct ohash moved_cache;  /* Caches moved_lookup results */
 #endif
 	unsigned int slot;
 	char *key = NULL;
@@ -90,12 +105,15 @@ mport_upgrade(mportInstance *mport) {
 
 #if defined(__MidnightBSD__)
 	ohash_init(&h, 6, &info);
+	ohash_init(&index_cache, 6, &cache_info);
+	ohash_init(&moved_cache, 6, &cache_info);
 	#endif
 
 	// check for moved/expired packages first
 	packs = packs_orig;
 	while (*packs != NULL) {
-		mportIndexMovedEntry **movedEntries;
+		mportIndexMovedEntry **movedEntries = NULL;
+		bool use_cached_moved = false;
 
 		#if defined(__MidnightBSD__)
 		slot = ohash_qlookup(&h, (*packs)->name);
@@ -104,12 +122,36 @@ mport_upgrade(mportInstance *mport) {
 			packs++;
 			continue;
 		}
+
+		/* Check cache for moved lookup */
+		slot = ohash_qlookup(&moved_cache, (*packs)->origin);
+		moved_lookup_cache_t *cached_moved = (moved_lookup_cache_t *)ohash_find(&moved_cache, slot);
+		if (cached_moved != NULL && cached_moved->cached) {
+			movedEntries = cached_moved->entries;
+			use_cached_moved = true;
+		}
 		#endif
 
-		if (mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK ||
-		    movedEntries == NULL || *movedEntries == NULL) {
-			packs++;
-			continue;
+		if (!use_cached_moved) {
+			if (mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK ||
+			    movedEntries == NULL || *movedEntries == NULL) {
+				#if defined(__MidnightBSD__)
+				/* Cache negative result to avoid repeated queries */
+				moved_lookup_cache_t *cache_entry = (moved_lookup_cache_t *)ecalloc(sizeof(moved_lookup_cache_t), NULL);
+				cache_entry->entries = NULL;
+				cache_entry->cached = true;
+				ohash_insert(&moved_cache, slot, cache_entry);
+				#endif
+				packs++;
+				continue;
+			}
+			#if defined(__MidnightBSD__)
+			/* Cache positive result - entries are managed by mport_moved_lookup */
+			moved_lookup_cache_t *cache_entry = (moved_lookup_cache_t *)ecalloc(sizeof(moved_lookup_cache_t), NULL);
+			cache_entry->entries = movedEntries;
+			cache_entry->cached = true;
+			ohash_insert(&moved_cache, slot, cache_entry);
+			#endif
 		}
 
 		if ((*movedEntries)->date[0] != '\0') {
@@ -126,7 +168,7 @@ mport_upgrade(mportInstance *mport) {
 			continue;
 		}		
 
-		if ((*movedEntries)->moved_to_pkgname != NULL && (*movedEntries)->moved_to_pkgname[0]!= '\0') {   
+		if ((*movedEntries)->moved_to_pkgname[0] != '\0') {   
 			mport_call_msg_cb(mport, "Package %s has moved to %s. Migrating %s\n", (*packs)->name, (*movedEntries)->moved_to_pkgname,  (*movedEntries)->moved_to_pkgname);
 			(*packs)->action = MPORT_ACTION_UPGRADE;
 			mport_delete_primative(mport, (*packs), true);
@@ -149,13 +191,34 @@ mport_upgrade(mportInstance *mport) {
 		key = ohash_find(&h, slot);
 		if (key == NULL) {
 		#endif
-			int match = mport_index_check(mport, *packs);
+			int match;
+			bool use_cached_index = false;
+
+			#if defined(__MidnightBSD__)
+			/* Check cache for index_check result */
+			slot = ohash_qlookup(&index_cache, (*packs)->name);
+			index_check_cache_t *cached_index = (index_check_cache_t *)ohash_find(&index_cache, slot);
+			if (cached_index != NULL && cached_index->cached) {
+				match = cached_index->result;
+				use_cached_index = true;
+			} else {
+				match = mport_index_check(mport, *packs);
+				/* Cache the result */
+				index_check_cache_t *cache_entry = (index_check_cache_t *)ecalloc(sizeof(index_check_cache_t), NULL);
+				cache_entry->result = match;
+				cache_entry->cached = true;
+				ohash_insert(&index_cache, slot, cache_entry);
+			}
+			#else
+			match = mport_index_check(mport, *packs);
+			#endif
+
 			if (match == 1) {
 				(*packs)->action = MPORT_ACTION_UPGRADE;
 				#if defined(__MidnightBSD__)
-				updated += mport_update_down(mport, *packs, &info, &h);
+				updated += mport_update_down(mport, *packs, &info, &h, &index_cache);
 				#else
-				updated += mport_update_down(mport, *packs, NULL, NULL);
+				updated += mport_update_down(mport, *packs, NULL, NULL, NULL);
 				#endif
 			} else if (match == 2) {
 				mportIndexEntry **ieUpdateMe;
@@ -179,6 +242,7 @@ mport_upgrade(mportInstance *mport) {
 					// TODO: how to mark this action as an update?
 					mport_install_single(mport, (*ieUpdateMe)->pkgname,  NULL, NULL, (*packs)->automatic);
 					#if defined(__MidnightBSD__)
+					slot = ohash_qlookup(&h, (*ieUpdateMe)->pkgname);
 					ohash_insert(&h, slot, (*ieUpdateMe)->pkgname);
 					#endif
 					updated++;
@@ -195,6 +259,23 @@ mport_upgrade(mportInstance *mport) {
 	packs_orig = NULL;
 	packs = NULL;
 #if defined(__MidnightBSD__)
+	/* Free cached moved entries - only free the cache structures, not the actual entries */
+	/* The actual moved entries are managed elsewhere and may still be in use */
+	for (slot = ohash_first(&moved_cache, &key); key != NULL; slot = ohash_next(&moved_cache, &slot)) {
+		moved_lookup_cache_t *cache_entry = (moved_lookup_cache_t *)ohash_find(&moved_cache, slot);
+		if (cache_entry != NULL) {
+			efree(cache_entry, sizeof(moved_lookup_cache_t), NULL);
+		}
+	}
+	ohash_delete(&moved_cache);
+	/* Free index cache entries */
+	for (slot = ohash_first(&index_cache, &key); key != NULL; slot = ohash_next(&index_cache, &slot)) {
+		index_check_cache_t *cache_entry = (index_check_cache_t *)ohash_find(&index_cache, slot);
+		if (cache_entry != NULL) {
+			efree(cache_entry, sizeof(index_check_cache_t), NULL);
+		}
+	}
+	ohash_delete(&index_cache);
 	ohash_delete(&h);
 #endif
 
@@ -203,7 +284,7 @@ mport_upgrade(mportInstance *mport) {
 }
 
 int
-mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_info *info, struct ohash *h) {
+mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_info *info, struct ohash *h, struct ohash *index_cache) {
 	mportPackageMeta **depends, **depends_orig;
 	int ret = 0;
 	unsigned int slot;
@@ -217,7 +298,34 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 			key = ohash_find(h, slot);
 			#endif
 			if (key == NULL) {
-				if (mport_index_check(mport, pack)) {
+				int match;
+				bool use_cached = false;
+
+				#if defined(__MidnightBSD__)
+				if (index_cache != NULL) {
+					slot = ohash_qlookup(index_cache, pack->name);
+					index_check_cache_t *cached = (index_check_cache_t *)ohash_find(index_cache, slot);
+					if (cached != NULL && cached->cached) {
+						match = cached->result;
+						use_cached = true;
+					}
+				}
+				#endif
+
+				if (!use_cached) {
+					match = mport_index_check(mport, pack);
+					#if defined(__MidnightBSD__)
+					if (index_cache != NULL) {
+						/* Cache the result */
+						index_check_cache_t *cache_entry = (index_check_cache_t *)ecalloc(sizeof(index_check_cache_t), NULL);
+						cache_entry->result = match;
+						cache_entry->cached = true;
+						ohash_insert(index_cache, slot, cache_entry);
+					}
+					#endif
+				}
+
+				if (match) {
 					mport_call_msg_cb(mport, "Updating %s\n", pack->name);
 					pack->action = MPORT_ACTION_UPGRADE;
 					if (mport_update(mport, pack->name) !=0) {
@@ -226,6 +334,7 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 					} else {
 						ret = 1;
 #if defined(__MidnightBSD__)
+						slot = ohash_qlookup(h, pack->name);
 						ohash_insert(h, slot, pack->name);
 #endif
 					}
@@ -242,8 +351,36 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 				key = ohash_find(h, slot);
 #endif
 				if (key == NULL) {
-					ret += mport_update_down(mport, (*depends), info, h);
-					if (mport_index_check(mport, *depends)) {
+					ret += mport_update_down(mport, (*depends), info, h, index_cache);
+					
+					int match;
+					bool use_cached = false;
+
+					#if defined(__MidnightBSD__)
+					if (index_cache != NULL) {
+						slot = ohash_qlookup(index_cache, (*depends)->name);
+						index_check_cache_t *cached = (index_check_cache_t *)ohash_find(index_cache, slot);
+						if (cached != NULL && cached->cached) {
+							match = cached->result;
+							use_cached = true;
+						}
+					}
+					#endif
+
+					if (!use_cached) {
+						match = mport_index_check(mport, *depends);
+						#if defined(__MidnightBSD__)
+						if (index_cache != NULL) {
+							/* Cache the result */
+							index_check_cache_t *cache_entry = (index_check_cache_t *)ecalloc(sizeof(index_check_cache_t), NULL);
+							cache_entry->result = match;
+							cache_entry->cached = true;
+							ohash_insert(index_cache, slot, cache_entry);
+						}
+						#endif
+					}
+
+					if (match) {
 						mport_call_msg_cb(mport, "Updating depends %s\n", (*depends)->name);
 						(*depends)->action = MPORT_ACTION_UPGRADE;
 						if (mport_update(mport, (*depends)->name) != 0) {
@@ -251,6 +388,7 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 						} else {
 							ret++;
 #if defined(__MidnightBSD__)
+							slot = ohash_qlookup(h, (*depends)->name);
 							ohash_insert(h, slot, (*depends)->name);
 #endif
 						}
@@ -258,7 +396,35 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 				}
 				depends++;
 			}
-			if (mport_index_check(mport, pack)) {
+			
+			int match;
+			bool use_cached = false;
+
+			#if defined(__MidnightBSD__)
+			if (index_cache != NULL) {
+				slot = ohash_qlookup(index_cache, pack->name);
+				index_check_cache_t *cached = (index_check_cache_t *)ohash_find(index_cache, slot);
+				if (cached != NULL && cached->cached) {
+					match = cached->result;
+					use_cached = true;
+				}
+			}
+			#endif
+
+			if (!use_cached) {
+				match = mport_index_check(mport, pack);
+				#if defined(__MidnightBSD__)
+				if (index_cache != NULL) {
+					/* Cache the result */
+					index_check_cache_t *cache_entry = (index_check_cache_t *)ecalloc(sizeof(index_check_cache_t), NULL);
+					cache_entry->result = match;
+					cache_entry->cached = true;
+					ohash_insert(index_cache, slot, cache_entry);
+				}
+				#endif
+			}
+
+			if (match) {
 				if (mport_update(mport, pack->name) != 0) {
 					mport_call_msg_cb(mport, "Error updating %s\n", pack->name);
 				} else {


### PR DESCRIPTION
Add a performance optimization for mport_upgrade to cut down on redundant sqlite queries.

## Summary by Sourcery

Introduce caching of package index checks and moved package lookups in the upgrade path to reduce redundant database queries and bump the library version.

Enhancements:
- Add in-memory caches for mport_index_check results and moved package lookups during mport_upgrade to avoid repeated sqlite queries across packages and dependencies.
- Extend mport_update_down to reuse cached index check results throughout recursive dependency upgrades.

Build:
- Bump the internal mport library version from 2.7.5 to 2.7.6.