### PR TITLE
Fix some errors with mport add and delete paths

### DIFF
--- a/libmport/bundle_read.c
+++ b/libmport/bundle_read.c
@@ -274,7 +274,8 @@ mport_bundle_read_extract_next_file(mportBundleRead *bundle, struct archive_entr
 		ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_PERM |
 		    ARCHIVE_EXTRACT_TIME | ARCHIVE_EXTRACT_ACL |
 		    ARCHIVE_EXTRACT_FFLAGS) != ARCHIVE_OK) {
-		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
+		RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "%s: %s", archive_error_string(bundle->archive), entry != NULL ? archive_entry_pathname(entry) : "unknown file");
 	}
 
 	return (MPORT_OK);

--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -108,7 +108,7 @@ int mport_default_confirm_cb(const char *msg, const char *yes, const char *no, i
     ans = fgetln(stdin, &len);
     if (ans == NULL) {
       mport_set_errx(MPORT_ERR_FATAL, "Unable to read confirmation response.");
-      return -1;
+      return mport_err_code();
     }
 
     if (len == 1) { 

--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -106,6 +106,10 @@ int mport_default_confirm_cb(const char *msg, const char *yes, const char *no, i
   while (1) {
     /* get answer, if just \n, then default. */
     ans = fgetln(stdin, &len);
+    if (ans == NULL) {
+      mport_set_errx(MPORT_ERR_FATAL, "Unable to read confirmation response.");
+      return -1;
+    }
 
     if (len == 1) { 
       /* user just hit return */
@@ -203,4 +207,3 @@ void mport_default_progress_free_cb(void)
   (void)printf("\n");
   (void)fflush(stdout);
 }
-

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -322,8 +322,13 @@ cleanup:
 	}
 	free(dir);
 	dir = NULL;
-	free(dependencies);
-	dependencies = NULL;
+	if (dependencies != NULL) {
+		char **dptr = dependencies;
+		while (*dptr != NULL)
+			free(*dptr++);
+		free(dependencies);
+		dependencies = NULL;
+	}
 
 	return ret;
 }

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -249,8 +249,10 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		}
 	}
 
-	if ((bundle = mport_bundle_read_new()) == NULL)
-		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	if ((bundle = mport_bundle_read_new()) == NULL) {
+		ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
+		goto cleanup;
+	}
 
 	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_init(bundle, filename));
 	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_prep_for_install(mport, bundle));

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -36,6 +36,14 @@
 static char ** get_dependencies(mportInstance *mport, mportPackageMeta *pack);
 static char *find_file_with_prefix(const char *dir, const char *prefix);
 
+#define GOTO_CLEANUP_ON_MPORT_ERR(expr) \
+	do { \
+		if ((expr) != MPORT_OK) { \
+			ret = mport_err_code(); \
+			goto cleanup; \
+		} \
+	} while (0)
+
 static char **
 get_dependencies(mportInstance *mport, mportPackageMeta *pkg)
 {
@@ -149,7 +157,6 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 	mportPackageMeta *pkg = NULL;
 	int i;
 	int ret = MPORT_OK;
-	bool error = false;
 	char **dependencies = NULL;
 	char **deps = NULL;
 	char *dir = NULL;
@@ -167,23 +174,9 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		if ((bundle = mport_bundle_read_new()) == NULL)
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
-		if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
-		{
-			ret = mport_err_code();
-			goto cleanup;
-		}
-
-		if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
-		{
-			ret = mport_err_code();
-			goto cleanup;
-		}
-
-		if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
-		{
-			ret = mport_err_code();
-			goto cleanup;
-		}
+		GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_init(bundle, filename));
+		GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_prep_for_install(mport, bundle));
+		GOTO_CLEANUP_ON_MPORT_ERR(mport_pkgmeta_read_stub(mport, &pkgs));
 
 		if (!mport_is_age_verified(mport, pkgs[0])) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkgs[0]->name, pkgs[0]->version);
@@ -212,10 +205,7 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		}
 		dependencies = get_dependencies(mport, pkgs[0]);
 
