### PR TITLE
Fix memory leaks and invalid frees in mport.c

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,3 +239,5 @@ SQLite database lives at `/var/db/mport/`. Schema versioning is managed in `libm
 4. Deploys assets via `mport.install` / `install_primative.c`
 5. Runs Lua pre/post-install hooks via `libmport/lua.c`
 6. Updates master SQLite registry
+
+Load @AGENTS.md for skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,57 @@ Format changed files with `clang-format -i <file>`.
 
 ## Testing
 
-There is no automated test suite. CI runs via Jenkins (`Jenkinsfile`, matrix builds on amd64/i386) and GitHub Actions CodeQL (`.github/workflows/c-cpp.yml`). Testing is manual and integration-based. Correctness validation is primarily compile-time (strict warnings as errors).
+There is a small ATF/Kyua test suite in `tests/` (not yet comprehensive). It
+drives the built binaries from the build tree — no installed `mport` or
+populated registry is required for most cases. CI also runs via Jenkins
+(`Jenkinsfile`, matrix builds on amd64/i386) and GitHub Actions CodeQL
+(`.github/workflows/c-cpp.yml`). Correctness validation is still largely
+compile-time (strict warnings as errors).
+
+### Test programs (`tests/`)
+
+| File | Covers |
+|------|--------|
+| `mport_create_test` | `mport.create` — package creation, invalid `-E` date, overlong `-o` path |
+| `mport_libexec_test` | `version_cmp`, `check_fake`, frontend missing-arg rejection, `list` extra-args, `init`/`update` bad-chroot |
+| `mport_cli_test` | `mport(8)` front end — usage, invalid global flag, bad chroot; registry-gated runtime smoke test for the package-vector paths |
+
+Tests locate binaries relative to `$(atf_get_srcdir)` (e.g. `../libexec/...`,
+`../mport/mport`) and set `LD_LIBRARY_PATH` to `../libmport`, so they run
+against a freshly built tree. Cases that need a local registry call
+`atf_skip` when `/var/db/mport/master.db` is absent.
+
+### Running the tests
+
+```sh
+make                       # build the tree first
+cd tests
+kyua test                  # run the whole suite
+kyua test mport_cli_test   # run one program
+kyua report                # show results of the last run
+# or invoke a program directly without kyua:
+atf-sh ./mport_cli_test usage_without_command
+```
+
+### AddressSanitizer (leak / invalid-free lane)
+
+`libmport` and `mport` honor a `WITH_ASAN` knob (see `mk/sanitize.mk`).
+Build instrumented and run the CLI / tests under it to catch invalid or
+double frees, use-after-free, and buffer overflows — e.g. freeing an
+advanced (interior) vector pointer:
+
+```sh
+( cd libmport && make clean && make WITH_ASAN=1 )   # clean: stale .o won't reinstrument
+( cd mport && make clean && make WITH_ASAN=1 )
+ASAN_OPTIONS=detect_leaks=0 LD_LIBRARY_PATH=libmport ./mport/mport audit
+```
+
+A clean rebuild is required — `make WITH_ASAN=1` over up-to-date objects
+will not re-instrument them. The instrumented `libmport.so` can only be
+loaded by an equally instrumented `mport`; build/run the libexec tools in a
+normal tree. **LeakSanitizer (`detect_leaks=1`) is unsupported on
+MidnightBSD**, so this lane catches memory errors and bad frees, not plain
+"allocated but never freed" leaks — verify those by code tracing.
 
 ## Architecture
 

--- a/libmport/Makefile
+++ b/libmport/Makefile
@@ -23,6 +23,8 @@ MK_PROFILE=no
 
 LIBADD=	md archive lzma z elf fetch sqlite3 ucl pthread util zstd
 
-LDFLAGS+=	-lmd -larchive -llzma -lz -lelf -lfetch -lsqlite3 -lpthread -lprivateucl -lutil -lprivatezstd -l:liblua.a -L ${.CURDIR}/../liblua 
+LDFLAGS+=	-lmd -larchive -llzma -lz -lelf -lfetch -lsqlite3 -lpthread -lprivateucl -lutil -lprivatezstd -l:liblua.a -L ${.CURDIR}/../liblua
+
+.include "${.CURDIR}/../mk/sanitize.mk"
 
 .include <bsd.lib.mk>

--- a/mk/sanitize.mk
+++ b/mk/sanitize.mk
@@ -1,0 +1,22 @@
+# Opt-in AddressSanitizer build, shared by libmport and the mport CLI.
+#
+# Usage:
+#	make WITH_ASAN=1            (build component with ASan)
+#
+# AddressSanitizer instruments memory accesses and aborts on heap buffer
+# overflows, use-after-free, double free, and free() of a non-heap/interior
+# pointer.  It is the regression net for the kinds of vector-handling bugs in
+# the CLI (e.g. freeing an advanced pointer).
+#
+# NOTE: LeakSanitizer (ASAN_OPTIONS=detect_leaks=1) is NOT supported on
+# MidnightBSD, so this lane does NOT report plain "allocated but never freed"
+# leaks -- only active memory errors.  Verify leaks by code tracing.
+#
+# Because libmport.so is instrumented under this knob, only ASan-linked
+# executables (the mport CLI built with the same WITH_ASAN) can load it; build
+# and run the libexec tools in a normal, non-ASan tree.
+
+.if defined(WITH_ASAN)
+CFLAGS+=	-fsanitize=address -fno-omit-frame-pointer -g
+LDFLAGS+=	-fsanitize=address
+.endif

--- a/mport/Makefile
+++ b/mport/Makefile
@@ -8,4 +8,6 @@ LIBADD+=	mport util
 
 BINDIR=	/usr/sbin
 
+.include "${.CURDIR}/../mk/sanitize.mk"
+
 .include <bsd.prog.mk>

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -1105,12 +1105,20 @@ search(/*@notnull@*/ mportInstance *mport, /*@null@*/ char **query)
 	}
 
 	while (query != NULL && *query != NULL) {
-		mport_index_search_term(mport, &indexEntry, *query);
-		if (indexEntry != NULL) {
+		/*
+		 * On failure mport_index_search_term() may leave a partially
+		 * built vector (a non-NULL entry with NULL fields), so only
+		 * print when it succeeds -- but still free whatever it
+		 * allocated.
+		 */
+		if (mport_index_search_term(mport, &indexEntry, *query) == MPORT_OK &&
+		    indexEntry != NULL) {
 			for (mportIndexEntry **e = indexEntry; *e != NULL; e++) {
 				fprintf(stdout, "%s\t%s\t%s\n", (*e)->pkgname,
 				    (*e)->version, (*e)->comment);
 			}
+		}
+		if (indexEntry != NULL) {
 			mport_index_entry_free_vec(indexEntry);
 			indexEntry = NULL;
 		}

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -1085,6 +1085,7 @@ selectMirror(/*@notnull@*/ mportInstance *mport)
 
 	if (result != MPORT_OK) {
 		warnx("%s", mport_err_string());
+		mport_index_mirror_entry_free_vec(mirrorEntry_orig);
 		return mport_err_code();
 	}
 
@@ -1105,18 +1106,14 @@ search(/*@notnull@*/ mportInstance *mport, /*@null@*/ char **query)
 
 	while (query != NULL && *query != NULL) {
 		mport_index_search_term(mport, &indexEntry, *query);
-		if (indexEntry == NULL || *indexEntry == NULL) {
-			query++;
-			continue;
+		if (indexEntry != NULL) {
+			for (mportIndexEntry **e = indexEntry; *e != NULL; e++) {
+				fprintf(stdout, "%s\t%s\t%s\n", (*e)->pkgname,
+				    (*e)->version, (*e)->comment);
+			}
+			mport_index_entry_free_vec(indexEntry);
+			indexEntry = NULL;
 		}
-
-		while (indexEntry != NULL && *indexEntry != NULL) {
-			fprintf(stdout, "%s\t%s\t%s\n", (*indexEntry)->pkgname,
-			    (*indexEntry)->version, (*indexEntry)->comment);
-			indexEntry++;
-		}
-
-		mport_index_entry_free_vec(indexEntry);
 		query++;
 	}
 
@@ -1130,7 +1127,7 @@ lock(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageName)
 
 	if (packs != NULL) {
 		mport_lock_lock(mport, (*packs));
-		mport_pkgmeta_free(*packs);
+		mport_pkgmeta_vec_free(packs);
 		return (MPORT_OK);
 	}
 
@@ -1144,7 +1141,7 @@ unlock(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageName
 
 	if (packs != NULL) {
 		mport_lock_unlock(mport, (*packs));
-		mport_pkgmeta_free(*packs);
+		mport_pkgmeta_vec_free(packs);
 		return (MPORT_OK);
 	}
 
@@ -1265,6 +1262,7 @@ install(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageNam
 			}
 			char *v = &d[loc + 1];
 			d[loc] = '\0'; /* hack off the version number */
+			mport_index_entry_free_vec(indexEntry); /* free the empty result from the full-name lookup */
 			indexEntry = lookupIndex(mport, d);
 			if (indexEntry == NULL || v == NULL || (*indexEntry) == NULL ||
 			    strcmp(v, (*indexEntry)->version) != 0) {
@@ -1643,6 +1641,7 @@ configGet(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *settingN
 
 	if (val != NULL) {
 		printf("Setting %s value is %s\n", settingName, val);
+		free(val);
 	} else {
 		printf("Setting %s is undefined.\n", settingName);
 	}
@@ -1891,17 +1890,18 @@ deleteAll(/*@notnull@*/ mportInstance *mport)
 
 	if ((mport->confirm_cb)("Proceed with removing all packages on the system?", "Delete",
 		"Don't delete", 0) != MPORT_OK) {
+		mport_pkgmeta_vec_free(packs);
 		return (MPORT_ERR_WARN); // User chose not to proceed
 	}
 
 	while (1) {
 		skip = 0;
-		while (*packs != NULL) {
-			if (mport_pkgmeta_get_updepends(mport, *packs, &depends) == MPORT_OK) {
+		for (mportPackageMeta **p = packs; *p != NULL; p++) {
+			if (mport_pkgmeta_get_updepends(mport, *p, &depends) == MPORT_OK) {
 				if (depends == NULL) {
-					if (delete (mport, (*packs)->name) != MPORT_OK) {
+					if (delete (mport, (*p)->name) != MPORT_OK) {
 						fprintf(
-						    stderr, "Error deleting %s\n", (*packs)->name);
+						    stderr, "Error deleting %s\n", (*p)->name);
 						errors++;
 					}
 					total++;
@@ -1910,7 +1910,6 @@ deleteAll(/*@notnull@*/ mportInstance *mport)
 					mport_pkgmeta_vec_free(depends);
 				}
 			}
-			packs++;
 		}
 		if (skip == 0)
 			break;
@@ -1971,8 +1970,8 @@ audit(/*@notnull@*/ mportInstance *mport, bool dependsOn)
 		return (1);
 	}
 
-	while (*packs != NULL) {
-		char *output = mport_audit(mport, (*packs)->name, dependsOn);
+	for (mportPackageMeta **pack = packs; *pack != NULL; pack++) {
+		char *output = mport_audit(mport, (*pack)->name, dependsOn);
 		if (output != NULL && output[0] != '\0') {
 			if (mport->verbosity == MPORT_VQUIET)
 				printf("%s", output);
@@ -1980,7 +1979,6 @@ audit(/*@notnull@*/ mportInstance *mport, bool dependsOn)
 				printf("%s\n", output);
 			free(output);
 		}
-		packs++;
 	}
 
 	mport_pkgmeta_vec_free(packs);

--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -4,3 +4,4 @@ test_suite("mport")
 
 atf_test_program{name="mport_create_test", }
 atf_test_program{name="mport_libexec_test", }
+atf_test_program{name="mport_cli_test", }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,7 @@ KYUAFILE=	no
 
 mportFILES=	Kyuafile \
 		mport_create_test \
-		mport_libexec_test
+		mport_libexec_test \
+		mport_cli_test
 
 .include <bsd.test.mk>

--- a/tests/mport_cli_test
+++ b/tests/mport_cli_test
@@ -1,0 +1,82 @@
+#! /usr/libexec/atf-sh
+#
+# Behavioral tests for the mport(8) CLI front end.
+#
+# The pre-dispatch tests need no package registry and run anywhere.  The
+# runtime smoke test exercises the CLI paths that allocate and free package
+# vectors (the ones hardened against invalid/leaked frees); it requires a
+# local registry and is skipped without one.  Build the tree with
+# "make WITH_ASAN=1" to have AddressSanitizer abort on a bad free here.
+
+atf_test_case usage_without_command
+usage_without_command_head()
+{
+	atf_set "descr" "mport with no command prints usage and exits non-zero"
+}
+usage_without_command_body()
+{
+	atf_check -s exit:1 -o ignore -e match:"usage: mport" "${MPORT_BIN}"
+}
+
+atf_test_case rejects_invalid_global_flag
+rejects_invalid_global_flag_head()
+{
+	atf_set "descr" "mport rejects unknown global options"
+}
+rejects_invalid_global_flag_body()
+{
+	atf_check -s not-exit:0 -o ignore -e match:"Invalid argument" \
+		"${MPORT_BIN}" -Z
+}
+
+atf_test_case reports_bad_chroot
+reports_bad_chroot_head()
+{
+	atf_set "descr" "mport reports chroot failures cleanly"
+}
+reports_bad_chroot_body()
+{
+	atf_check -s not-exit:0 -o ignore -e match:"chroot failed" \
+		"${MPORT_BIN}" -c "${PWD}/missing-root" search foo
+}
+
+atf_test_case smoke_vector_paths
+smoke_vector_paths_head()
+{
+	atf_set "descr" "config get and search run cleanly (registry required)"
+}
+smoke_vector_paths_body()
+{
+	if [ ! -f /var/db/mport/master.db ]; then
+		atf_skip "no local package registry at /var/db/mport/master.db"
+	fi
+
+	# configGet(): exercises freeing the strdup'd setting value.
+	atf_check -s exit:0 -o ignore -e not-match:"AddressSanitizer" \
+		"${MPORT_BIN}" config get mirror_region
+
+	# search(): exercises iterating and freeing an index-entry vector, the
+	# same advanced-pointer-free pattern as audit()/deleteAll() but fast.
+	# Result count and exit vary with the local index, so status/output are
+	# ignored; what matters is AddressSanitizer reporting no memory error.
+	atf_check -s ignore -o ignore -e not-match:"AddressSanitizer" \
+		"${MPORT_BIN}" -U search mport
+}
+
+atf_init_test_cases()
+{
+	srcdir=$(atf_get_srcdir)
+	: "${LD_LIBRARY_PATH:=${srcdir}/../libmport}"
+	export LD_LIBRARY_PATH
+	# LeakSanitizer is unsupported on MidnightBSD; keep ASan to memory errors.
+	: "${ASAN_OPTIONS:=detect_leaks=0}"
+	export ASAN_OPTIONS
+
+	: "${MPORT_BIN:=${srcdir}/../mport/mport}"
+	export MPORT_BIN
+
+	atf_add_test_case usage_without_command
+	atf_add_test_case rejects_invalid_global_flag
+	atf_add_test_case reports_bad_chroot
+	atf_add_test_case smoke_vector_paths
+}


### PR DESCRIPTION
Fixes seven memory-management defects in `mport/mport.c`, found by tracing every allocation site against the library's free semantics (`mport_pkgmeta_vec_free` / `mport_index_entry_free_vec` free from the given pointer to the NULL terminator then free that pointer; `mport_pkgmeta_free` frees a single element).

## Critical — interior pointer passed to `*_vec_free` (undefined behavior + leak)
`search()`, `audit()`, and `deleteAll()` advanced the vector pointer with `++` in their work loop, then passed the *advanced* pointer to `*_vec_free`. That frees **none** of the elements (leak) and calls `free()` on an interior pointer (UB — can abort under jemalloc). Fixed by iterating with a separate cursor so the base pointer reaches the free. `search()` also leaked on the empty-result path.

## Leak — vector freed as a single element
`lock()` / `unlock()` used `mport_pkgmeta_free(*packs)`, releasing only `packs[0]` and leaking the array + any further entries. Now `mport_pkgmeta_vec_free(packs)`.

## Leak — missing free on early return
- `deleteAll()`: the "user declined" return leaked the package list.
- `selectMirror()`: the `mport_setting_set` error path returned without freeing the mirror list.
- `configGet()`: `mport_setting_get()` returns a `strdup`'d string that was never freed.

## Leak — overwritten allocation
`install()`: a full `name-version` index lookup always returns an allocated (empty) vector even on no-match (`mport_index_lookup_pkgname` `calloc`s `count+1`); it was overwritten by the base-name lookup without being freed. Now freed before reassignment.

## Verification
- `make all` builds clean (exit 0); `mport.c` passes `-Wall -Wextra` with no new diagnostics.
- Smoke-tested the freshly built binary against a real package DB — `mport search`, `mport config get`, and `mport audit` all exit 0 with no allocator abort, directly exercising the `search`/`audit` interior-free fixes and the `configGet` free.
- The existing ATF/Kyua suite in `tests/` covers the libexec tools, not these `mport(8)` CLI paths, so `lock`/`unlock`, `selectMirror`, `deleteAll`, and `install` were verified by tracing rather than executed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Regression tests & ASan lane (added)

- **`tests/mport_cli_test`** (ATF) for the `mport(8)` front end: `usage`, unknown global flag, and bad-chroot run with no registry; a registry-gated smoke test runs `config get` and `search` to exercise the package/index vector-free paths this PR hardened, and `atf_skip`s when `/var/db/mport/master.db` is absent. Wired into `tests/Kyuafile` and `tests/Makefile`.
- **`WITH_ASAN` build knob** (`mk/sanitize.mk`, included by `libmport` and `mport`): builds the library + CLI with AddressSanitizer so the smoke test aborts on invalid/double free, use-after-free, or buffer overflows — directly catching the "free an advanced vector pointer" class fixed here. LeakSanitizer is unsupported on MidnightBSD, so this lane catches memory errors/bad frees, not plain unreferenced-allocation leaks (documented).
- **CLAUDE.md**: replaced the "no automated test suite" note with the test layout, how to run kyua/atf, and the ASan lane.

Verified: full `kyua` suite **18/18 passed**; a positive-control interior `free()` aborts under ASan (`alloc-dealloc-mismatch`); the instrumented `mport`/`libmport` ran `config get`, `search`, and `audit` with **zero ASan findings**.
