### PR TITLE
info: show local info for installed-but-unindexed packages

### DIFF
--- a/libmport/info.c
+++ b/libmport/info.c
@@ -71,14 +71,20 @@ mport_info(mportInstance *mport, const char *packageName) {
 		return (NULL);
 	}
 
-	if (indexEntry == NULL) {
-		SET_ERROR(MPORT_ERR_FATAL, "Could not resolve package.");
+	if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", packageName) != MPORT_OK) {
 		mport_index_entry_free_vec(indexEntries);
-		indexEntries = NULL;
 		return (NULL);
 	}
 
-	if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", packageName) != MPORT_OK) {
+	/*
+	 * Resolution only fails when the package is neither in the index nor
+	 * installed locally. A package that is installed but no longer in the
+	 * index still has local metadata to display.
+	 */
+	if (indexEntry == NULL && packs == NULL) {
+		SET_ERROR(MPORT_ERR_FATAL, "Could not resolve package.");
+		mport_index_entry_free_vec(indexEntries);
+		indexEntries = NULL;
 		return (NULL);
 	}
 


### PR DESCRIPTION
## Problem

These are two issues surfaced while reviewing #145, both stemming from one root cause in `mport_info()` (`libmport/info.c`):

1. **Dead code.** The formatting branch guarded by `packs != NULL && indexEntry == NULL` could never run.
2. **Installed-but-unindexed packages fail.** `mport info <pkg>` returned **"Could not resolve package."** for a package that *is* installed locally but is no longer present in the index — even though the branch above was written precisely to display its local metadata.

Both are caused by the early `indexEntry == NULL` check running **before** the local registry is queried, so the function bailed out before it could discover the package was installed.

## Fix

Query the local registry (`mport_pkgmeta_search_master`) first, and only fail resolution when the package is found in **neither** the index **nor** the local database (`indexEntry == NULL && packs == NULL`). This makes the installed-but-unindexed branch reachable, so such packages now display their local info instead of erroring.

Also frees the index entry vector on the pkgmeta search error path, which previously leaked it (that line was being moved anyway).

## Behavior matrix after the change

| In index | Installed | Result |
|---|---|---|
| yes | yes | full info (index + local) |
| no | yes | **local info** (was: "Could not resolve package.") |
| no | no | "Could not resolve package." (unchanged) |
| yes | no | handled by #145 (not in scope here) |

## Relationship to #145

Touches the same function as #145 but a non-overlapping region (the resolution/early-return logic vs. the formatting branches), so there is no textual or semantic conflict in either merge order.

## Out of scope (pre-existing, noted not fixed)

The now-live branch carries the same latent `ctime()` double-call pattern as the existing installed-package branch (two `ctime()` calls in one `asprintf` share libc's static buffer). It only manifests for an installed package that is also deprecated/moved, predates this change, and is left for a separate fix. The `moved_lookup` error path's leak is likewise pre-existing and untouched.

## Testing

`cd libmport && make` — clean `-Werror` compile. (No automated test suite exists in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle installed-but-unindexed packages correctly in mport info resolution logic.

Bug Fixes:
- Ensure mport info resolves and displays local metadata for packages installed locally but missing from the index instead of failing with 'Could not resolve package.'.
- Fix a memory leak by freeing the index entry vector on the pkgmeta search error path.