### PR TITLE
install: close symlink TOCTOU on file chown/chmod

### DIFF
--- a/libmport/bundle_read_install_pkg.c
+++ b/libmport/bundle_read_install_pkg.c
@@ -704,6 +704,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	mode_t *set = NULL;
 	mode_t newmode;
 	char *mode = NULL;
+	int filefd = -1;
 	char file[FILENAME_MAX], cwd[FILENAME_MAX];
 	sqlite3_stmt *insert = NULL;
 
@@ -847,12 +848,31 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 					}
 				}
 
-				if (lstat(file, &sb)) {
+				/*
+				 * Open the freshly extracted file with O_NOFOLLOW before
+				 * touching its ownership or mode. Operating on the file
+				 * descriptor (fchown/fchmod) instead of re-resolving the
+				 * path closes a symlink TOCTOU: an attacker who replaces the
+				 * file with a symlink after extraction cannot redirect the
+				 * privileged chown/chmod at another file. O_NONBLOCK avoids
+				 * blocking if the path was swapped for a FIFO. This mirrors
+				 * the fd-based directory handling in apply_dir_asset_attrs().
+				 * A symlink final component (EMLINK/ELOOP) or any other
+				 * non-regular file is left unmodified, as before, but is
+				 * still recorded in the database below.
+				 */
+				filefd = open(file, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+				if (filefd == -1 && errno != EMLINK && errno != ELOOP) {
+					SET_ERRORX(MPORT_ERR_FATAL, "Unable to open file %s: %s", file,
+					    strerror(errno));
+					goto ERROR;
+				}
+				if (filefd != -1 && fstat(filefd, &sb) != 0) {
 					SET_ERRORX(MPORT_ERR_FATAL, "Unable to stat file %s", file);
 					goto ERROR;
 				}
 
-				if (S_ISREG(sb.st_mode)) {
+				if (filefd != -1 && S_ISREG(sb.st_mode)) {
 					if (e->type == ASSET_FILE_OWNER_MODE || e->type == ASSET_SAMPLE_OWNER_MODE) {
 						/* Test for owner and group settings, otherwise roll with our default. */
 						if (e->owner != NULL && e->group != NULL && e->owner[0] != '\0' &&
@@ -860,7 +880,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 #ifdef DEBUG
 							mport_call_msg_cb(mport, "owner %s and group %s\n", e->owner, e->group);
 #endif
-							if (chown(file, mport_get_uid(e->owner),
+							if (fchown(filefd, mport_get_uid(e->owner),
 							          mport_get_gid(e->group)) == -1) {
 								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
 								goto ERROR;
@@ -869,7 +889,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 #ifdef DEBUG
 							mport_call_msg_cb(mport, "owner %s\n", e->owner);
 #endif
-							if (chown(file, mport_get_uid(e->owner), group) == -1) {
+							if (fchown(filefd, mport_get_uid(e->owner), group) == -1) {
 								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
 								goto ERROR;
 							}
@@ -877,20 +897,20 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 #ifdef DEBUG
 							mport_call_msg_cb(mport, "group %s\n", e->group);
 #endif
-							if (chown(file, owner, mport_get_gid(e->group)) == -1) {
+							if (fchown(filefd, owner, mport_get_gid(e->group)) == -1) {
 								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
 								goto ERROR;
 							}
 						} else {
 							// use default.
-							if (chown(file, owner, group) == -1) {
+							if (fchown(filefd, owner, group) == -1) {
 								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
 								goto ERROR;
 							}
 						}
 					} else {
 						/* Set the owner and group */
-						if (chown(file, owner, group) == -1) {
+						if (fchown(filefd, owner, group) == -1) {
 							SET_ERRORX(MPORT_ERR_FATAL,
 							           "Unable to set permissions on file %s", file);
 							goto ERROR;
@@ -900,7 +920,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 					/* Set the file permissions, assumes non NFSv4 */
 					if (mode != NULL || (e->mode != NULL && e->mode[0] != '\0' &&
 					                     (e->type == ASSET_SAMPLE_OWNER_MODE || e->type == ASSET_FILE_OWNER_MODE))) {
-						if (stat(file, &sb)) {
+						if (fstat(filefd, &sb)) {
 							SET_ERRORX(MPORT_ERR_FATAL, "Unable to stat file %s", file);
 							goto ERROR;
 						}
@@ -925,7 +945,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 						newmode = getmode(set, sb.st_mode);
 						free(set);
 
-						if (chmod(file, newmode)) {
+						if (fchmod(filefd, newmode)) {
 							SET_ERROR(MPORT_ERR_FATAL, "Unable to set file permissions");
 							goto ERROR;
 						}
@@ -986,6 +1006,11 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 						}
 						free(age_annotation);
 					}
+				}
+
+				if (filefd != -1) {
+					close(filefd);
+					filefd = -1;
 				}
 
 				/* for sample files, if we don't have an existing file, make a new one */
@@ -1148,6 +1173,8 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	return (MPORT_OK);
 
 	ERROR:
+		if (filefd != -1)
+			close(filefd);
 		sqlite3_finalize(insert);
 		(mport->progress_free_cb)();
 		free(orig_cwd);


### PR DESCRIPTION
## Summary

Closes a symlink TOCTOU in the package install path. `do_actual_install()` in `libmport/bundle_read_install_pkg.c` applied ownership and permissions to each extracted **regular file** with path-based `lstat(2)` → `chown(2)` → `stat(2)` → `chmod(2)`. `chown`/`chmod` follow symlinks, so a local attacker able to write to a target directory could, in the window after a file is extracted and `lstat`'d, swap it for a symlink and redirect root's `chown`/`chmod` at an arbitrary file — a local privilege-escalation primitive for packages that install into non-root-owned directories.

The **directory** asset path was already hardened this way in #119 (`apply_dir_asset_attrs` uses `fstat`/`fchmod`/`fchown` on an `O_NOFOLLOW` dirfd); the regular-file path was never given the same treatment. This change brings it in line.

## Change

- Open the freshly extracted file once with `O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC`.
- Apply ownership/mode via `fchown(2)`/`fchmod(2)`/`fstat(2)` on that descriptor instead of re-resolving the path.
- A swapped-in symlink fails the open (`EMLINK`/`ELOOP`); that final component — like any other non-regular file — is left unmodified exactly as the old `lstat`/`S_ISREG` check did, but is still recorded in the database.
- `O_NONBLOCK` avoids blocking if the path is swapped for a FIFO. The descriptor is closed on every path, including the `ERROR:` exit.

Diff is 36 insertions / 9 deletions, no behavior change for legitimate installs.

## Scope (intentionally narrow)

This closes the symlink race on the **chown/chmod step only**. Out of scope, left as follow-ups:
- the checksum read above (`MD5File`/`SHA256_File`) still operates by path;
- the age-restriction `setfacl(1)` still operates by path;
- `O_NOFOLLOW` does not defend against a pre-planted **hardlink** to a sensitive file.

Behavior note: a symlink where a regular file is expected is now silently tolerated (no attrs applied), matching the prior `lstat`/`S_ISREG` behavior rather than treated as tampering. Promoting that to a hard failure would be a separate policy change.

## Validation

- Builds clean under `-Werror` (full tree).
- `cppcheck` clean for this change (only pre-existing `variableScope` style notes remain).
- ATF/Kyua suite: 18/18 pass.
- The install-time chown/chmod path is **not** exercised by the runtime tests in this environment (no populated registry); that path was verified by code trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden file attribute application during package installation to avoid TOCTOU attacks on symlinks by switching to descriptor-based operations.

Bug Fixes:
- Close a symlink TOCTOU vulnerability in the installer by opening extracted files with O_NOFOLLOW and using fstat/fchown/fchmod instead of path-based lstat/chown/stat/chmod.

Enhancements:
- Ensure installer file descriptors are correctly managed and closed, including on error paths, when applying ownership and permissions during package install.