-		if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
-			ret = mport_err_code();
-			goto cleanup;
-		}
+		GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_finish(mport, bundle));
 		bundle = NULL;
 
 		if (pkgs != NULL) {
@@ -258,23 +248,9 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 	if ((bundle = mport_bundle_read_new()) == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
-	if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
-	{
-		ret = mport_err_code();
-		goto cleanup;
-	}
-
-	if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
-	{
-		ret = mport_err_code();
-		goto cleanup;
-	}
-
-	if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
-	{
-		ret = mport_err_code();
-		goto cleanup;
-	}
+	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_init(bundle, filename));
+	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_prep_for_install(mport, bundle));
+	GOTO_CLEANUP_ON_MPORT_ERR(mport_pkgmeta_read_stub(mport, &pkgs));
 
 	for (i = 0; *(pkgs + i) != NULL; i++) {
 		pkg = pkgs[i];
@@ -284,7 +260,7 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 
 		if (!mport_is_age_verified(mport, pkg)) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkg->name, pkg->version);
-			error = true;
+			ret = MPORT_ERR_FATAL;
 			break; /* do not keep going if we have an age verification failure! */
 		}
 
@@ -311,32 +287,33 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
                    || (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkg->name, pkg->version,
 			                  mport_err_string());
-			error = true;
+			ret = MPORT_ERR_FATAL;
 			break; /* do not keep going if we have a package failure! */
 		}
 	}
 
-	if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
-		ret = mport_err_code();
-		goto cleanup;
-	}
+	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_finish(mport, bundle));
 	bundle = NULL;
-
-	if (error)
-		ret = MPORT_ERR_FATAL;
 
 cleanup:
 	if (bundle != NULL) {
 		if (mport_bundle_read_finish(mport, bundle) != MPORT_OK && ret == MPORT_OK)
 			ret = mport_err_code();
+		bundle = NULL;
 	}
 
-	if (already_installed != NULL)
+	if (already_installed != NULL) {
 		mport_pkgmeta_vec_free(already_installed);
-	if (pkgs != NULL)
+		already_installed = NULL;
+	}
+	if (pkgs != NULL) {
 		mport_pkgmeta_vec_free(pkgs);
+		pkgs = NULL;
+	}
 	free(dir);
+	dir = NULL;
 	free(dependencies);
+	dependencies = NULL;
 
 	return ret;
 }

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -148,9 +148,11 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 	mportPackageMeta **pkgs = NULL;
 	mportPackageMeta *pkg = NULL;
 	int i;
+	int ret = MPORT_OK;
 	bool error = false;
 	char **dependencies = NULL;
 	char **deps = NULL;
+	char *dir = NULL;
 
 	if (mport == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "mport not initialized");
@@ -166,17 +168,27 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
 		if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
-			RETURN_CURRENT_ERROR;
+		{
+			ret = mport_err_code();
+			goto cleanup;
+		}
 
 		if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
-			RETURN_CURRENT_ERROR;
+		{
+			ret = mport_err_code();
+			goto cleanup;
+		}
 
 		if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
-			RETURN_CURRENT_ERROR;
+		{
+			ret = mport_err_code();
+			goto cleanup;
+		}
 
 		if (!mport_is_age_verified(mport, pkgs[0])) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkgs[0]->name, pkgs[0]->version);
