### PR TITLE
Detect file conflicts before package installation

### DIFF
--- a/libmport/check_preconditions.c
+++ b/libmport/check_preconditions.c
@@ -27,6 +27,8 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +42,7 @@ static int check_conflicts(mportInstance *mport, mportPackageMeta *);
 static int check_depends(mportInstance *mport, mportPackageMeta *);
 static int check_if_older_installed(mportInstance *, mportPackageMeta *);
 static int check_if_older_os(mportInstance *, mportPackageMeta *);
+static int check_file_conflicts(mportInstance *, mportPackageMeta *);
 
 /* Run the checks requested by the flags given.
  *
@@ -73,6 +76,8 @@ int mport_check_preconditions(mportInstance *mport, mportPackageMeta *pack, long
 	if (flags & MPORT_PRECHECK_DEPENDS && check_depends(mport, pack) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 	if (flags & MPORT_PRECHECK_OS && check_if_older_os(mport, pack) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+	if (flags & MPORT_PRECHECK_FILE_CONFLICTS && check_file_conflicts(mport, pack) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
@@ -423,4 +428,132 @@ check_if_older_os(mportInstance *mport, mportPackageMeta *pkg)
 	free((char*) os_release);
 
 	return ret;
+}
+
+static int
+check_file_conflicts(mportInstance *mport, mportPackageMeta *pack)
+{
+	sqlite3_stmt *stmt, *lookup;
+	int ret;
+	mportAssetListEntryType type;
+	const char *data;
+	char cwd[FILENAME_MAX];
+	char masterpath[FILENAME_MAX];
+	char fullpath[FILENAME_MAX];
+	char datastr[FILENAME_MAX];
+	struct stat st;
+
+	strlcpy(cwd, pack->prefix, sizeof(cwd));
+
+	if (mport_db_prepare(mport->db, &stmt,
+	    "SELECT type, data FROM stub.assets WHERE pkg=%Q ORDER BY rowid",
+	    pack->name) != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	if (mport_db_prepare(mport->db, &lookup,
+	    "SELECT pkg FROM assets WHERE data=? AND pkg!=?") != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		sqlite3_finalize(lookup);
+		RETURN_CURRENT_ERROR;
+	}
+
+	while (1) {
+		ret = sqlite3_step(stmt);
+
+		if (ret == SQLITE_DONE)
+			break;
+
+		if (ret != SQLITE_ROW) {
+			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+			sqlite3_finalize(lookup);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		type = (mportAssetListEntryType)sqlite3_column_int(stmt, 0);
+		data = sqlite3_column_text(stmt, 1);
+
+		if (type == ASSET_CWD) {
+			if (data != NULL)
+				strlcpy(cwd, data, sizeof(cwd));
+			else
+				strlcpy(cwd, pack->prefix, sizeof(cwd));
+			continue;
+		}
+
+		switch (type) {
+		case ASSET_FILE_OWNER_MODE:
+		case ASSET_FILE:
+		case ASSET_SHELL:
+		case ASSET_SAMPLE:
+		case ASSET_INFO:
+		case ASSET_SAMPLE_OWNER_MODE:
+			break;
+		default:
+			continue;
+		}
+
+		if (data == NULL)
+			continue;
+
+		strlcpy(datastr, data, sizeof(datastr));
+		if (type == ASSET_SAMPLE || type == ASSET_SAMPLE_OWNER_MODE) {
+			/* sample entries may have a destination separated by whitespace; use only the source */
+			char *sp = datastr;
+			while (*sp != '\0' && *sp != ' ' && *sp != '\t')
+				sp++;
+			*sp = '\0';
+		}
+
+		if (datastr[0] == '/')
+			strlcpy(masterpath, datastr, sizeof(masterpath));
+		else
+			snprintf(masterpath, sizeof(masterpath), "%s/%s", cwd, datastr);
+
+		snprintf(fullpath, sizeof(fullpath), "%s%s", mport->root, masterpath);
+
+		if (lstat(fullpath, &st) != 0)
+			continue;
+
+		if (S_ISDIR(st.st_mode))
+			continue;
+
+		sqlite3_reset(lookup);
+		sqlite3_clear_bindings(lookup);
+
+		if (sqlite3_bind_text(lookup, 1, masterpath, -1, SQLITE_STATIC) != SQLITE_OK ||
+		    sqlite3_bind_text(lookup, 2, pack->name, -1, SQLITE_STATIC) != SQLITE_OK) {
+			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+			sqlite3_finalize(lookup);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		int lret = sqlite3_step(lookup);
+		if (lret == SQLITE_ROW) {
+			const char *owner = sqlite3_column_text(lookup, 0);
+			SET_ERRORX(MPORT_ERR_FATAL,
+			    "%s is owned by %s; use -f to overwrite.", fullpath, owner);
+			sqlite3_finalize(lookup);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		} else if (lret == SQLITE_DONE) {
+			SET_ERRORX(MPORT_ERR_FATAL,
+			    "%s already exists but is not managed by mport; use -f to overwrite.", fullpath);
+			sqlite3_finalize(lookup);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		} else {
+			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+			sqlite3_finalize(lookup);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+	}
+
+	sqlite3_finalize(lookup);
+	sqlite3_finalize(stmt);
+	return MPORT_OK;
 }

