### PR TITLE
Constrain @sample destination handling to mport root

### DIFF
--- a/libmport/bundle_read_install_pkg.c
+++ b/libmport/bundle_read_install_pkg.c
@@ -546,13 +546,13 @@ create_sample_file(mportInstance *mport, char *cwd, const char *file)
 	if (file[0] != '/')
 		(void) snprintf(nonSample, FILENAME_MAX, "%s%s/%s", mport->root, cwd, file);
 	else
-		strlcpy(nonSample, file, FILENAME_MAX * 2);
+		(void) snprintf(nonSample, FILENAME_MAX * 2, "%s%s", mport->root, file);
 
 	char **fileargv = parse_sample(nonSample);
 
 	if (fileargv[1] != NULL) {
 		if (fileargv[1][0] == '/')
-			strlcpy(secondFile, fileargv[1], FILENAME_MAX);
+			(void) snprintf(secondFile, FILENAME_MAX, "%s%s", mport->root, fileargv[1]);
 		else
 			(void) snprintf(secondFile, FILENAME_MAX, "%s%s/%s", mport->root, cwd, fileargv[1]);
 


### PR DESCRIPTION
### Motivation
- Prevent package-controlled absolute `@sample` paths from causing `mport_mkdir()`/`mport_copy_file()` to create or write outside the configured `mport->root`, which breaks DESTDIR-style confinement.

### Description
- In `create_sample_file()` (`libmport/bundle_read_install_pkg.c`) rebase absolute `file` inputs under `mport->root` by building `nonSample` as `"%s%s"` instead of copying the host-absolute path directly.
- For two-argument `@sample` entries, rebase absolute `fileargv[1]` under `mport->root` when constructing `secondFile` (`"%s%s"`) instead of using the unprefixed absolute destination.
- All other logic (existence checks, `mport_directory()`, `mport_mkdir()`, and `mport_copy_file()`) is unchanged so behavior is preserved when `mport->root` is `/`.

### Testing
- Ran `make -C libmport` which failed because GNU `make` cannot parse the repository's BSD-style `Makefile` (`missing separator`), so a local build did not complete.
- Attempted `bmake -C libmport` but `bmake` is not installed in this environment, so the BSD make build could not be executed.
- No automated unit tests were executed here; the change is minimal and intended to be validated by integration tests verifying DESTDIR/mroot confinement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b1e065088322ae1b80f41e3097ca)

## Summary by Sourcery

Bug Fixes:
- Ensure absolute @sample file and secondary paths are rewritten under mport->root to prevent file creation or writes outside the installation root.