### PR TITLE
Fix bootstrap index hash verification failure handling

### DIFF
--- a/libmport/fetch.c
+++ b/libmport/fetch.c
@@ -184,8 +184,10 @@ mport_fetch_bootstrap_index(mportInstance *mport)
 
 		if (hash == NULL || mport_verify_hash(MPORT_INDEX_FILE_COMPRESSED, hash) == 0) {
 			mport_call_msg_cb(mport, "Bootstrap index hash failed verification: %s\n", hash);
+			result = MPORT_ERR_FATAL;
         } else {
 			mport_decompress_zstd(MPORT_INDEX_FILE_COMPRESSED, mport_index_file_path());
+			result = MPORT_OK;
 		}
 		free(hash);
 	} else {

--- a/libmport/fetch.c
+++ b/libmport/fetch.c
@@ -183,11 +183,11 @@ mport_fetch_bootstrap_index(mportInstance *mport)
 		char *hash = mport_extract_hash_from_file(MPORT_INDEX_FILE_HASH);
 
 		if (hash == NULL || mport_verify_hash(MPORT_INDEX_FILE_COMPRESSED, hash) == 0) {
-			mport_call_msg_cb(mport, "Bootstrap index hash failed verification: %s\n", hash);
+			mport_call_msg_cb(mport, "Bootstrap index hash failed verification: %s\n",
+			    hash != NULL ? hash : "(null)");
 			result = MPORT_ERR_FATAL;
-        } else {
-			mport_decompress_zstd(MPORT_INDEX_FILE_COMPRESSED, mport_index_file_path());
-			result = MPORT_OK;
+		} else {
+			result = mport_decompress_zstd(MPORT_INDEX_FILE_COMPRESSED, mport_index_file_path());
 		}
 		free(hash);
 	} else {


### PR DESCRIPTION
### Motivation
- Ensure `mport_fetch_bootstrap_index()` does not report success when the downloaded `.sha256` file is missing/invalid or when verification fails, preventing use of an unverified or undecompressed index.

### Description
- In `libmport/fetch.c` set `result = MPORT_ERR_FATAL` when `hash == NULL || mport_verify_hash(...) == 0`, and set `result = MPORT_OK` after successful decompression, so the function returns an error on verification failure and only `MPORT_OK` on verified decompression.

### Testing
- Ran the C pre-commit script `./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh`, which failed in this environment due to `cppcheck` not being available in `PATH`.
- Ran `./skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh`, which failed due to `splint` not being available in `PATH`.
- Committed the change locally and created PR metadata; the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0699faea4483228c36bb0b8e99993c)

## Summary by Sourcery

Correct error reporting in bootstrap index download to only return success after a verified and decompressed index.

Bug Fixes:
- Ensure bootstrap index fetch reports a fatal error when the hash file is missing or hash verification fails instead of silently succeeding.
- Only mark bootstrap index fetching as successful after the compressed index has been decompressed.