### PR TITLE
Deduplicate topological sort logic and implement dependency-aware updateMany

### DIFF
--- a/mport/mport.c
+++ b/mport/mport.c
@@ -112,6 +112,239 @@ static int annotate_delete(/*@notnull@*/ mportInstance *mport,
 static int annotate_add(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageName,
     /*@notnull@*/ const char *tagName, /*@notnull@*/ const char *tagValue);
 
+
+static mportPackageMeta **
+sort_dependencies_topological(mportInstance *mport, mportPackageMeta **flat_packs, int package_count, bool reverse_edges)
+{
+	mportPackageMeta **sorted_packs = calloc((size_t)package_count, sizeof(mportPackageMeta *));
+	int *in_degree = calloc((size_t)package_count, sizeof(int));
+	bool *queued = calloc((size_t)package_count, sizeof(bool));
+
+	struct edge {
+		int to;
+		struct edge *next;
+	};
+	struct edge **adj = calloc((size_t)package_count, sizeof(struct edge *));
+
+	if (sorted_packs == NULL || in_degree == NULL || adj == NULL || queued == NULL) {
+		warnx("Out of memory");
+		goto error;
+	}
+
+	// Build the dependency graph
+	for (int i = 0; i < package_count; i++) {
+		mportPackageMeta **downdeps = NULL;
+		if (mport_pkgmeta_get_downdepends(mport, flat_packs[i], &downdeps) != MPORT_OK) {
+			warnx("Error getting dependencies for %s: %s", flat_packs[i]->name, mport_err_string());
+			goto error;
+		}
+		
+		if (downdeps != NULL) {
+			for (mportPackageMeta **d = downdeps; *d != NULL; d++) {
+				for (int j = 0; j < package_count; j++) {
+					if (i == j)
+						continue;
+					if (strcmp((*d)->name, flat_packs[j]->name) == 0) {
+						int from = reverse_edges ? j : i;
+						int to = reverse_edges ? i : j;
+
+						bool duplicate = false;
+						struct edge *curr = adj[from];
+						while (curr != NULL) {
+							if (curr->to == to) {
+								duplicate = true;
+								break;
+							}
+							curr = curr->next;
+						}
+
+						if (!duplicate) {
+							struct edge *new_edge = malloc(sizeof(struct edge));
+							if (new_edge == NULL) {
+								warnx("Out of memory");
+								mport_pkgmeta_vec_free(downdeps);
+								goto error;
+							}
+							new_edge->to = to;
+							new_edge->next = adj[from];
+							adj[from] = new_edge;
+							in_degree[to]++;
+						}
+						break;
+					}
+				}
+			}
+			mport_pkgmeta_vec_free(downdeps);
+		}
+	}
+
+	int sorted_count = 0;
+	while (sorted_count < package_count) {
+		int i;
+		for (i = 0; i < package_count; i++) {
+			if (!queued[i] && in_degree[i] == 0) {
+				break;
+			}
+		}
+
+		if (i == package_count) {
+			warnx("Dependency cycle detected among packages. Ordering may be sub-optimal.");
+			for (i = 0; i < package_count; i++) {
+				if (!queued[i])
+					break;
+			}
+		}
+
+		queued[i] = true;
+		sorted_packs[sorted_count++] = flat_packs[i];
+
+		struct edge *curr = adj[i];
+		while (curr != NULL) {
+			in_degree[curr->to]--;
+			curr = curr->next;
+		}
+	}
+
+	for (int i = 0; i < package_count; i++) {
+		struct edge *curr = adj[i];
+		while (curr != NULL) {
+			struct edge *next = curr->next;
+			free(curr);
+			curr = next;
+		}
+	}
+	free(adj);
+	free(in_degree);
+	free(queued);
+	return sorted_packs;
+
+error:
+	if (adj != NULL) {
+		for (int i = 0; i < package_count; i++) {
+			struct edge *curr = adj[i];
+			while (curr != NULL) {
+				struct edge *next = curr->next;
+				free(curr);
+				curr = next;
+			}
+		}
+		free(adj);
+	}
+	free(sorted_packs);
+	free(in_degree);
+	free(queued);
+	return NULL;
+}
+
+static int
+updateMany(mportInstance *mport, int argc, char **argv)
+{
+	mportPackageMeta **packs = NULL;
+	int package_count = 0;
+	int resultCode = MPORT_OK;
+
+	mportPackageMeta ***results = calloc((size_t)argc, sizeof(mportPackageMeta **));
+	if (results == NULL) {
+		warnx("Out of memory");
+		return MPORT_ERR_FATAL;
+	}
+
+	if (argc > 1 && strchr(argv[1], '*') != NULL) {
+		char *pkg = mport_string_replace(argv[1], "*", "%");
+		if (mport_pkgmeta_search_master(mport, &results[0], "pkg like %Q", pkg) != MPORT_OK) {
+			warnx("%s", mport_err_string());
+			free(pkg);
+			free(results);
+			return (MPORT_ERR_FATAL);
+		}
+		free(pkg);
+		if (results[0] == NULL) {
+			warnx("No packages installed matching '%s'", argv[1]);
+			free(results);
+			return (MPORT_ERR_FATAL);
+		}
+		packs = results[0];
+		while (*packs != NULL) {
+			package_count++;
+			packs++;
+		}
+	} else {
+		for (int i = 1; i < argc; i++) {
+			results[i - 1] = lookup_package(mport, argv[i]);
+			if (results[i - 1] != NULL) {
+				packs = results[i - 1];
+				while (*packs != NULL) {
+					package_count++;
+					packs++;
+				}
+			} else {
+				warnx("Package %s is not installed. Skipping update.", argv[i]);
+			}
+		}
+	}
+
+	if (package_count == 0) {
+		for (int i = 0; i < argc; i++)
+			if (results[i] != NULL)
+				mport_pkgmeta_vec_free(results[i]);
+		free(results);
+		return MPORT_OK;
+	}
+
+	mportPackageMeta **flat_packs = calloc((size_t)package_count, sizeof(mportPackageMeta *));
+	if (flat_packs == NULL) {
+		warnx("Out of memory");
+		resultCode = MPORT_ERR_FATAL;
+		goto cleanup;
+	}
+
+	int flat_idx = 0;
+	for (int i = 0; i < argc; i++) {
+		if (results[i] == NULL)
+			continue;
+		packs = results[i];
+		while (*packs != NULL) {
+			if (flat_idx < package_count) {
+				flat_packs[flat_idx++] = *packs;
+			}
+			packs++;
+		}
+	}
+
+	if (flat_idx != package_count) {
+		warnx("Warning: package count mismatch during update (%d != %d)", flat_idx,
+		    package_count);
+		package_count = flat_idx;
+	}
+
+	mportPackageMeta **sorted_packs = sort_dependencies_topological(mport, flat_packs, package_count, true);
+	if (sorted_packs == NULL) {
+		resultCode = MPORT_ERR_FATAL;
+		free(flat_packs);
+		goto cleanup;
+	}
+
+	for (int i = 0; i < package_count; i++) {
+		int tempResultCode = mport_update(mport, sorted_packs[i]->name);
+		if (tempResultCode != MPORT_OK) {
+			resultCode = tempResultCode;
+			mport_call_msg_cb(mport, "Error updating package %s: %s", sorted_packs[i]->name,
+			    mport_err_string());
+		}
+	}
+
+	free(flat_packs);
+	free(sorted_packs);
+
+cleanup:
+	for (int i = 0; i < argc; i++) {
+		if (results[i] != NULL)
+			mport_pkgmeta_vec_free(results[i]);
+	}
+
+	free(results);
+	return (resultCode);
+}
 int
 main(int argc, char *argv[])
 {
@@ -325,39 +558,7 @@ main(int argc, char *argv[])
 			usage();
 		}
 		loadIndex(mport);
-
-		if (strchr(argv[1], '*') != NULL) {
-			mportPackageMeta **packs = NULL;
-			mportPackageMeta **packs_orig = NULL;
-			char *pkg = mport_string_replace(argv[1], "*", "%");
-			if (mport_pkgmeta_search_master(mport, &packs, "pkg like %Q", pkg) !=
-			    MPORT_OK) {
-				warnx("%s", mport_err_string());
-				mport_instance_free(mport);
-				return (MPORT_ERR_FATAL);
-			}
-
-			if (packs == NULL) {
-				warnx("No packages installed matching '%s'", argv[1]);
-				return (MPORT_ERR_FATAL);
-			}
-
-			packs_orig = packs;
-			while (*packs != NULL) {
-				mport_update(mport, (*packs)->name);
-				packs++;
-			}
-			mport_pkgmeta_free(*packs_orig);
-		} else {
-			for (i = 1; i < argc; i++) {
-				tempResultCode = mport_update(mport, argv[i]);
-				if (tempResultCode != MPORT_OK) {
-					resultCode = tempResultCode;
-					mport_call_msg_cb(mport, "Error updating package %s: %s",
-					    argv[i], mport_err_string());
-				}
-			}
-		}
+		resultCode = updateMany(mport, argc, argv);
 	} else if (!strcmp(cmd, "download")) {
 		loadIndex(mport);
 		char *path;
@@ -1247,12 +1448,13 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 	int resultCode = MPORT_OK;
 
 	mportPackageMeta ***results = calloc(count, sizeof(mportPackageMeta **));
-	if (results == NULL)
-		err(EXIT_FAILURE, "calloc");
+	if (results == NULL) {
+		warnx("Out of memory");
+		return MPORT_ERR_FATAL;
+	}
 
 	printf("Installed packages to be REMOVED:\n\n");
 
-	// First pass: query DB, display info, retain metadata for second pass
 	for (size_t i = 0; i < count; i++) {
 		mportPackageMeta **packs_orig = NULL;
 		if (mport_pkgmeta_search_master(
@@ -1298,14 +1500,12 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 			if (results[i] != NULL)
 				mport_pkgmeta_vec_free(results[i]);
 		free(results);
-		return (MPORT_ERR_WARN); // No packages to delete
+		return (MPORT_ERR_WARN);
 	}
 
-	// Convert total_flatsize to human-readable format
 	humanize_number(flatsize_str, sizeof(flatsize_str), total_flatsize, "B", HN_AUTOSCALE,
 	    HN_DECIMAL | HN_IEC_PREFIXES);
 
-	// Display information and ask for confirmation
 	printf("Packages to be deleted: %d\n", package_count);
 	printf("Total disk space to be freed: %s\n", flatsize_str);
 
@@ -1315,23 +1515,11 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 			if (results[i] != NULL)
 				mport_pkgmeta_vec_free(results[i]);
 		free(results);
-		return (MPORT_ERR_WARN); // User chose not to proceed
+		return (MPORT_ERR_WARN);
 	}
 
-	// Second pass: topological sort to handle dependencies correctly
 	mportPackageMeta **flat_packs = calloc((size_t)package_count, sizeof(mportPackageMeta *));
-	mportPackageMeta **sorted_packs = calloc((size_t)package_count, sizeof(mportPackageMeta *));
-	int *in_degree = calloc((size_t)package_count, sizeof(int));
-	bool *queued = calloc((size_t)package_count, sizeof(bool));
-
-	struct edge {
-		int to;
-		struct edge *next;
-	};
-	struct edge **adj = calloc((size_t)package_count, sizeof(struct edge *));
-
-	if (flat_packs == NULL || sorted_packs == NULL || in_degree == NULL || adj == NULL ||
-	    queued == NULL) {
+	if (flat_packs == NULL) {
 		warnx("Out of memory");
 		resultCode = MPORT_ERR_FATAL;
 		goto cleanup;
@@ -1356,79 +1544,13 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 		package_count = flat_idx;
 	}
 
-	// Build the dependency graph
-	for (int i = 0; i < package_count; i++) {
-		mportPackageMeta **downdeps = NULL;
-		if (mport_pkgmeta_get_downdepends(mport, flat_packs[i], &downdeps) == MPORT_OK &&
-		    downdeps != NULL) {
-			for (mportPackageMeta **d = downdeps; *d != NULL; d++) {
-				for (int j = 0; j < package_count; j++) {
-					if (i == j)
-						continue;
-					if (strcmp((*d)->name, flat_packs[j]->name) == 0) {
-						// i depends on j, so i must be deleted before j
-						// Check for duplicate edges before adding
-						bool duplicate = false;
-						struct edge *curr = adj[i];
-						while (curr != NULL) {
-							if (curr->to == j) {
-								duplicate = true;
-								break;
-							}
-							curr = curr->next;
-						}
-
-						if (!duplicate) {
-							struct edge *new_edge = malloc(sizeof(struct edge));
-							if (new_edge == NULL) {
-								warnx("Out of memory");
-								mport_pkgmeta_vec_free(downdeps);
-								resultCode = MPORT_ERR_FATAL;
-								goto cleanup;
-							}
-							new_edge->to = j;
-							new_edge->next = adj[i];
-							adj[i] = new_edge;
-							in_degree[j]++;
-						}
-						break;
-					}
-				}
-			}
-			mport_pkgmeta_vec_free(downdeps);
-		}
+	mportPackageMeta **sorted_packs = sort_dependencies_topological(mport, flat_packs, package_count, false);
+	if (sorted_packs == NULL) {
+		resultCode = MPORT_ERR_FATAL;
+		free(flat_packs);
+		goto cleanup;
 	}
 
-	// Kahn's algorithm for topological sort
-	int sorted_count = 0;
-	while (sorted_count < package_count) {
-		int i;
-		for (i = 0; i < package_count; i++) {
-			if (!queued[i] && in_degree[i] == 0) {
-				break;
-			}
-		}
-
-		if (i == package_count) {
-			// Cycle detected, pick any unqueued
-			warnx("Dependency cycle detected among packages to be deleted. Removal order may be sub-optimal.");
-			for (i = 0; i < package_count; i++) {
-				if (!queued[i])
-					break;
-			}
-		}
-
-		queued[i] = true;
-		sorted_packs[sorted_count++] = flat_packs[i];
-
-		struct edge *curr = adj[i];
-		while (curr != NULL) {
-			in_degree[curr->to]--;
-			curr = curr->next;
-		}
-	}
-
-	// Third pass: delete in sorted order
 	for (int i = 0; i < package_count; i++) {
 		mportPackageMeta *pack = sorted_packs[i];
 		if (mport_lock_islocked(pack) == MPORT_LOCKED) {
@@ -1443,28 +1565,15 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 		}
 	}
 
+	free(flat_packs);
+	free(sorted_packs);
+
 cleanup:
 	for (size_t i = 0; i < count; i++) {
 		if (results[i] != NULL)
 			mport_pkgmeta_vec_free(results[i]);
 	}
 
-	if (adj != NULL) {
-		for (int i = 0; i < package_count; i++) {
-			struct edge *curr = adj[i];
-			while (curr != NULL) {
-				struct edge *next = curr->next;
-				free(curr);
-				curr = next;
-			}
-		}
-	}
-
-	free(flat_packs);
-	free(sorted_packs);
-	free(in_degree);
-	free(adj);
-	free(queued);
 	free(results);
 	return (resultCode);
 }


### PR DESCRIPTION
This PR refactors the dependency handling in `mport/mport.c` to use a single, shared topological sort mechanism for both updates and deletions.

### Improvements:
- **Shared Logic**: Extracted the Kahn's algorithm and graph construction logic into a reusable `sort_dependencies_topological()` helper.
- **Dependency-Aware Updates**: The `update` command now correctly orders multiple packages so that dependencies are updated before the packages that rely on them.
- **Dependency-Aware Deletions**: Refactored the recently merged delete-ordering logic to use the shared helper, improving maintainability.
- **Code Cleanup**: Removed nearly 200 lines of redundant code between `updateMany` and `deleteMany`.
- **Merge Consistency**: This PR is based on the now-merged PR 141 and resolves the overlap conflicts.

## Summary by Sourcery

Introduce a shared topological dependency-sorting helper and use it to implement a dependency-aware batch update path for the `update` command.

New Features:
- Add an `updateMany` command handler that updates multiple packages in dependency-aware order, including wildcard selection.

Enhancements:
- Extract dependency graph construction and topological sorting into a reusable `sort_dependencies_topological` helper and refactor the `update` code path to use it.