### PR TITLE
Add -r flag to mport install for recursive dependent reinstall

### DIFF
--- a/libmport/install.c
+++ b/libmport/install.c
@@ -254,6 +254,14 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 				return mport_err_code();
 			}
 			mport_pkgmeta_vec_free(packs);
+		} else if (mport->force) {
+			/* force reinstall of already-installed package at the same version */
+			mport_pkgmeta_vec_free(packs);
+			packs = NULL;
+			if (mport_install_single(mport, packageName, version, NULL, automatic) != MPORT_OK) {
+				mport_call_msg_cb(mport, "%s", mport_err_string());
+				return mport_err_code();
+			}
 		} else {
 			if (getenv("MPORT_GUI") == NULL) {
 				mport_call_msg_cb(mport,

--- a/libmport/install.c
+++ b/libmport/install.c
@@ -255,7 +255,7 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 			}
 			mport_pkgmeta_vec_free(packs);
 		} else if (mport->force) {
-			/* force reinstall of already-installed package at the same version */
+			/* force reinstall of already-installed package, regardless of version */
 			mport_pkgmeta_vec_free(packs);
 			packs = NULL;
 			if (mport_install_single(mport, packageName, version, NULL, automatic) != MPORT_OK) {

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -54,7 +54,7 @@ static mportIndexEntry **lookupIndex(mportInstance *, const char *);
 static int add(mportInstance *mport, const char *filename, mportAutomatic automatic);
 static int install(mportInstance *, const char *, mportAutomatic);
 static int reinstall_dependents(mportInstance *, const char *);
-static int reinstall_dependents_impl(mportInstance *, const char *, char **, int *, int);
+static int reinstall_dependents_impl(mportInstance *, const char *, char ***, size_t *, size_t *);
 
 static int cpeList(mportInstance *);
 static int cpeGet(mportInstance *mport, const char *packageName);
@@ -1053,10 +1053,12 @@ install(mportInstance *mport, const char *packageName, mportAutomatic automatic)
  * Inner recursive worker for reinstall_dependents.
  * visited/visit_count/visit_max guard against reinstalling the same package
  * twice when it appears as a dependent via multiple paths in the tree.
+ * The visited array grows dynamically; visit_count and visit_cap are updated
+ * in place so callers can free every entry on return.
  */
 static int
 reinstall_dependents_impl(mportInstance *mport, const char *baseName,
-    char **visited, int *visit_count, int visit_max)
+    char ***visited_p, size_t *visit_count, size_t *visit_cap)
 {
 	mportPackageMeta **packs = NULL;
 	mportPackageMeta **updepends = NULL;
@@ -1080,8 +1082,8 @@ reinstall_dependents_impl(mportInstance *mport, const char *baseName,
 
 	for (mportPackageMeta **dep = updepends; *dep != NULL; dep++) {
 		bool already_visited = false;
-		for (int v = 0; v < *visit_count; v++) {
-			if (strcmp(visited[v], (*dep)->name) == 0) {
+		for (size_t v = 0; v < *visit_count; v++) {
+			if (strcmp((*visited_p)[v], (*dep)->name) == 0) {
 				already_visited = true;
 				break;
 			}
@@ -1089,14 +1091,25 @@ reinstall_dependents_impl(mportInstance *mport, const char *baseName,
 		if (already_visited)
 			continue;
 
-		if (*visit_count < visit_max) {
-			char *n = strdup((*dep)->name);
-			if (n != NULL)
-				visited[(*visit_count)++] = n;
+		/* grow visited array if needed */
+		if (*visit_count >= *visit_cap) {
+			size_t new_cap = *visit_cap * 2;
+			char **grown = reallocarray(*visited_p, new_cap, sizeof(char *));
+			if (grown == NULL) {
+				warnx("reinstall_dependents: out of memory growing visited set");
+				resultCode = MPORT_ERR_FATAL;
+				break;
+			}
+			*visited_p = grown;
+			*visit_cap = new_cap;
 		}
 
+		char *n = strdup((*dep)->name);
+		if (n != NULL)
+			(*visited_p)[(*visit_count)++] = n;
+
 		if (install(mport, (*dep)->name, (*dep)->automatic) == MPORT_OK) {
-			if (reinstall_dependents_impl(mport, (*dep)->name, visited, visit_count, visit_max) != MPORT_OK)
+			if (reinstall_dependents_impl(mport, (*dep)->name, visited_p, visit_count, visit_cap) != MPORT_OK)
 				resultCode = MPORT_ERR_FATAL;
 		} else {
 			resultCode = MPORT_ERR_FATAL;
@@ -1137,14 +1150,15 @@ reinstall_dependents(mportInstance *mport, const char *packageName)
 		}
 	}
 
-	char **visited = calloc(256, sizeof(char *));
-	int visit_count = 0;
+	size_t visit_cap = 32;
+	size_t visit_count = 0;
+	char **visited = calloc(visit_cap, sizeof(char *));
 	int ret = MPORT_ERR_FATAL;
 
 	if (visited != NULL)
-		ret = reinstall_dependents_impl(mport, baseName, visited, &visit_count, 256);
+		ret = reinstall_dependents_impl(mport, baseName, &visited, &visit_count, &visit_cap);
 
-	for (int i = 0; i < visit_count; i++)
+	for (size_t i = 0; i < visit_count; i++)
 		free(visited[i]);
 	free(visited);
 	mport_index_entry_free_vec(ie);

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -53,6 +53,7 @@ static mportIndexEntry **lookupIndex(mportInstance *, const char *);
 
 static int add(mportInstance *mport, const char *filename, mportAutomatic automatic);
 static int install(mportInstance *, const char *, mportAutomatic);
+static int reinstall_dependents(mportInstance *, const char *, mportAutomatic);
 
 static int cpeList(mportInstance *);
 static int cpeGet(mportInstance *mport, const char *packageName);
@@ -240,16 +241,24 @@ main(int argc, char *argv[])
 		int local_argc = argc;
 		char *const *local_argv = argv;
 		int aflag = 0;
+		int rflag = 0;
 
 		if (local_argc > 1) {
 			int ch2;
-			while ((ch2 = getopt(local_argc, local_argv, "AMy")) != -1) {
+#if defined(__MidnightBSD__)
+			optreset = 1;
+#endif
+			optind = 1;
+			while ((ch2 = getopt(local_argc, local_argv, "AMry")) != -1) {
 				switch (ch2) {
 				case 'A':
 					aflag = 1;
 					break;
 				case 'M':
 					mport->ignoreMissing = true;
+					break;
+				case 'r':
+					rflag = 1;
 					break;
 				case 'y':
 					setenv("ASSUME_ALWAYS_YES", "1", 1);
@@ -261,10 +270,16 @@ main(int argc, char *argv[])
 		}
 
 		loadIndex(mport);
-		for (i = 1; i < argc; i++) {
-			tempResultCode = install(mport, argv[i], aflag == 1 ? MPORT_AUTOMATIC : MPORT_EXPLICIT);
+		for (i = 0; i < local_argc; i++) {
+			tempResultCode = install(mport, local_argv[i], aflag == 1 ? MPORT_AUTOMATIC : MPORT_EXPLICIT);
 			if (tempResultCode != 0)
 				resultCode = tempResultCode;
+			if (rflag && mport->force) {
+				tempResultCode = reinstall_dependents(mport, local_argv[i],
+				    aflag == 1 ? MPORT_AUTOMATIC : MPORT_EXPLICIT);
+				if (tempResultCode != 0)
+					resultCode = tempResultCode;
+			}
 		}
 	} else if (!strcmp(cmd, "delete")) {
 		if (argc == 1) {
@@ -702,7 +717,7 @@ usage(void)
 	    "Commands:\n"
 	    "  Package Management:\n"
 	    "    add [-A] <package file>     Install package from file\n"
-	    "    install [-AMy] <package>      Install package from repository\n"
+	    "    install [-AMry] <package>     Install package from repository\n"
 	    "    delete <package>            Remove installed package\n"
 	    "    update [package]            Update installed package(s)\n"
 	    "    upgrade                     Upgrade all outdated packages\n"
@@ -1032,6 +1047,66 @@ install(mportInstance *mport, const char *packageName, mportAutomatic automatic)
 	mport_index_entry_free_vec(ie);
 
 	return (resultCode);
+}
+
+/*
+ * Reinstall all installed packages that directly depend on packageName.
+ * Used with -f -r to force-reinstall consumers of a library or base package.
+ */
+static int
+reinstall_dependents(mportInstance *mport, const char *packageName, mportAutomatic automatic)
+{
+	mportPackageMeta **packs = NULL;
+	mportPackageMeta **updepends = NULL;
+	char **names = NULL;
+	int count = 0;
+	int resultCode = MPORT_OK;
+
+	if (mport_pkgmeta_search_master(mport, &packs, "LOWER(pkg)=LOWER(%Q)", packageName) != MPORT_OK ||
+	    packs == NULL || packs[0] == NULL) {
+		mport_pkgmeta_vec_free(packs);
+		return MPORT_OK;
+	}
+
+	if (mport_pkgmeta_get_updepends(mport, packs[0], &updepends) != MPORT_OK) {
+		mport_pkgmeta_vec_free(packs);
+		warnx("%s", mport_err_string());
+		return MPORT_ERR_FATAL;
+	}
+	mport_pkgmeta_vec_free(packs);
+
+	if (updepends == NULL)
+		return MPORT_OK;
+
+	for (mportPackageMeta **dep = updepends; *dep != NULL; dep++)
+		count++;
+
+	names = calloc(count + 1, sizeof(char *));
+	if (names == NULL) {
+		mport_pkgmeta_vec_free(updepends);
+		return MPORT_ERR_FATAL;
+	}
+
+	for (int idx = 0; idx < count; idx++) {
+		names[idx] = strdup(updepends[idx]->name);
+		if (names[idx] == NULL) {
+			for (int j = 0; j < idx; j++)
+				free(names[j]);
+			free(names);
+			mport_pkgmeta_vec_free(updepends);
+			return MPORT_ERR_FATAL;
+		}
+	}
+	mport_pkgmeta_vec_free(updepends);
+
+	for (int idx = 0; idx < count; idx++) {
+		if (install(mport, names[idx], automatic) != MPORT_OK)
+			resultCode = MPORT_ERR_FATAL;
+		free(names[idx]);
+	}
+	free(names);
+
+	return resultCode;
 }
 
 int

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -53,7 +53,8 @@ static mportIndexEntry **lookupIndex(mportInstance *, const char *);
 
 static int add(mportInstance *mport, const char *filename, mportAutomatic automatic);
 static int install(mportInstance *, const char *, mportAutomatic);
-static int reinstall_dependents(mportInstance *, const char *, mportAutomatic);
+static int reinstall_dependents(mportInstance *, const char *);
+static int reinstall_dependents_impl(mportInstance *, const char *, char **, int *, int);
 
 static int cpeList(mportInstance *);
 static int cpeGet(mportInstance *mport, const char *packageName);
@@ -274,9 +275,8 @@ main(int argc, char *argv[])
 			tempResultCode = install(mport, local_argv[i], aflag == 1 ? MPORT_AUTOMATIC : MPORT_EXPLICIT);
 			if (tempResultCode != 0)
 				resultCode = tempResultCode;
-			if (rflag && mport->force) {
-				tempResultCode = reinstall_dependents(mport, local_argv[i],
-				    aflag == 1 ? MPORT_AUTOMATIC : MPORT_EXPLICIT);
+			if (tempResultCode == 0 && rflag && mport->force) {
+				tempResultCode = reinstall_dependents(mport, local_argv[i]);
 				if (tempResultCode != 0)
 					resultCode = tempResultCode;
 			}
@@ -1050,19 +1050,19 @@ install(mportInstance *mport, const char *packageName, mportAutomatic automatic)
 }
 
 /*
- * Reinstall all installed packages that directly depend on packageName.
- * Used with -f -r to force-reinstall consumers of a library or base package.
+ * Inner recursive worker for reinstall_dependents.
+ * visited/visit_count/visit_max guard against reinstalling the same package
+ * twice when it appears as a dependent via multiple paths in the tree.
  */
 static int
-reinstall_dependents(mportInstance *mport, const char *packageName, mportAutomatic automatic)
+reinstall_dependents_impl(mportInstance *mport, const char *baseName,
+    char **visited, int *visit_count, int visit_max)
 {
 	mportPackageMeta **packs = NULL;
 	mportPackageMeta **updepends = NULL;
-	char **names = NULL;
-	int count = 0;
 	int resultCode = MPORT_OK;
 
-	if (mport_pkgmeta_search_master(mport, &packs, "LOWER(pkg)=LOWER(%Q)", packageName) != MPORT_OK ||
+	if (mport_pkgmeta_search_master(mport, &packs, "LOWER(pkg)=LOWER(%Q)", baseName) != MPORT_OK ||
 	    packs == NULL || packs[0] == NULL) {
 		mport_pkgmeta_vec_free(packs);
 		return MPORT_OK;
@@ -1078,35 +1078,79 @@ reinstall_dependents(mportInstance *mport, const char *packageName, mportAutomat
 	if (updepends == NULL)
 		return MPORT_OK;
 
-	for (mportPackageMeta **dep = updepends; *dep != NULL; dep++)
-		count++;
+	for (mportPackageMeta **dep = updepends; *dep != NULL; dep++) {
+		bool already_visited = false;
+		for (int v = 0; v < *visit_count; v++) {
+			if (strcmp(visited[v], (*dep)->name) == 0) {
+				already_visited = true;
+				break;
+			}
+		}
+		if (already_visited)
+			continue;
 
-	names = calloc(count + 1, sizeof(char *));
-	if (names == NULL) {
-		mport_pkgmeta_vec_free(updepends);
-		return MPORT_ERR_FATAL;
-	}
+		if (*visit_count < visit_max) {
+			char *n = strdup((*dep)->name);
+			if (n != NULL)
+				visited[(*visit_count)++] = n;
+		}
 
-	for (int idx = 0; idx < count; idx++) {
-		names[idx] = strdup(updepends[idx]->name);
-		if (names[idx] == NULL) {
-			for (int j = 0; j < idx; j++)
-				free(names[j]);
-			free(names);
-			mport_pkgmeta_vec_free(updepends);
-			return MPORT_ERR_FATAL;
+		if (install(mport, (*dep)->name, (*dep)->automatic) == MPORT_OK) {
+			if (reinstall_dependents_impl(mport, (*dep)->name, visited, visit_count, visit_max) != MPORT_OK)
+				resultCode = MPORT_ERR_FATAL;
+		} else {
+			resultCode = MPORT_ERR_FATAL;
 		}
 	}
+
 	mport_pkgmeta_vec_free(updepends);
-
-	for (int idx = 0; idx < count; idx++) {
-		if (install(mport, names[idx], automatic) != MPORT_OK)
-			resultCode = MPORT_ERR_FATAL;
-		free(names[idx]);
-	}
-	free(names);
-
 	return resultCode;
+}
+
+/*
+ * Recursively reinstall all installed packages that depend on packageName.
+ * Resolves versioned inputs (e.g. "openssl-3.1.0") to the base package name
+ * via the index before walking the reverse-dependency tree.
+ */
+static int
+reinstall_dependents(mportInstance *mport, const char *packageName)
+{
+	mportIndexEntry **ie = NULL;
+	const char *baseName = packageName;
+	char *stripped = NULL;
+
+	/* resolve actual pkgname from index to handle "name-version" inputs */
+	if (mport_index_lookup_pkgname(mport, packageName, &ie) == MPORT_OK &&
+	    ie != NULL && *ie != NULL) {
+		baseName = (*ie)->pkgname;
+	} else {
+		mport_index_entry_free_vec(ie);
+		ie = NULL;
+		const char *dash = strrchr(packageName, '-');
+		if (dash != NULL && dash != packageName) {
+			stripped = strndup(packageName, (size_t)(dash - packageName));
+			if (stripped != NULL &&
+			    mport_index_lookup_pkgname(mport, stripped, &ie) == MPORT_OK &&
+			    ie != NULL && *ie != NULL) {
+				baseName = (*ie)->pkgname;
+			}
+		}
+	}
+
+	char **visited = calloc(256, sizeof(char *));
+	int visit_count = 0;
+	int ret = MPORT_ERR_FATAL;
+
+	if (visited != NULL)
+		ret = reinstall_dependents_impl(mport, baseName, visited, &visit_count, 256);
+
+	for (int i = 0; i < visit_count; i++)
+		free(visited[i]);
+	free(visited);
+	mport_index_entry_free_vec(ie);
+	free(stripped);
+
+	return ret;
 }
 
 int


### PR DESCRIPTION
## Summary

Fixes #111.

Adds `-r` to `mport install` so that `mport -f install -r <pkg>` force-reinstalls `<pkg>` and then reinstalls every installed package that directly depends on it. Typical use case: replacing a shared library (e.g. `libssl`) and needing its consumers reinstalled in one pass.

### Changes

**`libmport/install.c` — honour `force` for same-version packages**

`mport_install_depends` took the "already installed" branch and printed "most recent version already installed" even when `mport->force` was set and the package was at the latest version. The force-reinstall path in `mport_install_primative` was never reached in this case. A new `else if (mport->force)` branch now calls `mport_install_single` to delete-and-reinstall the package.

**`mport/mport.c` — fix install subcommand option parsing**

The install subcommand's inner `getopt` loop was missing the `optreset = 1` / `optind = 1` reset present in other subcommands (e.g. `delete`). Without it, getopt inherited a stale `optind` from the outer parse and skipped all flags. The iteration loop also used the original `argc`/`argv` instead of `local_argc`/`local_argv` after flag stripping, meaning flag strings like `-A` could be passed to `install()` as package names.

**`mport/mport.c` — add `-r` flag and `reinstall_dependents`**

The new `reinstall_dependents` helper looks up the named package in the master DB, calls `mport_pkgmeta_get_updepends` to get its reverse dependencies, copies the names out before freeing the metadata vector, and reinstalls each one. The `-r` flag is only meaningful in combination with `-f`; without `-f`, existing behaviour is unchanged.

## Test plan

- [ ] `mport -f install -r openssl` — verify openssl is reinstalled and all packages with `openssl` in their `depends` table are also reinstalled
- [ ] `mport install pkg` (no flags) — verify existing behaviour unchanged, no regression from optind fix
- [ ] `mport install -A pkg` — verify the `-A` flag is now correctly applied (was broken by the optind bug)
- [ ] `mport -f install pkg` (no `-r`) — verify dependents are NOT reinstalled
- [ ] `mport -f install pkg` where pkg is at latest version — verify it now actually reinstalls (previously silently no-op'd)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Add support for recursively reinstalling reverse dependencies when forcibly reinstalling a package via the install subcommand, and fix install option parsing.

New Features:
- Introduce a -r flag to the install command to recursively reinstall packages that depend on a forcibly reinstalled package.

Bug Fixes:
- Fix install subcommand option parsing so flags are correctly handled and not misinterpreted as package names.
- Ensure force installs actually reinstall already-installed packages at the same version instead of silently skipping them.

Enhancements:
- Add a helper to walk reverse dependency relationships and reinstall dependent packages while avoiding duplicate work.
- Update command-line usage text to document the new install flag.