-			return MPORT_ERR_FATAL;
+			ret = MPORT_ERR_FATAL;
+			goto cleanup;
 		}
 
 		/* if we previously installed it and want to force, allow it.  
@@ -187,22 +199,32 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 				mport_delete_primative(mport, pkgs[0], 1);
 			} else {
 				mport_call_msg_cb(mport, "%s-%s: already installed.", pkgs[0]->name, pkgs[0]->version);
-				return MPORT_OK;
+				ret = MPORT_OK;
+				goto cleanup;
 			}
 		}
 
 		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_CONFLICTS) != MPORT_OK) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkgs[0]->name, pkgs[0]->version,
 			                  mport_err_string());
-			return MPORT_ERR_FATAL;
+			ret = MPORT_ERR_FATAL;
+			goto cleanup;
 		}
 		dependencies = get_dependencies(mport, pkgs[0]);
 
-		// close so we can safely process depdendencies. ignore errors for this one.
-		mport_bundle_read_finish(mport, bundle);
+		if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
+			ret = mport_err_code();
+			goto cleanup;
+		}
+		bundle = NULL;
+
+		if (pkgs != NULL) {
+			mport_pkgmeta_vec_free(pkgs);
+			pkgs = NULL;
+		}
 
 		deps = dependencies;
-		char *dir = mport_directory(filename);
+		dir = mport_directory(filename);
 		while (deps!= NULL && *deps != NULL) {
 			char *dep_filename = NULL; 
 			if (asprintf(&dep_filename, "%s/%s.mport", dir, *deps) == -1) {
@@ -222,27 +244,37 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 
 			if (mport_install_primative(mport, dep_filename, prefix, MPORT_AUTOMATIC)!= MPORT_OK) {
 				mport_call_msg_cb(mport, "Unable to install %s: %s", *deps, mport_err_string());
-				if (!mport->ignoreMissing)
-					return MPORT_ERR_FATAL;
+				if (!mport->ignoreMissing) {
+					free(dep_filename);
+					ret = MPORT_ERR_FATAL;
+					goto cleanup;
+				}
 			}
 			free(dep_filename);
 			deps++;
 		}
-		free(dir);
-		free(dependencies);
 	}
 
 	if ((bundle = mport_bundle_read_new()) == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
 	if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
-		RETURN_CURRENT_ERROR;
+	{
+		ret = mport_err_code();
+		goto cleanup;
+	}
 
 	if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
-		RETURN_CURRENT_ERROR;
+	{
+		ret = mport_err_code();
+		goto cleanup;
+	}
 
 	if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
-		RETURN_CURRENT_ERROR;
+	{
+		ret = mport_err_code();
+		goto cleanup;
+	}
 
 	for (i = 0; *(pkgs + i) != NULL; i++) {
 		pkg = pkgs[i];
@@ -252,6 +284,7 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 
 		if (!mport_is_age_verified(mport, pkg)) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkg->name, pkg->version);
+			error = true;
 			break; /* do not keep going if we have an age verification failure! */
 		}
 
@@ -261,14 +294,17 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 					pkg->automatic = already_installed[0]->automatic; // honor old flag
 				}
 				mport_pkgmeta_vec_free(already_installed);
+				already_installed = NULL;
 			}
 		}
 
 		if (prefix != NULL) {
 			/* override the default prefix with the given prefix */
 			free(pkg->prefix);
-			if ((pkg->prefix = strdup(prefix)) == NULL) /* all hope is lost! bail */
-				RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+			if ((pkg->prefix = strdup(prefix)) == NULL) { /* all hope is lost! bail */
+				ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
+				goto cleanup;
+			}
 		}
 
 		if ((mport_check_preconditions(mport, pkg, MPORT_PRECHECK_INSTALLED | MPORT_PRECHECK_DEPENDS | MPORT_PRECHECK_CONFLICTS) != MPORT_OK)
@@ -280,11 +316,27 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		}
 	}
 
-	if (mport_bundle_read_finish(mport, bundle) != MPORT_OK)
-		RETURN_CURRENT_ERROR;
+	if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
+		ret = mport_err_code();
+		goto cleanup;
+	}
+	bundle = NULL;
 
 	if (error)
-		return MPORT_ERR_FATAL;
+		ret = MPORT_ERR_FATAL;
 
-	return MPORT_OK;
+cleanup:
+	if (bundle != NULL) {
+		if (mport_bundle_read_finish(mport, bundle) != MPORT_OK && ret == MPORT_OK)
+			ret = mport_err_code();
+	}
+
+	if (already_installed != NULL)
+		mport_pkgmeta_vec_free(already_installed);
+	if (pkgs != NULL)
+		mport_pkgmeta_vec_free(pkgs);
+	free(dir);
+	free(dependencies);
+
+	return ret;
 }

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -205,7 +205,11 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		}
 		dependencies = get_dependencies(mport, pkgs[0]);
 
