### PR TITLE
Add mtree directory structure check to mport verify

### DIFF
--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -44,6 +44,8 @@
 #include "mport.h"
 #include "mport_private.h"
 
+extern char **environ;
+
 static void verify_mtree(mportInstance *, mportPackageMeta *);
 
 MPORT_PUBLIC_API int
@@ -188,14 +190,19 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 		    strerror(error));
 		return;
 	}
-	posix_spawn_file_actions_adddup2(&action, pipefd[1], STDOUT_FILENO);
-	posix_spawn_file_actions_addclose(&action, pipefd[0]);
+	if ((error = posix_spawn_file_actions_adddup2(&action, pipefd[1], STDOUT_FILENO)) != 0 ||
+	    (error = posix_spawn_file_actions_addclose(&action, pipefd[0])) != 0) {
+		posix_spawn_file_actions_destroy(&action);
+		close(pipefd[0]);
+		close(pipefd[1]);
+		mport_call_msg_cb(mport, "mtree verify: file actions setup: %s", strerror(error));
+		return;
+	}
 
 	char *const args[] = { MPORT_MTREE_BIN, "-f", mtree_path, "-d", "-e",
 	    "-p", prefix, NULL };
-	char *const envp[] = { NULL };
 
-	error = posix_spawn(&pid, MPORT_MTREE_BIN, &action, NULL, args, envp);
+	error = posix_spawn(&pid, MPORT_MTREE_BIN, &action, NULL, args, environ);
 	posix_spawn_file_actions_destroy(&action);
 	close(pipefd[1]);
 
@@ -207,7 +214,7 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 
 	FILE *fp = fdopen(pipefd[0], "r");
 	if (fp != NULL) {
-		char line[FILENAME_MAX + 64];
+		char line[FILENAME_MAX * 2];
 		while (fgets(line, sizeof(line), fp) != NULL) {
 			size_t len = strlen(line);
 			if (len > 0 && line[len - 1] == '\n')
@@ -221,9 +228,21 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 		close(pipefd[0]);
 	}
 
-	while (waitpid(pid, &pstat, 0) == -1) {
-		if (errno != EINTR)
-			break;
+	int wres;
+	do {
+		wres = waitpid(pid, &pstat, 0);
+	} while (wres == -1 && errno == EINTR);
+
+	if (wres == -1) {
+		mport_call_msg_cb(mport, "mtree %s-%s: waitpid failed: %s",
+		    pack->name, pack->version, strerror(errno));
+	} else if (WIFSIGNALED(pstat)) {
+		mport_call_msg_cb(mport, "mtree %s-%s: terminated by signal %d",
+		    pack->name, pack->version, WTERMSIG(pstat));
+	} else if (WIFEXITED(pstat) && WEXITSTATUS(pstat) > 1) {
+		/* exit 1 means discrepancies found (normal); >1 indicates a tool error */
+		mport_call_msg_cb(mport, "mtree %s-%s: exited with status %d",
+		    pack->name, pack->version, WEXITSTATUS(pstat));
 	}
 }
 

--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -31,14 +31,20 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <errno.h>
 #include <string.h>
 #include <sqlite3.h>
 #include <md5.h>
 #include <sha256.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <spawn.h>
 #include "mport.h"
 #include "mport_private.h"
+
+static void verify_mtree(mportInstance *, mportPackageMeta *);
 
 MPORT_PUBLIC_API int
 mport_verify_package(mportInstance *mport, mportPackageMeta *pack)
@@ -145,8 +151,80 @@ mport_verify_package(mportInstance *mport, mportPackageMeta *pack)
 	}
 
 	sqlite3_finalize(stmt);
-	
+
+	verify_mtree(mport, pack);
+
 	return (MPORT_OK);
