### PR TITLE
Honor legacy REPO_AUTOUPDATE setting for index updates

### DIFF
--- a/libmport/index.c
+++ b/libmport/index.c
@@ -95,10 +95,15 @@ mport_index_load(mportInstance *mport)
 	bool noIndex = mport->noIndex; /* must come after index file path call */
 
 	char *autoupdate = mport_setting_get(mport, MPORT_SETTING_REPO_AUTOUPDATE);
+	if (autoupdate == NULL) {
+		autoupdate = mport_setting_get(mport, MPORT_SETTING_REPO_AUTOUPDATE_LEGACY);
+	}
 	if (autoupdate != NULL && (strcmp("FALSE", autoupdate) == 0 || strcmp("false", autoupdate) == 0 ||
 			strcmp("NO", autoupdate) == 0 || strcmp("no", autoupdate) == 0)) {
 		noIndex = true;
 	}
+	if (autoupdate != NULL)
+		free(autoupdate);
 	
 	if (mport_file_exists(indexFile)) {
 		if (attach_index_db(mport->db) != MPORT_OK) {

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -279,6 +279,7 @@ int mport_script_run_child(mportInstance *, int, int *, int, const char*);
 #define MPORT_MAX_INDEX_AGE (MPORT_DAY * 7) /* one week */
 #define MPORT_SETTING_INDEX_LAST_CHECKED "index_last_check"
 #define MPORT_SETTING_REPO_AUTOUPDATE "index_autoupdate"
+#define MPORT_SETTING_REPO_AUTOUPDATE_LEGACY "REPO_AUTOUPDATE"
 #define MPORT_SETTING_HANDLE_RC_SCRIPTS "handle_rc_scripts"
 
 /* Binaries we use */


### PR DESCRIPTION
### Motivation
- A rename of the persistent repository autoupdate key from `REPO_AUTOUPDATE` to `index_autoupdate` caused existing opt-out rows to be ignored, which can re-enable automatic index fetches on upgraded systems.
- Restoring backward compatibility prevents unexpected network index fetches that could expose later package operations to attacker-controlled metadata.

### Description
- Add a legacy settings constant `MPORT_SETTING_REPO_AUTOUPDATE_LEGACY` with the name `"REPO_AUTOUPDATE"` in `libmport/mport_private.h`.
- In `mport_index_load()` read `MPORT_SETTING_REPO_AUTOUPDATE` first and fall back to `MPORT_SETTING_REPO_AUTOUPDATE_LEGACY` when the new key is missing, preserving the `NO/FALSE` semantics.
- Free the returned setting string after use to avoid a memory leak.

### Testing
- Attempted to run `make -n` in this Linux container, but it failed with `Makefile:6: *** missing separator.  Stop.` because the repository uses BSD-style makefiles and is not directly buildable here, so no full build or unit test run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cdb8898c8322ac2a7de43c605f05)

## Summary by Sourcery

Honor legacy REPO_AUTOUPDATE setting when determining whether to auto-update the package index and clean up associated memory handling.

Bug Fixes:
- Restore recognition of the legacy REPO_AUTOUPDATE configuration key so existing opt-out settings continue to disable automatic index updates.

Enhancements:
- Ensure the autoupdate configuration string retrieved during index loading is freed after use to prevent a memory leak.