### PR TITLE
Silence 'Directory in use' warning for dirrmtry assets

### DIFF
--- a/libmport/delete_primative.c
+++ b/libmport/delete_primative.c
@@ -337,7 +337,7 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 					mport_call_msg_cb(mport, "Could not remove directory '%s': %s",
 				    	file, mport_err_string());
 				}
-			} else {
+			} else if (type != ASSET_DIRRMTRY) {
 				mport_call_msg_cb(mport, "Directory in use by another package? '%s'", file);
 			}
 


### PR DESCRIPTION
## Summary

- Fixes #70
- `ASSET_DIRRMTRY` is a best-effort directory removal — if the directory is still referenced by another package, that is an expected and normal outcome
- Previously the `else` branch emitted `"Directory in use by another package? '%s'"` for all non-removable directories including `dirrmtry`, flooding output during package deletion (e.g. locale dirs shared across many packages)
- One-character change: `} else {` → `} else if (type != ASSET_DIRRMTRY) {` so the message is only shown for `ASSET_DIR`, `ASSET_DIRRM`, and `ASSET_DIR_OWNER_MODE`

## Test plan

- [ ] Delete a package that has `@dirrmtry` entries for shared locale directories and confirm no "Directory in use by another package?" messages appear
- [ ] Delete a package that has `@dirrm` entries for a directory still owned by another package and confirm the message still appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent excessive "Directory in use by another package" messages when deleting packages with shared dirrmtry directories.