### PR TITLE
Fix memory leak and integer truncation in stats.c

### DIFF
--- a/libmport/stats.c
+++ b/libmport/stats.c
@@ -51,65 +51,76 @@ mport_stats_free(mportStats *stats)
 MPORT_PUBLIC_API int
 mport_stats(mportInstance *mport, mportStats **stats)
 {
-	sqlite3_stmt *stmt;
+	sqlite3_stmt *stmt = NULL;
 	sqlite3 *db = mport->db;
 	mportStats *s;
 	int result = MPORT_OK;
-	char *err;
+
+	if (stats == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "stats pointer is NULL");
 
 	if ((s = mport_stats_new()) == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
-	*stats = s;
-
 	if (mport_db_prepare(db, &stmt, "SELECT COUNT(*) FROM packages") != MPORT_OK) {
-		sqlite3_finalize(stmt);
-		RETURN_CURRENT_ERROR;
+		result = mport_err_code();
+		goto cleanup;
 	}
 
 	if (sqlite3_step(stmt) != SQLITE_ROW) {
-		sqlite3_finalize(stmt);
-		err = (char *) sqlite3_errmsg(db);
+		SET_ERRORX(MPORT_ERR_FATAL, "%s", sqlite3_errmsg(db));
 		result = MPORT_ERR_FATAL;
-		SET_ERRORX(result, "%s", err);
-		return result;
+		goto cleanup;
 	}
 
 	s->pkg_installed = (unsigned int) sqlite3_column_int(stmt, 0);
 	sqlite3_finalize(stmt);
+	stmt = NULL;
 
 
 	if (mport_db_prepare(db, &stmt, "SELECT sum(flatsize) FROM packages") != MPORT_OK) {
-		sqlite3_finalize(stmt);
-		RETURN_CURRENT_ERROR;
+		result = mport_err_code();
+		goto cleanup;
 	}
 
 	if (sqlite3_step(stmt) != SQLITE_ROW) {
-		sqlite3_finalize(stmt);
-		err = (char *) sqlite3_errmsg(db);
+		SET_ERRORX(MPORT_ERR_FATAL, "%s", sqlite3_errmsg(db));
 		result = MPORT_ERR_FATAL;
-		SET_ERRORX(result, "%s", err);
-		return result;
+		goto cleanup;
 	}
 
-	s->pkg_installed_size = (unsigned int) sqlite3_column_int(stmt, 0);
+	s->pkg_installed_size = sqlite3_column_int64(stmt, 0);
 	sqlite3_finalize(stmt);
+	stmt = NULL;
 
 	if (mport_db_prepare(db, &stmt, "SELECT COUNT(*) FROM idx.packages") != MPORT_OK) {
+		int errcode = sqlite3_errcode(db);
+		/* If the index is missing or detached, we still want to return what we have for local */
+		if (errcode == SQLITE_ERROR && strstr(sqlite3_errmsg(db), "no such table") != NULL) {
+			s->pkg_available = 0;
+			sqlite3_finalize(stmt);
+			stmt = NULL;
+		} else {
+			result = MPORT_ERR_FATAL;
+			goto cleanup;
+		}
+	} else {
+		if (sqlite3_step(stmt) != SQLITE_ROW) {
+			s->pkg_available = 0;
+		} else {
+			s->pkg_available = (unsigned int) sqlite3_column_int(stmt, 0);
+		}
 		sqlite3_finalize(stmt);
-		RETURN_CURRENT_ERROR;
+		stmt = NULL;
 	}
 
-	if (sqlite3_step(stmt) != SQLITE_ROW) {
+	*stats = s;
+	return MPORT_OK;
+
+cleanup:
+	if (stmt != NULL)
 		sqlite3_finalize(stmt);
-		err = (char *) sqlite3_errmsg(db);
-		result = MPORT_ERR_FATAL;
-		SET_ERRORX(result, "%s", err);
-		return result;
-	}
-
-	s->pkg_available = (unsigned int) sqlite3_column_int(stmt, 0);
-	sqlite3_finalize(stmt);
-
+	mport_stats_free(s);
+	*stats = NULL;
 	return result;
 }


### PR DESCRIPTION
This PR fixes a critical truncation bug and a memory leak in the package statistics logic.

### Fixes:
- **Integer Truncation**: Replaced `sqlite3_column_int()` with `sqlite3_column_int64()` for the total disk space calculation. The previous implementation would overflow once total package size exceeded ~2GB.
- **Memory Leak**: Implemented a central `cleanup` block in `mport_stats()` to ensure the allocated `mportStats` structure and all `sqlite3_stmt` handles are properly freed on any error path.
- **Graceful Error Handling**: If the remote index is missing or unreachable, the function now returns local statistics with available packages set to 0, rather than failing entirely. This improves the offline experience.
- **Safety**: Added a check for `NULL` output pointers.

## Summary by Sourcery

Fix package statistics querying to avoid leaks and truncation while improving error handling.

Bug Fixes:
- Prevent integer truncation in total installed package size by using a 64-bit aggregate value.
- Ensure allocated stats structures and SQLite statements are always freed on error paths to avoid memory leaks.
- Return local statistics with zero available packages when the remote index is missing or unreachable instead of failing.
- Reject calls with a null stats output pointer to avoid invalid writes.