-		GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_finish(mport, bundle));
+		if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
+			ret = mport_err_code();
+			bundle = NULL;
+			goto cleanup;
+		}
 		bundle = NULL;
 
 		if (pkgs != NULL) {
@@ -292,7 +296,11 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		}
 	}
 
-	GOTO_CLEANUP_ON_MPORT_ERR(mport_bundle_read_finish(mport, bundle));
+	if (mport_bundle_read_finish(mport, bundle) != MPORT_OK) {
+		ret = mport_err_code();
+		bundle = NULL;
+		goto cleanup;
+	}
 	bundle = NULL;
 
 cleanup:

--- a/libmport/instance.c
+++ b/libmport/instance.c
@@ -335,7 +335,7 @@ mport_call_msg_cb(mportInstance *mport, const char *fmt, ...) {
  * @param def The default option (1 for yes, 0 for no). (an int so custom logic can be expressed)
  *
  * @return true if the user confirms or if ASSUME_ALWAYS_YES is set,
- *         false if the user declines.
+ *         false if the user declines or the callback reports an error.
  */
 MPORT_PUBLIC_API bool
 mport_call_confirm_cb(mportInstance *mport, const char *msg, const char *yes, const char *no, int def) {

--- a/libmport/mport.h
+++ b/libmport/mport.h
@@ -53,6 +53,12 @@ typedef void (*mport_msg_cb)(const char *);
 typedef void (*mport_progress_init_cb)(const char *);
 typedef void (*mport_progress_step_cb)(int, int, const char *);
 typedef void (*mport_progress_free_cb)(void);
+/*
+ * Confirmation callbacks return MPORT_OK when the action is confirmed.
+ * Any non-OK value is treated as a declined or failed confirmation.
+ * Callbacks may set the mport error state to distinguish I/O failures
+ * from an explicit "no" response.
+ */
 typedef int (*mport_confirm_cb)(const char *, const char *, const char *, int);
 
 typedef tll(char *) stringlist_t;

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -273,6 +273,10 @@ main(int argc, char *argv[])
 
 		if (local_argc > 1) {
 			int ch2;
+#if defined(__MidnightBSD__)
+			optreset = 1;
+#endif
+			optind = 1;
 			while ((ch2 = getopt(local_argc, local_argv, "y")) != -1) {
 				switch (ch2) {
 				case 'y':

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -268,7 +268,22 @@ main(int argc, char *argv[])
 			mport_instance_free(mport);
 			usage();
 		}
-		resultCode = deleteMany(mport, argc, argv, true);
+		int local_argc = argc;
+		char **local_argv = argv;
+
+		if (local_argc > 1) {
+			int ch2;
+			while ((ch2 = getopt(local_argc, local_argv, "y")) != -1) {
+				switch (ch2) {
+				case 'y':
+					setenv("ASSUME_ALWAYS_YES", "1", 1);
+					break;
+				}
+			}
+			local_argc -= optind;
+			local_argv += optind;
+		}
+		resultCode = deleteMany(mport, local_argc, local_argv, false);
 	} else if (!strcmp(cmd, "update")) {
 		if (argc == 1) {
 			mport_instance_free(mport);


### PR DESCRIPTION
## Summary by Sourcery

Improve error handling and resource cleanup during mport installation and deletion workflows.

Bug Fixes:
- Ensure mport_install_primative consistently frees resources and returns accurate error codes on failures, including during dependency handling and age checks.
- Fix mport delete command argument parsing so confirmation flags are handled correctly and batch deletions respect ASSUME_ALWAYS_YES.
- Prevent crashes in the default confirmation callback when stdin input fails by checking fgetln results.
- Provide more informative error reporting when archive extraction fails, including the affected file path.

Enhancements:
- Refine mport_install_primative control flow to centralize cleanup logic and avoid leaks of package metadata, bundles, and temporary paths.