### PR TITLE
info: fix aliased ctime() buffers in mport_info output

### DIFF
--- a/libmport/info.c
+++ b/libmport/info.c
@@ -215,6 +215,20 @@ mport_info(mportInstance *mport, const char *packageName) {
 	if (annotations_str == NULL)
 		annotations_str = strdup("");
 
+	/*
+	 * ctime() returns a pointer to a single static buffer, so calling it
+	 * twice within one asprintf() argument list makes both date fields
+	 * print the same (last evaluated) value. Format each date into its
+	 * own buffer with ctime_r() up front instead.
+	 */
+	char expdate_buf[26], insdate_buf[26];
+	const char *expdate_str = expirationDate == 0 ? "" : ctime_r(&expirationDate, expdate_buf);
+	const char *insdate_str = installDate == 0 ? "\n" : ctime_r(&installDate, insdate_buf);
+	if (expdate_str == NULL)
+		expdate_str = "";
+	if (insdate_str == NULL)
+		insdate_str = "\n";
+
 	if (packs !=NULL && indexEntry == NULL) {
 		asprintf(&info_text,
 	         "%s-%s\n"
@@ -226,8 +240,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 	         (*packs)->name, status, "", "", origin,
 	         flavor, os_release,
 		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         expirationDate == 0 ? "" : ctime(&expirationDate),
-	         installDate == 0 ? "\n" : ctime(&installDate),
+	         expdate_str,
+	         insdate_str,
 	         "",
 	         annotations_str,
 	         options,
@@ -245,8 +259,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 	         (*packs)->name, status, indexEntry == NULL ? "" : indexEntry->version, indexEntry == NULL ? "" : indexEntry->license, origin,
 	         flavor, os_release,
 		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         expirationDate == 0 ? "" : ctime(&expirationDate),
-	         installDate == 0 ? "\n" : ctime(&installDate),
+	         expdate_str,
+	         insdate_str,
 	         indexEntry == NULL ? "" : indexEntry->comment,
 	         annotations_str,
 	         options,

--- a/libmport/info.c
+++ b/libmport/info.c
@@ -36,6 +36,12 @@
 #include <unistd.h>
 #include <libutil.h>
 
+/*
+ * ctime_r(3) requires a caller-supplied buffer of at least 26 bytes to hold
+ * the formatted "Www Mmm dd hh:mm:ss yyyy\n\0" time string.
+ */
+#define CTIME_R_BUFLEN 26
+
 MPORT_PUBLIC_API char *
 mport_info(mportInstance *mport, const char *packageName) {
 	mportIndexEntry **indexEntries = NULL;
@@ -221,7 +227,7 @@ mport_info(mportInstance *mport, const char *packageName) {
 	 * print the same (last evaluated) value. Format each date into its
 	 * own buffer with ctime_r() up front instead.
 	 */
-	char expdate_buf[26], insdate_buf[26];
+	char expdate_buf[CTIME_R_BUFLEN], insdate_buf[CTIME_R_BUFLEN];
 	const char *expdate_str = expirationDate == 0 ? "" : ctime_r(&expirationDate, expdate_buf);
 	const char *insdate_str = installDate == 0 ? "\n" : ctime_r(&installDate, insdate_buf);
 	if (expdate_str == NULL)


### PR DESCRIPTION
## Problem

`mport_info()` calls `ctime()` twice inside a single `asprintf()` argument list — once for the Expiration Date and once for the Install Date:

```c
expirationDate == 0 ? "" : ctime(&expirationDate),
installDate    == 0 ? "\n" : ctime(&installDate),
```

`ctime()` returns a pointer into a single static buffer. Since both `asprintf` arguments are evaluated before the call, both end up pointing at the same storage, which holds only the **last** formatted time. So when both dates are non-zero, the Expiration Date and Install Date fields print the *same* value.

This manifests for an installed package that is also deprecated/moved (expiration date set from the moved entry, install date set from the registry).

## Fix

Format each date into its own buffer with `ctime_r()` before the `asprintf()` call, and pass the resulting strings. `ctime_r()` keeps the trailing newline `ctime()` produced, so the output layout is unchanged. NULL returns are guarded back to the original empty/`"\n"` placeholders.

This corrects both the installed+indexed formatting branch and the installed-but-unindexed branch (the latter being the one #146 makes reachable).

## Relationship to #145 / #146

This is the pre-existing `ctime()` issue noted in #146's description. All three PRs touch `mport_info()`:
- #145 — OOM fix for uninstalled packages (adds the index-only branch)
- #146 — installed-but-unindexed packages (makes the dead branch live)
- this — aliased `ctime()` buffers

This change edits the date arguments of the format branches and adds a block before them, regions distinct from #145/#146, so conflicts should be trivial if any.

## Testing

`cd libmport && make` — clean `-Werror` compile. (No automated test suite exists in this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure expiration and install dates in mport_info output are formatted independently so they no longer print the same timestamp when both are present.