### PR TITLE
Fix bogus "Out of memory" error in mport info for uninstalled packages

### DIFF
--- a/libmport/info.c
+++ b/libmport/info.c
@@ -250,7 +250,27 @@ mport_info(mportInstance *mport, const char *packageName) {
 	         indexEntry == NULL ? "" : indexEntry->comment,
 	         annotations_str,
 	         options,
-		 type == MPORT_TYPE_APP ? "Application" : "System", 
+		 type == MPORT_TYPE_APP ? "Application" : "System",
+		 flatsize_str,
+		 desc);
+	} else {
+		/* Not installed locally; report index information only. */
+		asprintf(&info_text,
+	         "%s-%s\n"
+	         "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
+	         "Flavor          : %s\nOS              : %s\n"
+	         "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
+	         "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
+	         indexEntry->pkgname, indexEntry->version,
+	         indexEntry->pkgname, status, indexEntry->version, indexEntry->license == NULL ? "" : indexEntry->license, origin,
+	         flavor, os_release,
+		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
+	         expirationDate == 0 ? "" : ctime(&expirationDate),
+	         installDate == 0 ? "\n" : ctime(&installDate),
+	         indexEntry->comment == NULL ? "" : indexEntry->comment,
+	         annotations_str,
+	         options,
+		 type == MPORT_TYPE_APP ? "Application" : "System",
 		 flatsize_str,
 		 desc);
 	}

--- a/libmport/info.c
+++ b/libmport/info.c
@@ -265,8 +265,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 	         indexEntry->pkgname, status, indexEntry->version, indexEntry->license == NULL ? "" : indexEntry->license, origin,
 	         flavor, os_release,
 		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         expirationDate == 0 ? "" : ctime(&expirationDate),
-	         installDate == 0 ? "\n" : ctime(&installDate),
+	         "",  /* expiration date: not installed, always empty */
+	         "\n", /* install date: not installed, always empty */
 	         indexEntry->comment == NULL ? "" : indexEntry->comment,
 	         annotations_str,
 	         options,


### PR DESCRIPTION
## Problem

`mport info <pkg>` reported **"Out of memory"** for any package that exists in the index but is **not installed locally**. This is a common path — checking a package's info before installing it — so the error showed up frequently.

## Root cause

In `mport_info()` (`libmport/info.c`), when a package isn't installed, `mport_pkgmeta_search_master()` returns `packs == NULL`. The code sets up placeholder strings for this case, but **both** `asprintf` branches that build the output were gated on `packs != NULL`. As a result `info_text` stayed `NULL` and the function fell through to the `SET_ERROR(MPORT_ERR_FATAL, "Out of memory.")` path. It was never an actual allocation failure — just a missing format branch.

## Fix

Add the missing `else` branch for the `packs == NULL` case, populating the output from the index entry (`pkgname`, `version` as Latest, `license`, `comment`) plus the already-prepared placeholder fields, with NULL guards on the index strings.

## Testing

Validated with `cd libmport && make` — clean `-Werror` compile. (No automated test suite exists in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle mport info queries for packages not installed locally without spuriously reporting out-of-memory errors.

Bug Fixes:
- Fix mport info reporting a bogus "Out of memory" error when querying packages present in the index but not installed locally.

Enhancements:
- Show index-derived metadata for packages that are not installed locally when running mport info.