### PR TITLE
Update CI workflow for MidnightBSD build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,19 @@ jobs:
     name: build (MidnightBSD 4.0.4)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    defaults:
+      run:
+        shell: cpa.sh {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Build on MidnightBSD
-        uses: cross-platform-actions/action@v1.1.0
+      - name: Setup VM
+        uses: cross-platform-actions/action@v1.2.0
         with:
           operating_system: midnightbsd
           version: '4.0.4'
-          shell: sh
-          run: |
+
+      - name: Build on MidnightBSD
+        run: |
             make
             kyua test -k tests/Kyuafile


### PR DESCRIPTION
- Bump `actions/checkout` and `cross-platform-actions/action` to `v6` and `v1.2.0` respectively.
- The run command is deprecated in `cross-platform-actions/action`. It's highly recommended to use the custom shell `cpa.sh {0}` instead. All subsequent steps after the VM setup will run within the VM through this shell.

## Summary by Sourcery

Update the MidnightBSD CI job to use the newer cross-platform VM workflow and standardized shell configuration.

Build:
- Bump actions/checkout to v6 and cross-platform-actions/action to v1.2.0 in the CI workflow.
- Configure the MidnightBSD CI job to use the cpa.sh shell by default and separate VM setup from the build step.