--- a/libmport/check_preconditions.c
+++ b/libmport/check_preconditions.c
@@ -523,7 +523,7 @@ check_file_conflicts(mportInstance *mport, mportPackageMeta *pack)
 		sqlite3_reset(lookup);
 		sqlite3_clear_bindings(lookup);
 
-		if (sqlite3_bind_text(lookup, 1, masterpath, -1, SQLITE_STATIC) != SQLITE_OK ||
+		if (sqlite3_bind_text(lookup, 1, masterpath, -1, SQLITE_TRANSIENT) != SQLITE_OK ||
 		    sqlite3_bind_text(lookup, 2, pack->name, -1, SQLITE_STATIC) != SQLITE_OK) {
 			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 			sqlite3_finalize(lookup);

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -315,7 +315,10 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 			}
 		}
 
-		if ((mport_check_preconditions(mport, pkg, MPORT_PRECHECK_INSTALLED | MPORT_PRECHECK_DEPENDS | MPORT_PRECHECK_CONFLICTS) != MPORT_OK)
+		long precheck_flags = MPORT_PRECHECK_INSTALLED | MPORT_PRECHECK_DEPENDS | MPORT_PRECHECK_CONFLICTS;
+		if (!mport->force)
+			precheck_flags |= MPORT_PRECHECK_FILE_CONFLICTS;
+		if ((mport_check_preconditions(mport, pkg, precheck_flags) != MPORT_OK)
                    || (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
 			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkg->name, pkg->version,
 			                  mport_err_string());

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -74,6 +74,7 @@ struct ohash {
 #define MPORT_PRECHECK_OS          16
 #define MPORT_PRECHECK_MOVED       32
 #define MPORT_PRECHECK_DEPRECATED  64
+#define MPORT_PRECHECK_FILE_CONFLICTS 128
 int mport_check_preconditions(mportInstance *, mportPackageMeta *, long);
 
 /* schema */


### PR DESCRIPTION
Closes #102

## Summary

- Adds `MPORT_PRECHECK_FILE_CONFLICTS` (flag 128) to `mport_private.h`
- Implements `check_file_conflicts()` in `check_preconditions.c`: walks the incoming package's `stub.assets` list (tracking CWD via `ASSET_CWD` entries), and for each file asset that already exists on disk and is not a directory, checks whether another installed package owns it
- Two distinct error messages: "owned by `<pkg>`" vs "not managed by mport", both advising `-f` to override
- Wires the flag into `mport_install_primative()` — skipped when `mport->force` is set

## Behavior

- File asset exists and is owned by another package → fatal error naming the owner
- File asset exists and is not tracked by mport → fatal error noting it is unmanaged
- File asset does not exist → no conflict
- File asset is a directory → skipped (directories are shared)
- `mport install -f` → check bypassed entirely

## Test plan

- [ ] Install a package that would write a file already present on disk — verify installation is rejected with an appropriate message
- [ ] Repeat with `mport install -f` — verify installation proceeds
- [ ] Install a package whose file is already owned by another installed package — verify the owning package is named in the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add pre-install file conflict detection and post-install mtree-based verification, and wire these checks into package installation while preserving a force override.

New Features:
- Introduce a precondition check that scans package assets for existing on-disk files and reports ownership or unmanaged conflicts before installation.
- Run mtree(8) against stored package metadata during verification to report filesystem discrepancies for installed packages.

Enhancements:
- Integrate the new file-conflict precheck into the installation flow, enabling it by default and skipping it when force is requested.
- Apply minor formatting and style cleanups across precondition and install logic for consistency.