### PR TITLE
Harden privileged metafile tempdir selection

### DIFF
--- a/libmport/bundle_read.c
+++ b/libmport/bundle_read.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <errno.h>
 #include <archive_entry.h>
+#include <unistd.h>
 
 /*
  * mport_bundle_read_new()
@@ -147,9 +148,17 @@ mport_bundle_read_extract_metafiles(mportBundleRead *bundle, char **dirnamep)
 	char dirtmpl[MAXPATHLEN];
 	char *tmpdir;
 
-	tmpdir = getenv("TMPDIR");
-	if (tmpdir == NULL)
+	/*
+	 * If running with elevated privileges, do not trust TMPDIR from the
+	 * environment for security-sensitive metadata extraction.
+	 */
+	if (geteuid() == 0) {
 		tmpdir = "/tmp";
+	} else {
+		tmpdir = getenv("TMPDIR");
+		if (tmpdir == NULL)
+			tmpdir = "/tmp";
+	}
 
 	strlcpy(dirtmpl, tmpdir, sizeof(dirtmpl));
 	strlcat(dirtmpl, "/mport.XXXXXXXX", sizeof(dirtmpl));

--- a/libmport/bundle_read.c
+++ b/libmport/bundle_read.c
@@ -149,16 +149,12 @@ mport_bundle_read_extract_metafiles(mportBundleRead *bundle, char **dirnamep)
 	char *tmpdir;
 
 	/*
-	 * If running with elevated privileges, do not trust TMPDIR from the
-	 * environment for security-sensitive metadata extraction.
+	 * Do not trust TMPDIR when running with elevated privileges or in a
+	 * setuid/setgid context to prevent environment-based attacks.
 	 */
-	if (geteuid() == 0) {
+	tmpdir = (issetugid() || geteuid() == 0) ? NULL : getenv("TMPDIR");
+	if (tmpdir == NULL || *tmpdir == '\0')
 		tmpdir = "/tmp";
-	} else {
-		tmpdir = getenv("TMPDIR");
-		if (tmpdir == NULL)
-			tmpdir = "/tmp";
-	}
 
 	strlcpy(dirtmpl, tmpdir, sizeof(dirtmpl));
 	strlcat(dirtmpl, "/mport.XXXXXXXX", sizeof(dirtmpl));


### PR DESCRIPTION
### Motivation
- `mport_bundle_read_extract_metafiles()` previously created package metadata extraction directories under `getenv("TMPDIR")` unconditionally, which allows a local attacker who can control an inherited `TMPDIR` to race/replace the temp tree and supply attacker-controlled metadata/hook files that a privileged process later trusts and executes. 
- The intent is to remove that privileged-path trust while preserving current behavior for non-root callers.

### Description
- Added `#include <unistd.h>` and changed `mport_bundle_read_extract_metafiles()` to force the temp root to `/tmp` when `geteuid() == 0`.
- For non-root processes the previous semantics are preserved by still honoring `TMPDIR` when set and falling back to `/tmp` otherwise.
- The `mkdtemp()`-based directory creation and subsequent extraction/attachment logic are left intact to minimize behavioral changes.

### Testing
- Ran `rg -n "getenv(\"TMPDIR\")|mkdtemp(" libmport` to locate and verify occurrences; this check succeeded.
- Inspected the modified file with `sed` and `nl` (e.g. `sed -n '120,240p' libmport/bundle_read.c` and `nl -ba libmport/bundle_read.c | sed -n '30,180p'`) to confirm the new `geteuid()` conditional and added include; these inspections succeeded.
- Executed the `python`-based edit used to produce the patch; the replacement completed successfully.
- Attempted a full build with `make CFLAGS='-O0 -g'` in this Linux container but it failed due to the repository's BSD `Makefile` syntax, so a full build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b8a07ec8832290fdc2db64c4d065)

## Summary by Sourcery

Bug Fixes:
- Prevent privileged metadata extraction from using an environment-controlled TMPDIR by forcing /tmp when running as root while preserving existing behavior for non-root callers.