### PR TITLE
Enforce HTTPS for index and package mirror fetches

### DIFF
--- a/libmport/fetch.c
+++ b/libmport/fetch.c
@@ -46,6 +46,7 @@
 static int fetch(mportInstance *, const char *, const char *);
 static int fetch_bundle_to_dir(mportInstance *, const char *, const char *, const char *);
 static int fetch_to_file(mportInstance *, const char *, FILE *, bool);
+static bool url_is_https(const char *);
 
 
 /* mport_fetch_index(mport)
@@ -79,6 +80,11 @@ mport_fetch_index(mportInstance *mport)
 	while (mirrorsPtr != NULL) {
 		if (*mirrorsPtr == NULL)
 			break;
+		if (!url_is_https(*mirrorsPtr)) {
+			mport_call_msg_cb(mport, "Skipping non-HTTPS mirror URL: %s\n", *mirrorsPtr);
+			mirrorsPtr++;
+			continue;
+		}
 		
 		if (asprintf(&url, "%s/%s/%s/%s", *mirrorsPtr,  MPORT_ARCH, osrel, MPORT_INDEX_FILE_SOURCE) == -1 ||
 		    asprintf(&hashUrl, "%s/%s/%s/%s", *mirrorsPtr,  MPORT_ARCH, osrel, MPORT_INDEX_FILE_SOURCE ".sha256") == -1) {
@@ -144,6 +150,10 @@ mport_fetch_bootstrap_index(mportInstance *mport)
 	char *osrel;
 
 	osrel = mport_get_osrelease(mport);
+	if (!url_is_https(MPORT_BOOTSTRAP_INDEX_URL)) {
+		free(osrel);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Bootstrap index URL must use HTTPS");
+	}
 
 	if (asprintf(&url, "%s/%s/%s/%s", MPORT_BOOTSTRAP_INDEX_URL, MPORT_ARCH, osrel, MPORT_INDEX_FILE_SOURCE) == -1 ||
 	    asprintf(&hashUrl, "%s/%s/%s/%s", MPORT_BOOTSTRAP_INDEX_URL,  MPORT_ARCH, osrel, MPORT_INDEX_FILE_SOURCE ".sha256") == -1) {
@@ -207,6 +217,11 @@ mport_fetch_bundle(mportInstance *mport, const char *directory, const char *file
 	while (mirrorsPtr != NULL) {
 		if (*mirrorsPtr == NULL)
 			break;
+		if (!url_is_https(*mirrorsPtr)) {
+			mport_call_msg_cb(mport, "Skipping non-HTTPS mirror URL: %s\n", *mirrorsPtr);
+			mirrorsPtr++;
+			continue;
+		}
 		if (asprintf(&url, "%s/%s/%s/%s", *mirrorsPtr,  MPORT_ARCH, osrel, filename) == -1) {
 			free(osrel);
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
@@ -230,6 +245,15 @@ mport_fetch_bundle(mportInstance *mport, const char *directory, const char *file
 		free(mirrors[mi]);
 
 	RETURN_CURRENT_ERROR; 
+}
+
+static bool
+url_is_https(const char *url)
+{
+	if (url == NULL)
+		return false;
+
+	return strncasecmp(url, "https://", 8) == 0;
 }
 
 


### PR DESCRIPTION
### Motivation
- The package index/bootstrap and mirror fetch logic trusted plaintext HTTP URLs, enabling on-path or mirror tampering to supply a forged index and attacker-controlled packages. 
- Provide a small, focused hardening that reduces exposure from transport-layer tampering without redesigning the repository trust model.

### Description
- Add a `url_is_https` helper and require mirror URLs to start with `https://` in `mport_fetch_index` and `mport_fetch_bundle` so non-HTTPS mirrors are skipped. 
- Add a guard in `mport_fetch_bootstrap_index` to fail if `MPORT_BOOTSTRAP_INDEX_URL` is not HTTPS. 
- Emit callback messages with `mport_call_msg_cb` when non-HTTPS mirror URLs are skipped to aid operators. 
- This change is intentionally minimal and does not add index signing or new cryptographic trust metadata.

### Testing
- No automated test suite was executed in this environment; please run the project CI/build and relevant unit/integration tests on the target BSD environment (for example via `make`/CI) to validate behavior and platform integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d7ad105c832284138d6bacffcf26)

## Summary by Sourcery

Enforce HTTPS-only transport for fetching package indexes and bundles to harden against tampering.

Enhancements:
- Require HTTPS for all mirror URLs used when fetching package indexes and bundles, skipping non-HTTPS mirrors and notifying via the message callback.
- Validate that the bootstrap index URL is HTTPS and fail early if it is not.