### PR TITLE
Fix memory leaks and resource management in service.c

### DIFF
--- a/libmport/service.c
+++ b/libmport/service.c
@@ -47,7 +47,6 @@ int
 mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_action_t action) 
 {
 	sqlite3_stmt *stmt;
-	int ret;
 	char *service;
 	const unsigned char *rc_script;
 	char *handle_rc_script;
@@ -60,7 +59,9 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 
 	// if handle rc scripts is disabled, we don't need to do anything
 	handle_rc_script = mport_setting_get(mport, MPORT_SETTING_HANDLE_RC_SCRIPTS);
-	if (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script))
+	bool skip = (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script));
+	free(handle_rc_script);
+	if (skip)
 	    return (MPORT_OK);
 	
 	/* stop any services that might exist; this replaces @stopdaemon */
@@ -69,16 +70,16 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 		ASSET_FILE, pack->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
-	while (1) {
-		ret = sqlite3_step(stmt);
-		if (ret != SQLITE_ROW) {
-			break;
-		}
-
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
 		rc_script = sqlite3_column_text(stmt, 0);
 		if (rc_script == NULL)
 			continue;
-		service = basename((char *)rc_script);
+
+		char *rc_script_dup = strdup((const char *)rc_script);
+		if (rc_script_dup == NULL)
+			continue;
+
+		service = basename(rc_script_dup);
 
 		if (action == SERVICE_START) {
 			if (run_service_cmd(mport, service, "quietstart") != 0) {
@@ -88,8 +89,11 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 			if (run_service_cmd(mport, service, "forcestop") != 0) {
 				mport_call_msg_cb(mport, "Unable to stop service %s\n", service);
 			}
-		}	
+		}
+		free(rc_script_dup);
 	}
+
+	sqlite3_finalize(stmt);
 
 	return (MPORT_OK);
 }
@@ -100,7 +104,6 @@ run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
 	int error, pstat;
 	pid_t pid;
 	const char *argv[4];
-	char *service;
 
 	if (rc_script == NULL || command == NULL)
 		return (0);
@@ -110,10 +113,9 @@ run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
 	argv[2] = command;
 	argv[3] = NULL;
 
-	service = basename((char *)rc_script);
 	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL, (char **)argv, environ)) != 0) {
 		errno = error;
-		mport_call_msg_cb(mport, "Unable to %s service %s\n", command, service);
+		mport_call_msg_cb(mport, "Unable to %s service %s\n", command, rc_script);
 		return (-1);
 	}
 


### PR DESCRIPTION
This PR addresses several resource management and stability issues in the service handling logic (`mport_start_stop_service`).

### Fixes:
- **Memory Leak Fix**: The `handle_rc_script` setting string returned by `mport_setting_get` was never freed, causing a small leak every time a service was started or stopped.
- **SQLite Statement Leak**: Added a missing `sqlite3_finalize(stmt)` call to prevent leaking SQLite statement handles.
- **Safety Hardening**: The code now uses `strdup()` before calling `basename()` on pointers returned by `sqlite3_column_text()`. This is critical because `basename()` may modify its input, which could lead to undefined behavior when acting on internal SQLite memory buffers.
- **Code Cleanup**: Simplified `run_service_cmd()` by removing redundant calls and unnecessary temporary variables, and refactored the main loop for better readability.

## Summary by Sourcery

Fix memory and SQLite resource leaks in service handling and simplify service command execution.

Bug Fixes:
- Free the handle_rc_script setting string after use to prevent a memory leak on service start/stop.
- Finalize SQLite statements after iterating over service records to avoid leaking statement handles.
- Avoid modifying SQLite-managed memory by duplicating rc_script strings before passing them to basename().

Enhancements:
- Simplify the service iteration loop and run_service_cmd helper by removing redundant variables and using clearer control flow.