### PR TITLE
Warn when package flatsize exceeds available disk space

### DIFF
--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -295,9 +295,15 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 			struct statvfs sfs;
 			const char *check_path = (mport->root != NULL && mport->root[0] != '\0') ? mport->root : pkg->prefix;
 			if (statvfs(check_path, &sfs) == 0) {
-				int64_t avail_bytes = (int64_t)sfs.f_bavail * (int64_t)sfs.f_frsize;
+				int64_t avail_bytes;
+				if (sfs.f_frsize != 0 &&
+				    (uintmax_t)sfs.f_bavail > (uintmax_t)INT64_MAX / (uintmax_t)sfs.f_frsize) {
+					avail_bytes = INT64_MAX;
+				} else {
+					avail_bytes = (int64_t)((uintmax_t)sfs.f_bavail * (uintmax_t)sfs.f_frsize);
+				}
 				if (pkg->flatsize > avail_bytes) {
-					char avail_str[8], need_str[8];
+					char avail_str[32], need_str[32];
 					humanize_number(avail_str, sizeof(avail_str), avail_bytes, "B",
 					    HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
 					humanize_number(need_str, sizeof(need_str), pkg->flatsize, "B",

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -32,6 +32,8 @@
 #include <stdlib.h>
 #include <dirent.h>
 #include <string.h>
+#include <sys/statvfs.h>
+#include <libutil.h>
 
 static char ** get_dependencies(mportInstance *mport, mportPackageMeta *pack);
 static char *find_file_with_prefix(const char *dir, const char *prefix);
@@ -286,6 +288,24 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 			if ((pkg->prefix = strdup(prefix)) == NULL) { /* all hope is lost! bail */
 				ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
 				goto cleanup;
+			}
+		}
+
+		if (pkg->flatsize > 0) {
+			struct statvfs sfs;
+			const char *check_path = (mport->root != NULL && mport->root[0] != '\0') ? mport->root : pkg->prefix;
+			if (statvfs(check_path, &sfs) == 0) {
+				int64_t avail_bytes = (int64_t)sfs.f_bavail * (int64_t)sfs.f_frsize;
+				if (pkg->flatsize > avail_bytes) {
+					char avail_str[8], need_str[8];
+					humanize_number(avail_str, sizeof(avail_str), avail_bytes, "B",
+					    HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
+					humanize_number(need_str, sizeof(need_str), pkg->flatsize, "B",
+					    HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
+					mport_call_msg_cb(mport,
+					    "Warning: %s-%s requires %s but only %s is available on %s.",
+					    pkg->name, pkg->version, need_str, avail_str, check_path);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Closes #96

- Before installing each package, calls `statvfs(2)` on the install root (`mport->root` if set, otherwise `pkg->prefix`) to get available space
- Compares `pkg->flatsize` against `f_bavail * f_frsize` (available blocks × fragment size, per POSIX)
- If space is insufficient, emits a human-readable warning via `mport_call_msg_cb` (non-fatal — installation proceeds so the user can decide to abort)
- Skips the check if `statvfs` fails (e.g. path doesn't exist yet) or if `flatsize <= 0`

**Note**: `flatsize` is read from the bundle's stub metadata after the package is downloaded (via `mport_pkgmeta_read_stub`). It is not available from the index entry, so the check cannot happen before downloading.

## Test plan

- [ ] Install a package on a filesystem with sufficient space — no warning should appear
- [ ] Install a package on a nearly-full filesystem — warning should appear with human-readable sizes before installation proceeds
- [ ] Verify build compiles clean on amd64 and i386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Warn when installing a package whose declared size exceeds available disk space on the target filesystem.

Enhancements:
- Add a pre-install disk space check comparing package flatsize against available space on the install root or package prefix.
- Emit a non-fatal, human-readable warning when insufficient disk space is detected before proceeding with installation.