### PR TITLE
Add mport verify -d to detect missing dependencies (issue #94)

### DIFF
--- a/libmport/mport.h
+++ b/libmport/mport.h
@@ -348,6 +348,7 @@ int mport_autoremove(mportInstance *);
 /* package verify */
 int mport_verify_package(mportInstance *, mportPackageMeta *);
 int mport_recompute_checksums(mportInstance *, mportPackageMeta *);
+int mport_check_missing_depends(mportInstance *);
 
 /* version comparing */
 int mport_version_cmp(const char *, const char *);

--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -404,7 +404,8 @@ mport_check_missing_depends(mportInstance *mport)
 	    "  SELECT 1 FROM packages p2 WHERE p2.pkg = d.depend_pkgname"
 	    ") "
 	    "ORDER BY d.pkg, d.depend_pkgname") != MPORT_OK) {
-		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		return (-1);
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {

--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -397,8 +397,11 @@ mport_check_missing_depends(mportInstance *mport)
 	if (mport_db_prepare(mport->db, &stmt,
 	    "SELECT d.pkg, d.depend_pkgname, d.depend_pkgversion "
 	    "FROM depends d "
-	    "WHERE NOT EXISTS ("
-	    "  SELECT 1 FROM packages p WHERE p.pkg = d.depend_pkgname"
+	    "WHERE EXISTS ("
+	    "  SELECT 1 FROM packages p WHERE p.pkg = d.pkg"
+	    ") "
+	    "AND NOT EXISTS ("
+	    "  SELECT 1 FROM packages p2 WHERE p2.pkg = d.depend_pkgname"
 	    ") "
 	    "ORDER BY d.pkg, d.depend_pkgname") != MPORT_OK) {
 		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));

--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -379,3 +379,54 @@ mport_recompute_checksums(mportInstance *mport, mportPackageMeta *pack)
 
 	return (MPORT_OK);
 }
+
+/*
+ * mport_check_missing_depends(mport)
+ *
+ * Scan all installed packages and report any whose recorded dependencies are
+ * not currently installed.  Returns the number of missing dependency
+ * relationships found, or -1 on a fatal error.
+ */
+MPORT_PUBLIC_API int
+mport_check_missing_depends(mportInstance *mport)
+{
+	sqlite3_stmt *stmt;
+	int missing = 0;
+	int ret;
+
+	if (mport_db_prepare(mport->db, &stmt,
+	    "SELECT d.pkg, d.depend_pkgname, d.depend_pkgversion "
+	    "FROM depends d "
+	    "WHERE NOT EXISTS ("
+	    "  SELECT 1 FROM packages p WHERE p.pkg = d.depend_pkgname"
+	    ") "
+	    "ORDER BY d.pkg, d.depend_pkgname") != MPORT_OK) {
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+	}
+
+	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
+		const char *pkg     = (const char *)sqlite3_column_text(stmt, 0);
+		const char *dep     = (const char *)sqlite3_column_text(stmt, 1);
+		const char *ver     = (const char *)sqlite3_column_text(stmt, 2);
+
+		if (ver != NULL && *ver != '\0') {
+			mport_call_msg_cb(mport,
+			    "Missing dependency: %s requires %s-%s (not installed)",
+			    pkg, dep, ver);
+		} else {
+			mport_call_msg_cb(mport,
+			    "Missing dependency: %s requires %s (not installed)",
+			    pkg, dep);
+		}
+		missing++;
+	}
+
+	sqlite3_finalize(stmt);
+
+	if (ret != SQLITE_DONE) {
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		return (-1);
+	}
+
+	return (missing);
+}

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -653,14 +653,14 @@ main(int argc, char *argv[])
 				resultCode = mport_err_code();
 			} else if (nmissing == 0) {
 				printf("All dependencies are satisfied.\n");
-				resultCode = MPORT_OK;
 			} else {
 				printf("%d missing dependenc%s found.\n",
 				    nmissing, nmissing == 1 ? "y" : "ies");
 				resultCode = MPORT_ERR_WARN;
 			}
-		} else if (rflag) {
-			resultCode = MPORT_OK;
+		}
+
+		if (rflag) {
 			for (int x = 0; x < local_argc; x++) {
 				mportPackageMeta **packs = lookup_package(mport, local_argv[x]);
 				if (packs == NULL) {
@@ -671,7 +671,9 @@ main(int argc, char *argv[])
 					resultCode = tempResultCode;
 				mport_pkgmeta_vec_free(packs);
 			}
-		} else {
+		}
+
+		if (!dflag && !rflag) {
 			if (argc > 1) {
 				resultCode = verify_many(mport, argc, argv, true);
 			} else {

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -632,6 +632,7 @@ main(int argc, char *argv[])
 
 		if (local_argc > 1) {
 			int ch2;
+			optind = 1;
 			while ((ch2 = getopt(local_argc, local_argv, "dr")) != -1) {
 				switch (ch2) {
 				case 'd':

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -628,11 +628,15 @@ main(int argc, char *argv[])
 		int local_argc = argc;
 		char *const *local_argv = argv;
 		int rflag = 0;
+		int dflag = 0;
 
 		if (local_argc > 1) {
 			int ch2;
-			while ((ch2 = getopt(local_argc, local_argv, "r")) != -1) {
+			while ((ch2 = getopt(local_argc, local_argv, "dr")) != -1) {
 				switch (ch2) {
+				case 'd':
+					dflag = 1;
+					break;
 				case 'r':
 					rflag = 1;
 					break;
@@ -642,7 +646,20 @@ main(int argc, char *argv[])
 			local_argv += optind;
 		}
 
-		if (rflag) {
+		if (dflag) {
+			int nmissing = mport_check_missing_depends(mport);
+			if (nmissing < 0) {
+				warnx("%s", mport_err_string());
+				resultCode = mport_err_code();
+			} else if (nmissing == 0) {
+				printf("All dependencies are satisfied.\n");
+				resultCode = MPORT_OK;
+			} else {
+				printf("%d missing dependenc%s found.\n",
+				    nmissing, nmissing == 1 ? "y" : "ies");
+				resultCode = MPORT_ERR_WARN;
+			}
+		} else if (rflag) {
 			resultCode = MPORT_OK;
 			for (int x = 0; x < local_argc; x++) {
 				mportPackageMeta **packs = lookup_package(mport, local_argv[x]);
@@ -749,7 +766,8 @@ usage(void)
 	    "    upgrade                     Upgrade all outdated packages\n"
 	    "    autoremove                  Remove automatically installed packages\n"
 	    "    clean                       Clean package cache\n"
-	    "    verify [-r] [package]            Verify installed packages\n"
+	    "    verify [-d] [-r] [package]       Verify installed packages\n"
+	    "      -d                            Check for missing dependencies\n"
 	    "    deleteall                   Remove all installed packages\n\n"
 	    "  Information:\n"
 	    "    search <query>              Search for packages\n"


### PR DESCRIPTION
Implement mport_check_missing_depends() in libmport/verify.c which queries the depends table and reports any recorded dependency that is not currently present in the packages table.  Wire it into the CLI as 'mport verify -d'; prints each missing dep via the message callback and summarises the count on exit.  Returns MPORT_ERR_WARN when any are found so callers can detect the condition programmatically.

## Summary by Sourcery

Add a verification mode to detect and report missing package dependencies in installed packages.

New Features:
- Introduce mport_check_missing_depends() API to scan installed packages for recorded dependencies that are not currently installed.
- Extend the CLI with `mport verify -d` to run the missing-dependency check and surface results via exit status and messages.

Enhancements:
- Update CLI usage text to document the new verify option for checking missing dependencies.