+}
+
+static void
+verify_mtree(mportInstance *mport, mportPackageMeta *pack)
+{
+	char mtree_path[FILENAME_MAX];
+	char prefix[FILENAME_MAX];
+	int pipefd[2];
+	posix_spawn_file_actions_t action;
+	pid_t pid;
+	int error, pstat;
+
+	(void)snprintf(mtree_path, sizeof(mtree_path), "%s%s/%s-%s/%s",
+	    mport->root, MPORT_INST_INFRA_DIR, pack->name, pack->version,
+	    MPORT_MTREE_FILE);
+
+	if (!mport_file_exists(mtree_path))
+		return;
+
+	(void)snprintf(prefix, sizeof(prefix), "%s%s", mport->root, pack->prefix);
+
+	if (pipe(pipefd) == -1) {
+		mport_call_msg_cb(mport, "mtree verify: pipe: %s", strerror(errno));
+		return;
+	}
+
+	if ((error = posix_spawn_file_actions_init(&action)) != 0) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		mport_call_msg_cb(mport, "mtree verify: posix_spawn_file_actions_init: %s",
+		    strerror(error));
+		return;
+	}
+	posix_spawn_file_actions_adddup2(&action, pipefd[1], STDOUT_FILENO);
+	posix_spawn_file_actions_addclose(&action, pipefd[0]);
+
+	char *const args[] = { MPORT_MTREE_BIN, "-f", mtree_path, "-d", "-e",
+	    "-p", prefix, NULL };
+	char *const envp[] = { NULL };
+
+	error = posix_spawn(&pid, MPORT_MTREE_BIN, &action, NULL, args, envp);
+	posix_spawn_file_actions_destroy(&action);
+	close(pipefd[1]);
+
+	if (error != 0) {
+		close(pipefd[0]);
+		mport_call_msg_cb(mport, "mtree verify: posix_spawn: %s", strerror(error));
+		return;
+	}
+
+	FILE *fp = fdopen(pipefd[0], "r");
+	if (fp != NULL) {
+		char line[FILENAME_MAX + 64];
+		while (fgets(line, sizeof(line), fp) != NULL) {
+			size_t len = strlen(line);
+			if (len > 0 && line[len - 1] == '\n')
+				line[len - 1] = '\0';
+			if (line[0] != '\0')
+				mport_call_msg_cb(mport, "mtree %s-%s: %s",
+				    pack->name, pack->version, line);
+		}
+		fclose(fp);
+	} else {
+		close(pipefd[0]);
+	}
+
+	while (waitpid(pid, &pstat, 0) == -1) {
+		if (errno != EINTR)
+			break;
+	}
 }
 
 MPORT_PUBLIC_API int


### PR DESCRIPTION
## Summary

Closes #56

- `mport_verify_package` now runs a second pass using `/usr/sbin/mtree` to validate directory structure against the spec stored in `/var/db/mport/infrastructure/<name>-<version>/mtree`
- Any discrepancies (missing directories, wrong modes/ownership) are reported via `mport_call_msg_cb` — same non-fatal pattern as the existing checksum warnings
- If no mtree file exists for a package the check is silently skipped (older installs, packages with no directories)
- The `-p` prefix is computed as `mport->root + pkg->prefix` so chrooted installs check the correct filesystem location
- mtree is invoked with `-d -e` (directories only, don't complain about extra dirs not in spec), without `-U` so it checks rather than updates

**Scope note**: The infrastructure mtree files contain only `type=dir` entries, so this validates directory structure (existence, mode, ownership of directories). File-level verification continues to use the existing checksum check.

## Implementation

`libmport/verify.c` — added static `verify_mtree(mportInstance *, mportPackageMeta *)`:
- Constructs the mtree path and prefix path
- Uses `posix_spawn` with a stdout pipe to capture mtree output
- Reads output line-by-line, forwarding each discrepancy to `mport_call_msg_cb`
- Reads pipe to EOF before `waitpid` to avoid deadlock on large output

## Test plan

- [ ] `mport verify <package>` on a clean install — no mtree output expected
- [ ] Manually remove a directory from an installed package's prefix, then `mport verify <package>` — should report missing directory
- [ ] Verify on a package with no mtree in infrastructure — should skip silently
- [ ] Verify CI builds clean on amd64 and i386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an mtree-based directory structure verification step to mport package verification, reporting any discrepancies as non-fatal messages.

New Features:
- Run mtree against the stored infrastructure spec during mport_verify_package to validate installed directory structure and metadata.

Enhancements:
- Capture and relay mtree discrepancy output via the existing message callback mechanism while remaining non-fatal when mtree data is absent or errors occur.