### PR TITLE
[codex] Format C sources with clang-format

### DIFF
--- a/libexec/mport.create/mport.create.c
+++ b/libexec/mport.create/mport.create.c
@@ -91,8 +91,8 @@ main(int argc, char *argv[])
 	    -1) {
 		switch (ch) {
 		case 'o':
-			checked_strlcpy(
-			    extra->pkg_filename, optarg, sizeof(extra->pkg_filename), "package filename");
+			checked_strlcpy(extra->pkg_filename, optarg, sizeof(extra->pkg_filename),
+			    "package filename");
 			break;
 		case 'n':
 			if (optarg != NULL) {
@@ -137,7 +137,8 @@ main(int argc, char *argv[])
 			}
 			break;
 		case 's':
-			checked_strlcpy(extra->sourcedir, optarg, sizeof(extra->sourcedir), "source dir");
+			checked_strlcpy(
+			    extra->sourcedir, optarg, sizeof(extra->sourcedir), "source dir");
 			break;
 		case 'd':
 			if (optarg != NULL) {

--- a/libexec/mport.init/mport.init.c
+++ b/libexec/mport.init/mport.init.c
@@ -44,9 +44,9 @@ main(int argc, char *argv[])
 
 	while ((ch = getopt(argc, argv, "c:")) != -1) {
 		switch (ch) {
-			case 'c':
-				chroot_path = optarg;
-				break;
+		case 'c':
+			chroot_path = optarg;
+			break;
 		}
 	}
 
@@ -63,14 +63,14 @@ main(int argc, char *argv[])
 	}
 
 	mport = mport_instance_new();
-  
+
 	if (mport_instance_init(mport, NULL, NULL, false, false) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		mport_instance_free(mport);
 		exit(EXIT_FAILURE);
 	}
-  
-	mport_instance_free(mport); 
-  
+
+	mport_instance_free(mport);
+
 	return 0;
 }

--- a/libexec/mport.list/mport.list.c
+++ b/libexec/mport.list/mport.list.c
@@ -108,7 +108,8 @@ main(int argc, char *argv[])
 	}
 
 	mport = mport_instance_new();
-	if (mport_instance_init(mport, NULL, NULL, noIndex, mport_verbosity(quiet, verbose, brief)) != MPORT_OK) {
+	if (mport_instance_init(
+		mport, NULL, NULL, noIndex, mport_verbosity(quiet, verbose, brief)) != MPORT_OK) {
 		warnx("%s", mport_err_string());
 		exit(EXIT_FAILURE);
 	}
@@ -129,18 +130,18 @@ usage(void)
 {
 	fprintf(stderr, "Usage: mport.list [OPTIONS]\n");
 	fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -b         Brief output format\n");
-    fprintf(stderr, "  -c <path>  Set chroot path\n");
-    fprintf(stderr, "  -l         List locked packages\n");
-    fprintf(stderr, "  -o         Show package origins\n");
-    fprintf(stderr, "  -p         List prime packages only\n");
-    fprintf(stderr, "  -q         Quiet mode\n");
-    fprintf(stderr, "  -v         Verbose mode\n");
-    fprintf(stderr, "  -u         Show available updates\n");
-    fprintf(stderr, "  -U         Do not use index for update information\n");
-    fprintf(stderr, "\nExamples:\n");
-    fprintf(stderr, "  mport.list -v            # List all packages verbosely\n");
-    fprintf(stderr, "  mport.list -q -u         # Quietly list available updates\n");
- 
+	fprintf(stderr, "  -b         Brief output format\n");
+	fprintf(stderr, "  -c <path>  Set chroot path\n");
+	fprintf(stderr, "  -l         List locked packages\n");
+	fprintf(stderr, "  -o         Show package origins\n");
+	fprintf(stderr, "  -p         List prime packages only\n");
+	fprintf(stderr, "  -q         Quiet mode\n");
+	fprintf(stderr, "  -v         Verbose mode\n");
+	fprintf(stderr, "  -u         Show available updates\n");
+	fprintf(stderr, "  -U         Do not use index for update information\n");
+	fprintf(stderr, "\nExamples:\n");
+	fprintf(stderr, "  mport.list -v            # List all packages verbosely\n");
+	fprintf(stderr, "  mport.list -q -u         # Quietly list available updates\n");
+
 	exit(2);
 }

--- a/libexec/mport.update/mport.update.c
+++ b/libexec/mport.update/mport.update.c
@@ -39,7 +39,9 @@
 
 static void usage(void);
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char *argv[])
+{
 	int i, ch;
 	mportInstance *mport;
 	const char *chroot_path = NULL;
@@ -48,13 +50,13 @@ int main(int argc, char *argv[]) {
 
 	while ((ch = getopt(argc, argv, "c:")) != -1) {
 		switch (ch) {
-			case 'c':
-				chroot_path = optarg;
-				break;
-			case '?':
-			default:
-				usage();
-				break;
+		case 'c':
+			chroot_path = optarg;
+			break;
+		case '?':
+		default:
+			usage();
+			break;
 		}
 	}
 
@@ -98,7 +100,8 @@ int main(int argc, char *argv[]) {
 }
 
 static void
-usage(void) {
+usage(void)
+{
 
 	fprintf(stderr, "Usage: mport.update [-c <chroot directory>] pkgfile1 pkgfile2 ...\n");
 	exit(2);

--- a/libexec/mport.version_cmp/mport.version_cmp.c
+++ b/libexec/mport.version_cmp/mport.version_cmp.c
@@ -31,19 +31,17 @@
 #include <mport.h>
 
 int
-main(int argc, char *argv[]) 
+main(int argc, char *argv[])
 {
-  int result;
-  
-  if (argc != 3) {
-    fprintf(stderr, "Usage: mport.version_cmp <version1> <version2>\n");
-    return 1;
-  }
-  
-  result = mport_version_cmp(argv[1], argv[2]);
-  
-  printf("%c\n", result == 0 ? '=' : result == -1 ? '<' : '>');
-  return 0;
+	int result;
+
+	if (argc != 3) {
+		fprintf(stderr, "Usage: mport.version_cmp <version1> <version2>\n");
+		return 1;
+	}
+
+	result = mport_version_cmp(argv[1], argv[2]);
+
+	printf("%c\n", result == 0 ? '=' : result == -1 ? '<' : '>');
+	return 0;
 }
-
-

--- a/libmport/age.c
+++ b/libmport/age.c
@@ -38,46 +38,47 @@
 #include "mport.h"
 #include "mport_private.h"
 
-bool 
-mport_is_age_verified(mportInstance *mport, mportPackageMeta *pack) 
+bool
+mport_is_age_verified(mportInstance *mport, mportPackageMeta *pack)
 {
 
-#if defined(__MidnightBSD__) && __MidnightBSD_version >= 400004    
-    char *age_str = NULL;
-    int age = 0;
+#if defined(__MidnightBSD__) && __MidnightBSD_version >= 400004
+	char *age_str = NULL;
+	int age = 0;
 
-    mport_annotation_get(mport, pack->origin, "age", &age_str);
+	mport_annotation_get(mport, pack->origin, "age", &age_str);
 
-    if (age_str == NULL) {
-        return true; /* No age annotation means it's appropriate for all ages */
-    }
+	if (age_str == NULL) {
+		return true; /* No age annotation means it's appropriate for all ages */
+	}
 
-    age = atoi(age_str);
-    free(age_str);
+	age = atoi(age_str);
+	free(age_str);
 
-    const char *username = getlogin();
-    if (username == NULL) {
-        mport_call_msg_cb(mport, "Could not determine username to verify age: %s", strerror(errno));
-        return false;
-    }
+	const char *username = getlogin();
+	if (username == NULL) {
+		mport_call_msg_cb(
+		    mport, "Could not determine username to verify age: %s", strerror(errno));
+		return false;
+	}
 
-    int *user_age_bracket = agev_get_age_bracket(username);
-    if (user_age_bracket == NULL) {
-        mport_call_msg_cb(mport, "Could not determine user age bracket.");
-        return false;
-    }
+	int *user_age_bracket = agev_get_age_bracket(username);
+	if (user_age_bracket == NULL) {
+		mport_call_msg_cb(mport, "Could not determine user age bracket.");
+		return false;
+	}
 
-    bool verified = false;
-    if (user_age_bracket[0] >= 18 && user_age_bracket[1] == -1) {
-        verified = true;
-    } else {
-        verified = age <= user_age_bracket[1];
-    }
+	bool verified = false;
+	if (user_age_bracket[0] >= 18 && user_age_bracket[1] == -1) {
+		verified = true;
+	} else {
+		verified = age <= user_age_bracket[1];
+	}
 
-    free(user_age_bracket);
+	free(user_age_bracket);
 
-    return verified;
+	return verified;
 #else
-    return true;
+	return true;
 #endif
 }

--- a/libmport/annotation.c
+++ b/libmport/annotation.c
@@ -26,7 +26,6 @@
  * SUCH DAMAGE.
  */
 
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -39,132 +38,131 @@
 MPORT_PUBLIC_API int
 mport_annotation_get(mportInstance *mport, const char *pkg, const char *tag, char **annotation)
 {
-    sqlite3_stmt *stmt = NULL;
+	sqlite3_stmt *stmt = NULL;
 
-    if (mport_db_prepare(mport->db, &stmt, "SELECT val FROM annotation WHERE pkg=%Q AND tag=%Q", pkg, tag) != MPORT_OK) {
-        sqlite3_finalize(stmt);
-        RETURN_CURRENT_ERROR;
-    }
+	if (mport_db_prepare(mport->db, &stmt, "SELECT val FROM annotation WHERE pkg=%Q AND tag=%Q",
+		pkg, tag) != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
 
-    if (stmt == NULL) {
-        RETURN_ERROR(MPORT_ERR_FATAL, "AnnotationStatement was null");
-    }
+	if (stmt == NULL) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "AnnotationStatement was null");
+	}
 
-    int ret = sqlite3_step(stmt);
+	int ret = sqlite3_step(stmt);
 
 	switch (ret) {
-	        case SQLITE_ROW:
-	            {
-	                const unsigned char *value = sqlite3_column_text(stmt, 0);
-	                *annotation = (value == NULL) ? NULL : strdup((const char *)value);
-	            }
-	            sqlite3_finalize(stmt);
-	            if (*annotation == NULL)
-	                RETURN_ERROR(MPORT_ERR_FATAL, "Malformed annotation row.");
-	            break;
-        case SQLITE_DONE:
-            sqlite3_finalize(stmt);
-            RETURN_ERRORX(MPORT_ERR_FATAL, "No annotation found for package %s with tag %s", pkg, tag);
-        default:
-            sqlite3_finalize(stmt);
-            RETURN_ERRORX(MPORT_ERR_FATAL, "Database error: %s", sqlite3_errmsg(mport->db));
-    }
+	case SQLITE_ROW: {
+		const unsigned char *value = sqlite3_column_text(stmt, 0);
+		*annotation = (value == NULL) ? NULL : strdup((const char *)value);
+	}
+		sqlite3_finalize(stmt);
+		if (*annotation == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Malformed annotation row.");
+		break;
+	case SQLITE_DONE:
+		sqlite3_finalize(stmt);
+		RETURN_ERRORX(
+		    MPORT_ERR_FATAL, "No annotation found for package %s with tag %s", pkg, tag);
+	default:
+		sqlite3_finalize(stmt);
+		RETURN_ERRORX(MPORT_ERR_FATAL, "Database error: %s", sqlite3_errmsg(mport->db));
+	}
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 MPORT_PUBLIC_API int
 mport_annotation_set(mportInstance *mport, const char *pkg, const char *tag, const char *annotation)
 {
 
-    return mport_db_do(mport->db,
-                         "INSERT OR REPLACE INTO annotation (pkg, tag, val) VALUES (%Q, %Q, %Q)",
-                         pkg, tag, annotation);
+	return mport_db_do(mport->db,
+	    "INSERT OR REPLACE INTO annotation (pkg, tag, val) VALUES (%Q, %Q, %Q)", pkg, tag,
+	    annotation);
 }
 
 MPORT_PUBLIC_API int
 mport_annotation_delete(mportInstance *mport, const char *pkg, const char *tag)
 {
-    return mport_db_do(mport->db,
-                         "DELETE FROM annotation WHERE pkg=%Q AND tag=%Q",
-                         pkg, tag);
+	return mport_db_do(mport->db, "DELETE FROM annotation WHERE pkg=%Q AND tag=%Q", pkg, tag);
 }
 
 MPORT_PUBLIC_API int
 mport_annotation_delete_all(mportInstance *mport, const char *pkg)
 {
-    return mport_db_do(mport->db,
-                         "DELETE FROM annotation WHERE pkg=%Q",
-                         pkg);
+	return mport_db_do(mport->db, "DELETE FROM annotation WHERE pkg=%Q", pkg);
 }
 
 MPORT_PUBLIC_API int
 mport_annotation_list(mportInstance *mport, const char *pkg, char ***tags, int *tag_count)
 {
-    sqlite3_stmt *stmt = NULL;
-    int count = 0;
-    int i = 0;
+	sqlite3_stmt *stmt = NULL;
+	int count = 0;
+	int i = 0;
 
-    if (mport_db_prepare(mport->db, &stmt, "SELECT tag FROM annotation WHERE pkg=%Q", pkg) != MPORT_OK) {
-        sqlite3_finalize(stmt);
-        RETURN_CURRENT_ERROR;
-    }
+	if (mport_db_prepare(mport->db, &stmt, "SELECT tag FROM annotation WHERE pkg=%Q", pkg) !=
+	    MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
 
-    if (stmt == NULL) {
-        RETURN_ERROR(MPORT_ERR_FATAL, "AnnotationStatement was null");
-    }
+	if (stmt == NULL) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "AnnotationStatement was null");
+	}
 
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-        count++;
-    }
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		count++;
+	}
 
-    sqlite3_finalize(stmt);
+	sqlite3_finalize(stmt);
 
-    if (count == 0) {
-        *tags = NULL;
-        *tag_count = 0;
-        return MPORT_OK;
-    }
+	if (count == 0) {
+		*tags = NULL;
+		*tag_count = 0;
+		return MPORT_OK;
+	}
 
-    *tags = malloc(count * sizeof(char*));
-    if (*tags == NULL) {
-        RETURN_ERROR(MPORT_ERR_FATAL, "Failed to allocate memory for tags");
-    }
+	*tags = malloc(count * sizeof(char *));
+	if (*tags == NULL) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "Failed to allocate memory for tags");
+	}
 
-    if (mport_db_prepare(mport->db, &stmt, "SELECT tag FROM annotation WHERE pkg=%Q", pkg) != MPORT_OK) {
-        sqlite3_finalize(stmt);
-        free(*tags);
-        RETURN_CURRENT_ERROR;
-    }
+	if (mport_db_prepare(mport->db, &stmt, "SELECT tag FROM annotation WHERE pkg=%Q", pkg) !=
+	    MPORT_OK) {
+		sqlite3_finalize(stmt);
+		free(*tags);
+		RETURN_CURRENT_ERROR;
+	}
 
-	    while (sqlite3_step(stmt) == SQLITE_ROW && i < count) {
-	        const unsigned char *tag = sqlite3_column_text(stmt, 0);
-	        if (tag == NULL) {
-	            while (i > 0) {
-	                i--;
-	                free((*tags)[i]);
-	            }
-	            free(*tags);
-	            *tags = NULL;
-	            sqlite3_finalize(stmt);
-	            RETURN_ERROR(MPORT_ERR_FATAL, "Malformed annotation row.");
-	        }
-	        (*tags)[i] = strdup((const char *)tag);
-	        if ((*tags)[i] == NULL) {
-	            while (i > 0) {
-	                i--;
-	                free((*tags)[i]);
-	            }
-	            free(*tags);
-	            *tags = NULL;
-	            sqlite3_finalize(stmt);
-	            RETURN_ERROR(MPORT_ERR_FATAL, "Failed to allocate memory for tag.");
-	        }
-	        i++;
-	    }
+	while (sqlite3_step(stmt) == SQLITE_ROW && i < count) {
+		const unsigned char *tag = sqlite3_column_text(stmt, 0);
+		if (tag == NULL) {
+			while (i > 0) {
+				i--;
+				free((*tags)[i]);
+			}
+			free(*tags);
+			*tags = NULL;
+			sqlite3_finalize(stmt);
+			RETURN_ERROR(MPORT_ERR_FATAL, "Malformed annotation row.");
+		}
+		(*tags)[i] = strdup((const char *)tag);
+		if ((*tags)[i] == NULL) {
+			while (i > 0) {
+				i--;
+				free((*tags)[i]);
+			}
+			free(*tags);
+			*tags = NULL;
+			sqlite3_finalize(stmt);
+			RETURN_ERROR(MPORT_ERR_FATAL, "Failed to allocate memory for tag.");
+		}
+		i++;
+	}
 
-    sqlite3_finalize(stmt);     
-    *tag_count = count;
+	sqlite3_finalize(stmt);
+	*tag_count = count;
 
-    return MPORT_OK;
+	return MPORT_OK;
 }

--- a/libmport/asset.c
+++ b/libmport/asset.c
@@ -26,7 +26,6 @@
  * SUCH DAMAGE.
  */
 
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -37,13 +36,15 @@
 #include "mport_private.h"
 
 MPORT_PUBLIC_API int
-mport_asset_get_package_from_file_path(mportInstance *mport, const char *filePath, mportPackageMeta **pack)
+mport_asset_get_package_from_file_path(
+    mportInstance *mport, const char *filePath, mportPackageMeta **pack)
 {
 	sqlite3_stmt *stmt = NULL;
 	int result = MPORT_OK;
 	char *err;
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT pkg FROM assets WHERE data=%Q", filePath) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt, "SELECT pkg FROM assets WHERE data=%Q", filePath) !=
+	    MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -64,7 +65,7 @@ mport_asset_get_package_from_file_path(mportInstance *mport, const char *filePat
 			break;
 
 		if (ret != SQLITE_ROW) {
-			err = (char *) sqlite3_errmsg(mport->db);
+			err = (char *)sqlite3_errmsg(mport->db);
 			result = MPORT_ERR_FATAL;
 			break; // we finalize below
 		}
@@ -72,7 +73,9 @@ mport_asset_get_package_from_file_path(mportInstance *mport, const char *filePat
 		const unsigned char *pkgName = sqlite3_column_text(stmt, 0);
 		if (pkgName != NULL) {
 			mportPackageMeta **packs = NULL;
-			if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", pkgName) != MPORT_OK || packs[0] == NULL) {
+			if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", pkgName) !=
+				MPORT_OK ||
+			    packs[0] == NULL) {
 				err = "Package does not exist despite having assets";
 				result = MPORT_ERR_FATAL;
 				break; // we finalize below
@@ -104,10 +107,12 @@ mport_asset_get_assetlist(mportInstance *mport, mportPackageMeta *pack, mportAss
 
 	*alist_p = alist;
 
-	// pkg text NOT NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text)
+	// pkg text NOT NULL, type int NOT NULL, data text, checksum text, owner text, grp text,
+	// mode text)
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT type,data,checksum,owner,grp,mode FROM assets WHERE pkg=%Q",
-	                     pack->name) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT type,data,checksum,owner,grp,mode FROM assets WHERE pkg=%Q",
+		pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -115,7 +120,6 @@ mport_asset_get_assetlist(mportInstance *mport, mportPackageMeta *pack, mportAss
 	if (stmt == NULL) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "Statement was null");
 	}
-
 
 	while (1) {
 		mportAssetListEntry *e = NULL;
@@ -131,12 +135,12 @@ mport_asset_get_assetlist(mportInstance *mport, mportPackageMeta *pack, mportAss
 			break;
 
 		if (ret != SQLITE_ROW) {
-			err = (char *) sqlite3_errmsg(mport->db);
+			err = (char *)sqlite3_errmsg(mport->db);
 			result = MPORT_ERR_FATAL;
 			break; // we finalize below
 		}
 
-		e = (mportAssetListEntry *) calloc(1, sizeof(mportAssetListEntry));
+		e = (mportAssetListEntry *)calloc(1, sizeof(mportAssetListEntry));
 
 		if (e == NULL) {
 			err = "Out of memory";
@@ -144,14 +148,14 @@ mport_asset_get_assetlist(mportInstance *mport, mportPackageMeta *pack, mportAss
 			break; // we finalize below
 		}
 
-		e->type = (mportAssetListEntryType) sqlite3_column_int(stmt, 0);
+		e->type = (mportAssetListEntryType)sqlite3_column_int(stmt, 0);
 		const unsigned char *data = sqlite3_column_text(stmt, 1);
 		const unsigned char *checksum = sqlite3_column_text(stmt, 2);
 		const unsigned char *owner = sqlite3_column_text(stmt, 3);
 		const unsigned char *group = sqlite3_column_text(stmt, 4);
 		const unsigned char *mode = sqlite3_column_text(stmt, 5);
 
-		e->data = (data == NULL) ? NULL : strdup((char *) data);
+		e->data = (data == NULL) ? NULL : strdup((char *)data);
 		if (checksum != NULL)
 			strlcpy(e->checksum, checksum, 65);
 		if (owner != NULL)

--- a/libmport/audit.c
+++ b/libmport/audit.c
@@ -113,14 +113,15 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 			size_t size;
 			FILE *bufferFp = open_memstream(&pkgAudit, &size);
 			if (bufferFp == NULL) {
-				SET_ERROR(MPORT_ERR_FATAL, "Error allocating memory for audit entries");
+				SET_ERROR(
+				    MPORT_ERR_FATAL, "Error allocating memory for audit entries");
 				free(jsonData);
 				jsonData = NULL;
 
 				unlink(path);
 				free(path);
 				path = NULL;
-				
+
 				mport_pkgmeta_vec_free(packs);
 				packs = NULL;
 
@@ -130,7 +131,8 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 			bool first = true;
 			while ((cur = ucl_object_iterate(root, &it, true))) {
 				if (ucl_object_type(cur) != UCL_OBJECT) {
-					SET_ERROR(MPORT_ERR_FATAL, "Expected an object in the array");
+					SET_ERROR(
+					    MPORT_ERR_FATAL, "Expected an object in the array");
 					continue;
 				}
 
@@ -140,16 +142,23 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 					ucl_object_iter_t pit = NULL;
 					const ucl_object_t *product;
 
-					for (product = ucl_object_iterate(products, &pit, true); product != NULL; product = ucl_object_iterate(products, &pit, true)) {
-						const ucl_object_t *version = ucl_object_find_key(product, "version");
-						if (version != NULL && ucl_object_type(version) == UCL_STRING) {
-							const char *version_str = ucl_object_tostring(version);
+					for (product = ucl_object_iterate(products, &pit, true);
+					    product != NULL;
+					    product = ucl_object_iterate(products, &pit, true)) {
+						const ucl_object_t *version =
+						    ucl_object_find_key(product, "version");
+						if (version != NULL &&
+						    ucl_object_type(version) == UCL_STRING) {
+							const char *version_str =
+							    ucl_object_tostring(version);
 
 							if (version_str == NULL)
-							    continue;
+								continue;
 
 							// Skip based on the version field
-							if ('*' == version_str[0] || mport_version_cmp((*packs)->version, version_str) <= 0) {
+							if ('*' == version_str[0] ||
+							    mport_version_cmp((*packs)->version,
+								version_str) <= 0) {
 								isVulnerable = true;
 								break;
 							}
@@ -162,7 +171,8 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 				}
 
 				if (mport->verbosity == MPORT_VQUIET) {
-					fprintf(bufferFp, "%s-%s\n", (*packs)->name, (*packs)->version);
+					fprintf(
+					    bufferFp, "%s-%s\n", (*packs)->name, (*packs)->version);
 					break;
 				}
 
@@ -176,23 +186,30 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 				if (cveId != NULL && ucl_object_type(cveId) == UCL_STRING) {
 					fprintf(bufferFp, "%s\n", ucl_object_tostring(cveId));
 
-					const ucl_object_t *desc = ucl_object_find_key(cur, "description");
+					const ucl_object_t *desc =
+					    ucl_object_find_key(cur, "description");
 					if (desc != NULL && ucl_object_type(desc) == UCL_STRING) {
-						fprintf(bufferFp, "Description: %s\n", ucl_object_tostring(desc));
+						fprintf(bufferFp, "Description: %s\n",
+						    ucl_object_tostring(desc));
 					}
-					const ucl_object_t *severity = ucl_object_find_key(cur, "severity");
-					if (severity != NULL && ucl_object_type(severity) == UCL_STRING) {
-						fprintf(bufferFp, "Severity: %s\n", ucl_object_tostring(severity));
+					const ucl_object_t *severity =
+					    ucl_object_find_key(cur, "severity");
+					if (severity != NULL &&
+					    ucl_object_type(severity) == UCL_STRING) {
+						fprintf(bufferFp, "Severity: %s\n",
+						    ucl_object_tostring(severity));
 					}
 					fprintf(bufferFp, "\n");
 				}
 			}
 
 			if (dependOn) {
-				if (mport_pkgmeta_get_downdepends(mport, (*packs), &depends_orig) == MPORT_OK) {
+				if (mport_pkgmeta_get_downdepends(mport, (*packs), &depends_orig) ==
+				    MPORT_OK) {
 					if (depends_orig != NULL) {
 						depends = depends_orig;
-						fprintf(bufferFp, "Packages that depend on %s:", (*packs)->name);
+						fprintf(bufferFp,
+						    "Packages that depend on %s:", (*packs)->name);
 						while (*depends != NULL) {
 							fprintf(bufferFp, " %s", (*depends)->name);
 							depends++;
@@ -221,70 +238,70 @@ mport_audit(mportInstance *mport, const char *packageName, bool dependOn)
 			mport_pkgmeta_vec_free(packs);
 			packs = NULL;
 		}
-
 	}
 	return pkgAudit;
 }
 
-static char *readJsonFile(char *jsonFile)
+static char *
+readJsonFile(char *jsonFile)
 {
-		FILE *fp;
-		long file_size;
-		size_t size;
-		char *buffer;
+	FILE *fp;
+	long file_size;
+	size_t size;
+	char *buffer;
 
-		if (jsonFile == NULL) {
-			return (NULL);
-		}
-		
-		// Open the JSON file
-		fp = fopen(jsonFile, "rb");
-		if (!fp) {
-			SET_ERROR(MPORT_ERR_WARN, "could not open file");
-			return NULL;
-		}
-
-		// Get the file size
-		if (fseek(fp, 0, SEEK_END) != 0) {
-			SET_ERROR(MPORT_ERR_WARN, "could not determine file size");
-			fclose(fp);
-			return NULL;
-		}
-
-		file_size = ftell(fp);
-		if (file_size < 0) {
-			SET_ERROR(MPORT_ERR_WARN, "could not determine file size");
-			fclose(fp);
-			return NULL;
-		}
-
-		if (fseek(fp, 0, SEEK_SET) != 0) {
-			SET_ERROR(MPORT_ERR_WARN, "could not rewind file");
-			fclose(fp);
-			return NULL;
-		}
-
-		size = (size_t)file_size;
-
-		// Allocate memory for the file contents
-		buffer = (char *)malloc(size + 1);
-		if (!buffer) {
-			SET_ERROR(MPORT_ERR_WARN, "could not allocate memory");
-			fclose(fp);
-			return NULL;
-		}
-
-		// Read the file into the buffer
-		if (fread(buffer, 1, size, fp) != size) {
-			SET_ERROR(MPORT_ERR_WARN, "could not read file");
-			fclose(fp);
-			free(buffer);
-			return NULL;
-		}
-		buffer[size] = '\0';
-
-		// Close the file
-		fclose(fp);
-
-		return buffer;
+	if (jsonFile == NULL) {
+		return (NULL);
 	}
+
+	// Open the JSON file
+	fp = fopen(jsonFile, "rb");
+	if (!fp) {
+		SET_ERROR(MPORT_ERR_WARN, "could not open file");
+		return NULL;
+	}
+
+	// Get the file size
+	if (fseek(fp, 0, SEEK_END) != 0) {
+		SET_ERROR(MPORT_ERR_WARN, "could not determine file size");
+		fclose(fp);
+		return NULL;
+	}
+
+	file_size = ftell(fp);
+	if (file_size < 0) {
+		SET_ERROR(MPORT_ERR_WARN, "could not determine file size");
+		fclose(fp);
+		return NULL;
+	}
+
+	if (fseek(fp, 0, SEEK_SET) != 0) {
+		SET_ERROR(MPORT_ERR_WARN, "could not rewind file");
+		fclose(fp);
+		return NULL;
+	}
+
+	size = (size_t)file_size;
+
+	// Allocate memory for the file contents
+	buffer = (char *)malloc(size + 1);
+	if (!buffer) {
+		SET_ERROR(MPORT_ERR_WARN, "could not allocate memory");
+		fclose(fp);
+		return NULL;
+	}
+
+	// Read the file into the buffer
+	if (fread(buffer, 1, size, fp) != size) {
+		SET_ERROR(MPORT_ERR_WARN, "could not read file");
+		fclose(fp);
+		free(buffer);
+		return NULL;
+	}
+	buffer[size] = '\0';
+
+	// Close the file
+	fclose(fp);
+
+	return buffer;
+}

--- a/libmport/autoremove.c
+++ b/libmport/autoremove.c
@@ -32,74 +32,76 @@
 #include "mport_private.h"
 
 MPORT_PUBLIC_API int
-mport_autoremove(mportInstance *mport) 
+mport_autoremove(mportInstance *mport)
 {
-    mportPackageMeta **packs = NULL;
-    mportPackageMeta **packs_start = NULL;
-    mportPackageMeta **depends = NULL;
-    mportPackageMeta **depends_start = NULL;
+	mportPackageMeta **packs = NULL;
+	mportPackageMeta **packs_start = NULL;
+	mportPackageMeta **depends = NULL;
+	mportPackageMeta **depends_start = NULL;
 
-    if (mport_pkgmeta_list(mport, &packs) != MPORT_OK) {
-        RETURN_CURRENT_ERROR;
-    }
+	if (mport_pkgmeta_list(mport, &packs) != MPORT_OK) {
+		RETURN_CURRENT_ERROR;
+	}
 
-    if (packs == NULL)
-        return MPORT_OK;
+	if (packs == NULL)
+		return MPORT_OK;
 
-    packs_start = packs;
-    while (*packs != NULL) {
-        if ((*packs)->automatic == MPORT_EXPLICIT) {
-            packs++;
-            continue;
-        }
+	packs_start = packs;
+	while (*packs != NULL) {
+		if ((*packs)->automatic == MPORT_EXPLICIT) {
+			packs++;
+			continue;
+		}
 
-        if (mport_pkgmeta_get_updepends(mport, *packs, &depends) != MPORT_OK) {
-            mport_call_msg_cb(mport, "Unable to evaluate package %s: %s", (*packs)->name, mport_err_string());
-            packs++;
-            continue;
-        }
+		if (mport_pkgmeta_get_updepends(mport, *packs, &depends) != MPORT_OK) {
+			mport_call_msg_cb(mport, "Unable to evaluate package %s: %s",
+			    (*packs)->name, mport_err_string());
+			packs++;
+			continue;
+		}
 
-        if (depends == NULL) {
-            packs++;
-            continue;
-        }
+		if (depends == NULL) {
+			packs++;
+			continue;
+		}
 
-        depends_start = depends;
-        bool found = false;
-        while (*depends != NULL) {
-            if ((*depends)->automatic == MPORT_EXPLICIT) {
-                found = true;
-                break;
-            }
-            depends++;
-        }
+		depends_start = depends;
+		bool found = false;
+		while (*depends != NULL) {
+			if ((*depends)->automatic == MPORT_EXPLICIT) {
+				found = true;
+				break;
+			}
+			depends++;
+		}
 
-        if (found) {
-            packs++;
-            continue;
-        }
+		if (found) {
+			packs++;
+			continue;
+		}
 
-        depends = depends_start;
-        while ((*depends) != NULL) {
-            mport_call_msg_cb(mport, "Auto-removing %s", (*depends)->name);
-            (*depends)->action = MPORT_ACTION_DELETE;
-            if (mport_delete_primative(mport, *depends, true) != MPORT_OK) {
-                mport_call_msg_cb(mport, "Unable to autoremove %s: %s", (*depends)->name, mport_err_string());
-                continue;
-            }
+		depends = depends_start;
+		while ((*depends) != NULL) {
+			mport_call_msg_cb(mport, "Auto-removing %s", (*depends)->name);
+			(*depends)->action = MPORT_ACTION_DELETE;
+			if (mport_delete_primative(mport, *depends, true) != MPORT_OK) {
+				mport_call_msg_cb(mport, "Unable to autoremove %s: %s",
+				    (*depends)->name, mport_err_string());
+				continue;
+			}
 
-            depends++;
-        }
-        mport_pkgmeta_vec_free(depends_start);
-        depends_start = NULL;
-        depends = NULL;
+			depends++;
+		}
+		mport_pkgmeta_vec_free(depends_start);
+		depends_start = NULL;
+		depends = NULL;
 
-        packs++;
-    }
-    
-    mport_pkgmeta_vec_free(packs_start);
-    packs_start = NULL;
-    packs = NULL;
+		packs++;
+	}
 
-    return MPORT_OK;
+	mport_pkgmeta_vec_free(packs_start);
+	packs_start = NULL;
+	packs = NULL;
+
+	return MPORT_OK;
 }

--- a/libmport/bundle_read.c
+++ b/libmport/bundle_read.c
@@ -101,9 +101,10 @@ mport_bundle_read_finish(mportInstance *mport, mportBundleRead *bundle)
 			mport_call_msg_cb(mport, "Unable to close pacakge.");
 			ret = SET_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
 		}
-		
+
 		if (ret != MPORT_ERR_FATAL && archive_read_free(bundle->archive) != ARCHIVE_OK) {
-			mport_call_msg_cb(mport, "Unable to free memory used by package archive file.");
+			mport_call_msg_cb(
+			    mport, "Unable to free memory used by package archive file.");
 			ret = SET_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
 		}
 	}
@@ -179,12 +180,10 @@ mport_bundle_read_extract_metafiles(mportBundleRead *bundle, char **dirnamep)
 		file = archive_entry_pathname(entry);
 
 		if (*file == '+') {
-			(void)snprintf(
-			    filepath, FILENAME_MAX, "%s/%s", tmpdir, file);
+			(void)snprintf(filepath, FILENAME_MAX, "%s/%s", tmpdir, file);
 			archive_entry_set_pathname(entry, filepath);
 
-			if (mport_bundle_read_extract_next_file(
-				bundle, entry) != MPORT_OK)
+			if (mport_bundle_read_extract_next_file(bundle, entry) != MPORT_OK)
 				RETURN_CURRENT_ERROR;
 		} else {
 			/* entry points to the first real file in the bundle, so
@@ -276,11 +275,10 @@ int
 mport_bundle_read_extract_next_file(mportBundleRead *bundle, struct archive_entry *entry)
 {
 	if (archive_read_extract(bundle->archive, entry,
-		ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_PERM |
-		    ARCHIVE_EXTRACT_TIME | ARCHIVE_EXTRACT_ACL |
-		    ARCHIVE_EXTRACT_FFLAGS) != ARCHIVE_OK) {
-		RETURN_ERRORX(MPORT_ERR_FATAL,
-			    "%s: %s", archive_error_string(bundle->archive), entry != NULL ? archive_entry_pathname(entry) : "unknown file");
+		ARCHIVE_EXTRACT_OWNER | ARCHIVE_EXTRACT_PERM | ARCHIVE_EXTRACT_TIME |
+		    ARCHIVE_EXTRACT_ACL | ARCHIVE_EXTRACT_FFLAGS) != ARCHIVE_OK) {
+		RETURN_ERRORX(MPORT_ERR_FATAL, "%s: %s", archive_error_string(bundle->archive),
+		    entry != NULL ? archive_entry_pathname(entry) : "unknown file");
 	}
 
 	return (MPORT_OK);
@@ -293,8 +291,7 @@ mport_bundle_read_extract_next_file(mportBundleRead *bundle, struct archive_entr
  * db for the instance master database.
  */
 int
-mport_bundle_read_prep_for_install(
-    mportInstance *mport, mportBundleRead *bundle)
+mport_bundle_read_prep_for_install(mportInstance *mport, mportBundleRead *bundle)
 {
 	sqlite3_stmt *stmt;
 	int bundle_version;
@@ -311,8 +308,7 @@ mport_bundle_read_prep_for_install(
 	bundle->stub_attached = 1;
 
 	if (mport_db_prepare(mport->db, &stmt,
-		"SELECT value FROM stub.meta WHERE field='bundle_format_version'") !=
-	    MPORT_OK) {
+		"SELECT value FROM stub.meta WHERE field='bundle_format_version'") != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -331,8 +327,8 @@ mport_bundle_read_prep_for_install(
 		break;
 	case SQLITE_DONE:
 		sqlite3_finalize(stmt);
-		RETURN_ERRORX(MPORT_ERR_FATAL, "%s: no stub.meta table, or no bundle_format_version field",
-		    bundle->filename);
+		RETURN_ERRORX(MPORT_ERR_FATAL,
+		    "%s: no stub.meta table, or no bundle_format_version field", bundle->filename);
 	default:
 		sqlite3_finalize(stmt);
 		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));

--- a/libmport/bundle_read_install_pkg.c
+++ b/libmport/bundle_read_install_pkg.c
@@ -57,9 +57,7 @@
 #include <md5.h>
 #include <sha256.h>
 
-enum phase {
-	PREINSTALL, ACTUALINSTALL, POSTINSTALL
-};
+enum phase { PREINSTALL, ACTUALINSTALL, POSTINSTALL };
 
 static int do_pre_install(mportInstance *, mportBundleRead *, mportPackageMeta *);
 
@@ -94,7 +92,8 @@ static char **parse_sample(char *input);
 
 static int mark_complete(mportInstance *, mportPackageMeta *);
 
-static int mport_bundle_read_get_assetlist(mportInstance *mport, mportPackageMeta *pkg, mportAssetList **alist_p, enum phase);
+static int mport_bundle_read_get_assetlist(
+    mportInstance *mport, mportPackageMeta *pkg, mportAssetList **alist_p, enum phase);
 
 static int copy_metafile(mportInstance *, mportBundleRead *, mportPackageMeta *, char *);
 
@@ -123,9 +122,8 @@ mport_bundle_read_install_pkg(mportInstance *mport, mportBundleRead *bundle, mpo
 	return MPORT_OK;
 }
 
-
 /* This does everything that has to happen before we start installing files.
- * We run mtree, pkg-install PRE-INSTALL, etc... 
+ * We run mtree, pkg-install PRE-INSTALL, etc...
  */
 static int
 do_pre_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
@@ -137,7 +135,8 @@ do_pre_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *
 	char *age_annotation = NULL;
 
 	/* Check for age restrictions */
-	if (mport_annotation_get(mport, pkg->name, "age", &age_annotation) == MPORT_OK && age_annotation != NULL) {
+	if (mport_annotation_get(mport, pkg->name, "age", &age_annotation) == MPORT_OK &&
+	    age_annotation != NULL) {
 		const char *user = getlogin();
 		if (user != NULL) {
 			int *ages = agev_get_age_bracket(user);
@@ -149,12 +148,12 @@ do_pre_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *
 				errno = 0;
 				parsed_age = strtol(age_annotation, &endptr, 10);
 
-				/* Validate that the annotation is a clean, non-negative integer within int range */
-				if (errno != 0 ||
-				    endptr == age_annotation || /* no digits parsed */
-				    *endptr != '\0' ||          /* trailing garbage */
-				    parsed_age < 0 ||           /* negative ages not allowed */
-				    parsed_age > INT_MAX) {     /* out of int range */
+				/* Validate that the annotation is a clean, non-negative integer
+				 * within int range */
+				if (errno != 0 || endptr == age_annotation || /* no digits parsed */
+				    *endptr != '\0' || /* trailing garbage */
+				    parsed_age < 0 || /* negative ages not allowed */
+				    parsed_age > INT_MAX) { /* out of int range */
 					free(ages);
 					free(age_annotation);
 					RETURN_ERRORX(MPORT_ERR_FATAL,
@@ -198,36 +197,35 @@ do_pre_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *
 	if (mport_bundle_read_get_assetlist(mport, pkg, &alist, PREINSTALL) != MPORT_OK)
 		goto ERROR;
 
-	(void) strlcpy(cwd, pkg->prefix, sizeof(cwd));
+	(void)strlcpy(cwd, pkg->prefix, sizeof(cwd));
 
-	if (mport_chdir(mport, cwd) != MPORT_OK)  {
+	if (mport_chdir(mport, cwd) != MPORT_OK) {
 		if (strcmp("/compat/linux", cwd) == 0) {
 			mport_mkdir("/compat");
 			mport_mkdir("/compat/linux");
 		} else {
 			mport_mkdir(cwd);
 		}
-		if (mport_chdir(mport, cwd) != MPORT_OK)  {
+		if (mport_chdir(mport, cwd) != MPORT_OK) {
 			goto ERROR;
 		}
 	}
 
-	STAILQ_FOREACH(e, alist, next)
-	{
+	STAILQ_FOREACH (e, alist, next) {
 		switch (e->type) {
-			case ASSET_CWD:
-				(void) strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
-				if (mport_chdir(mport, cwd) != MPORT_OK)
-					goto ERROR;
+		case ASSET_CWD:
+			(void)strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
+			if (mport_chdir(mport, cwd) != MPORT_OK)
+				goto ERROR;
 
-				break;
-			case ASSET_PREEXEC:
-				if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
-					goto ERROR;
-				break;
-			default:
-				/* do nothing */
-				break;
+			break;
+		case ASSET_PREEXEC:
+			if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
+				goto ERROR;
+			break;
+		default:
+			/* do nothing */
+			break;
 		}
 	}
 
@@ -236,7 +234,7 @@ do_pre_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *
 
 	return MPORT_OK;
 
-	ERROR:
+ERROR:
 	// TODO: asset list free
 	RETURN_CURRENT_ERROR;
 }
@@ -253,23 +251,22 @@ get_file_count(mportInstance *mport, char *pkg_name, int *file_total)
 		RETURN_ERROR(MPORT_ERR_FATAL, "pkg_name is null");
 
 	if (mport_db_prepare(mport->db, &count,
-	                     "SELECT COUNT(*) FROM stub.assets WHERE (type=%i or type=%i or type=%i or type=%i or type=%i or type=%i) AND pkg=%Q",
-	                     ASSET_FILE, ASSET_SAMPLE, ASSET_SHELL, ASSET_FILE_OWNER_MODE, ASSET_SAMPLE_OWNER_MODE, ASSET_INFO, 
-	                     pkg_name) != MPORT_OK) {
+		"SELECT COUNT(*) FROM stub.assets WHERE (type=%i or type=%i or type=%i or type=%i or type=%i or type=%i) AND pkg=%Q",
+		ASSET_FILE, ASSET_SAMPLE, ASSET_SHELL, ASSET_FILE_OWNER_MODE,
+		ASSET_SAMPLE_OWNER_MODE, ASSET_INFO, pkg_name) != MPORT_OK) {
 		sqlite3_finalize(count);
 		RETURN_CURRENT_ERROR;
 	}
 
-
 	switch (sqlite3_step(count)) {
-		case SQLITE_ROW:
-			*file_total = sqlite3_column_int(count, 0);
-			sqlite3_finalize(count);
-			break;
-		default:
-			err = (char *) sqlite3_errmsg(mport->db);
-			result = MPORT_ERR_FATAL;
-			sqlite3_finalize(count);
+	case SQLITE_ROW:
+		*file_total = sqlite3_column_int(count, 0);
+		sqlite3_finalize(count);
+		break;
+	default:
+		err = (char *)sqlite3_errmsg(mport->db);
+		result = MPORT_ERR_FATAL;
+		sqlite3_finalize(count);
 	}
 
 	if (result == MPORT_ERR_FATAL)
@@ -285,13 +282,15 @@ create_package_row(mportInstance *mport, mportPackageMeta *pkg)
 	if (mport->db == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "mport database is not initialized");
 
-	/* Insert the package meta row into the packages table (We use pack here because things might have been twiddled) */
+	/* Insert the package meta row into the packages table (We use pack here because things
+	 * might have been twiddled) */
 	/* Note that this will be marked as dirty by default */
 	if (mport_db_do(mport->db,
-	                "INSERT INTO packages (pkg, version, origin, prefix, lang, options, comment, os_release, cpe, locked, deprecated, expiration_date, no_provide_shlib, flavor, automatic, install_date, flatsize) VALUES (%Q,%Q,%Q,%Q,%Q,%Q,%Q,%Q,%Q,0,%Q,%ld,%d,%Q,%d,%ld,%ld)",
-	                pkg->name, pkg->version, pkg->origin, pkg->prefix, pkg->lang, pkg->options, pkg->comment,
-	                pkg->os_release, pkg->cpe, pkg->deprecated, pkg->expiration_date, pkg->no_provide_shlib,
-	                pkg->flavor, pkg->automatic, pkg->install_date, pkg->flatsize) != MPORT_OK)
+		"INSERT INTO packages (pkg, version, origin, prefix, lang, options, comment, os_release, cpe, locked, deprecated, expiration_date, no_provide_shlib, flavor, automatic, install_date, flatsize) VALUES (%Q,%Q,%Q,%Q,%Q,%Q,%Q,%Q,%Q,0,%Q,%ld,%d,%Q,%d,%ld,%ld)",
+		pkg->name, pkg->version, pkg->origin, pkg->prefix, pkg->lang, pkg->options,
+		pkg->comment, pkg->os_release, pkg->cpe, pkg->deprecated, pkg->expiration_date,
+		pkg->no_provide_shlib, pkg->flavor, pkg->automatic, pkg->install_date,
+		pkg->flatsize) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
@@ -307,8 +306,8 @@ create_depends(mportInstance *mport, mportPackageMeta *pkg)
 
 	/* Insert the dependencies into the master table */
 	if (mport_db_do(mport->db,
-	                "INSERT INTO depends (pkg, depend_pkgname, depend_pkgversion, depend_port) SELECT pkg,depend_pkgname,depend_pkgversion,depend_port FROM stub.depends WHERE pkg=%Q",
-	                pkg->name) != MPORT_OK)
+		"INSERT INTO depends (pkg, depend_pkgname, depend_pkgversion, depend_port) SELECT pkg,depend_pkgname,depend_pkgversion,depend_port FROM stub.depends WHERE pkg=%Q",
+		pkg->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
@@ -324,8 +323,8 @@ create_categories(mportInstance *mport, mportPackageMeta *pkg)
 
 	/* Insert the categories into the master table */
 	if (mport_db_do(mport->db,
-	                "INSERT INTO categories (pkg, category) SELECT pkg, category FROM stub.categories WHERE pkg=%Q",
-	                pkg->name) != MPORT_OK)
+		"INSERT INTO categories (pkg, category) SELECT pkg, category FROM stub.categories WHERE pkg=%Q",
+		pkg->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
@@ -341,8 +340,8 @@ create_conflicts(mportInstance *mport, mportPackageMeta *pkg)
 
 	/* Insert the conflicts into the master table */
 	if (mport_db_do(mport->db,
-	                "INSERT INTO conflicts (pkg, conflict_pkg, conflict_version) SELECT pkg, conflict_pkg, conflict_version FROM stub.conflicts WHERE pkg=%Q",
-	                pkg->name) != MPORT_OK)
+		"INSERT INTO conflicts (pkg, conflict_pkg, conflict_version) SELECT pkg, conflict_pkg, conflict_version FROM stub.conflicts WHERE pkg=%Q",
+		pkg->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
@@ -358,15 +357,16 @@ create_annotations(mportInstance *mport, mportPackageMeta *pkg)
 
 	/* Insert the annotations into the master table */
 	if (mport_db_do(mport->db,
-	                "INSERT INTO annotation (pkg, tag, val) SELECT %Q as pkg, field as tag, value as val FROM stub.meta",
-	                pkg->name) != MPORT_OK)
+		"INSERT INTO annotation (pkg, tag, val) SELECT %Q as pkg, field as tag, value as val FROM stub.meta",
+		pkg->name) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	return MPORT_OK;
 }
 
 static int
-create_dir_asset_fd(mportInstance *mport, const char *cwd, const char *path, mode_t mode, int *dirfd)
+create_dir_asset_fd(
+    mportInstance *mport, const char *cwd, const char *path, mode_t mode, int *dirfd)
 {
 	char *work = NULL;
 	int fd = -1;
@@ -402,7 +402,7 @@ create_dir_asset_fd(mportInstance *mport, const char *cwd, const char *path, mod
 	 */
 	oumask = umask(0);
 	(void)umask(oumask);
-	for (p = work; ;) {
+	for (p = work;;) {
 		mode_t mkdir_mode;
 		int final_component;
 		char save;
@@ -459,10 +459,12 @@ unsafe_path:
 	result = SET_ERRORX(MPORT_ERR_FATAL, "Refusing unsafe directory path %s", path);
 	goto err;
 mkdir_error:
-	result = SET_ERRORX(MPORT_ERR_FATAL, "Unable to create directory %s: %s", path, strerror(errno));
+	result =
+	    SET_ERRORX(MPORT_ERR_FATAL, "Unable to create directory %s: %s", path, strerror(errno));
 	goto err;
 open_error:
-	result = SET_ERRORX(MPORT_ERR_FATAL, "Unable to open directory %s: %s", path, strerror(errno));
+	result =
+	    SET_ERRORX(MPORT_ERR_FATAL, "Unable to open directory %s: %s", path, strerror(errno));
 	goto err;
 err:
 	if (nextfd != -1)
@@ -484,7 +486,8 @@ apply_dir_asset_attrs(int dirfd, mportAssetListEntry *e, uid_t default_uid, gid_
 	gid_t dir_gid = default_gid;
 
 	if (fstat(dirfd, &sb) == -1)
-		RETURN_ERRORX(MPORT_ERR_FATAL, "Unable to stat directory %s: %s", e->data, strerror(errno));
+		RETURN_ERRORX(
+		    MPORT_ERR_FATAL, "Unable to stat directory %s: %s", e->data, strerror(errno));
 	if (!S_ISDIR(sb.st_mode))
 		RETURN_ERRORX(MPORT_ERR_FATAL, "%s is not a directory", e->data);
 
@@ -496,7 +499,9 @@ apply_dir_asset_attrs(int dirfd, mportAssetListEntry *e, uid_t default_uid, gid_
 		free(dirset);
 		dirset = NULL;
 		if (fchmod(dirfd, dirnewmode) == -1)
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Unable to set permissions on directory %s: %s", e->data, strerror(errno));
+			RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "Unable to set permissions on directory %s: %s", e->data,
+			    strerror(errno));
 	}
 
 	if (e->owner != NULL && e->owner[0] != '\0')
@@ -544,17 +549,18 @@ create_sample_file(mportInstance *mport, char *cwd, const char *file)
 	char *dir;
 
 	if (file[0] != '/')
-		(void) snprintf(nonSample, FILENAME_MAX, "%s%s/%s", mport->root, cwd, file);
+		(void)snprintf(nonSample, FILENAME_MAX, "%s%s/%s", mport->root, cwd, file);
 	else
-		(void) snprintf(nonSample, FILENAME_MAX * 2, "%s%s", mport->root, file);
+		(void)snprintf(nonSample, FILENAME_MAX * 2, "%s%s", mport->root, file);
 
 	char **fileargv = parse_sample(nonSample);
 
 	if (fileargv[1] != NULL) {
 		if (fileargv[1][0] == '/')
-			(void) snprintf(secondFile, FILENAME_MAX, "%s%s", mport->root, fileargv[1]);
+			(void)snprintf(secondFile, FILENAME_MAX, "%s%s", mport->root, fileargv[1]);
 		else
-			(void) snprintf(secondFile, FILENAME_MAX, "%s%s/%s", mport->root, cwd, fileargv[1]);
+			(void)snprintf(
+			    secondFile, FILENAME_MAX, "%s%s/%s", mport->root, cwd, fileargv[1]);
 
 		if (!mport_file_exists(secondFile)) {
 			dir = mport_directory(secondFile);
@@ -591,11 +597,12 @@ create_sample_file(mportInstance *mport, char *cwd, const char *file)
 }
 
 /**
- * Get the list of assets (plist entries) from the stub attached database (package we are installing)
- * filtered on entries that are not pre/post exec groups.
+ * Get the list of assets (plist entries) from the stub attached database (package we are
+ * installing) filtered on entries that are not pre/post exec groups.
  */
 static int
-mport_bundle_read_get_assetlist(mportInstance *mport, mportPackageMeta *pkg, mportAssetList **alist_p, enum phase state)
+mport_bundle_read_get_assetlist(
+    mportInstance *mport, mportPackageMeta *pkg, mportAssetList **alist_p, enum phase state)
 {
 	mportAssetList *alist;
 	sqlite3_stmt *stmt = NULL;
@@ -609,23 +616,24 @@ mport_bundle_read_get_assetlist(mportInstance *mport, mportPackageMeta *pkg, mpo
 
 	if (state == PREINSTALL) {
 		if (mport_db_prepare(mport->db, &stmt,
-		                     "SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type in (%d, %d)",
-		                     pkg->name, ASSET_CWD, ASSET_PREEXEC) != MPORT_OK) {
+			"SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type in (%d, %d)",
+			pkg->name, ASSET_CWD, ASSET_PREEXEC) != MPORT_OK) {
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;
 		}
 	} else if (state == ACTUALINSTALL) {
 		if (mport_db_prepare(mport->db, &stmt,
-		                     "SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type not in (%d, %d, %d, %d)",
-		                     pkg->name, ASSET_PREEXEC, ASSET_POSTEXEC, ASSET_LDCONFIG, ASSET_LDCONFIG_LINUX) !=
-		    MPORT_OK) {
+			"SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type not in (%d, %d, %d, %d)",
+			pkg->name, ASSET_PREEXEC, ASSET_POSTEXEC, ASSET_LDCONFIG,
+			ASSET_LDCONFIG_LINUX) != MPORT_OK) {
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;
 		}
 	} else if (state == POSTINSTALL) {
 		if (mport_db_prepare(mport->db, &stmt,
-		                     "SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type in (%d, %d, %d, %d, %d, %d, %d)",
-		                     pkg->name, ASSET_CWD, ASSET_POSTEXEC, ASSET_LDCONFIG, ASSET_LDCONFIG_LINUX, ASSET_GLIB_SCHEMAS, ASSET_INFO, ASSET_TOUCH) != MPORT_OK) {
+			"SELECT type,data,checksum,owner,grp,mode FROM stub.assets WHERE pkg=%Q and type in (%d, %d, %d, %d, %d, %d, %d)",
+			pkg->name, ASSET_CWD, ASSET_POSTEXEC, ASSET_LDCONFIG, ASSET_LDCONFIG_LINUX,
+			ASSET_GLIB_SCHEMAS, ASSET_INFO, ASSET_TOUCH) != MPORT_OK) {
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;
 		}
@@ -635,54 +643,54 @@ mport_bundle_read_get_assetlist(mportInstance *mport, mportPackageMeta *pkg, mpo
 		RETURN_ERROR(MPORT_ERR_FATAL, "Statement was null");
 	}
 
-		while (1) {
-			mportAssetListEntry *e;
+	while (1) {
+		mportAssetListEntry *e;
 
-			int ret = sqlite3_step(stmt);
+		int ret = sqlite3_step(stmt);
 
-			if (ret == SQLITE_BUSY || ret == SQLITE_LOCKED) {
-				sleep(5);
-				ret = sqlite3_step(stmt);
-			}
-
-			if (ret == SQLITE_DONE)
-				break;
-
-			if (ret != SQLITE_ROW) {
-				err = (char *) sqlite3_errmsg(mport->db);
-				result = MPORT_ERR_FATAL;
-				break; // we finalize below
-			}
-
-			e = (mportAssetListEntry *) calloc(1, sizeof(mportAssetListEntry));
-
-			if (e == NULL) {
-				err = "Out of memory";
-				result = MPORT_ERR_FATAL;
-				break; // we finalize below
-			}
-
-			e->type = (mportAssetListEntryType) sqlite3_column_int(stmt, 0);
-			const unsigned char *data = sqlite3_column_text(stmt, 1);
-			const unsigned char *checksum = sqlite3_column_text(stmt, 2);
-			const unsigned char *owner = sqlite3_column_text(stmt, 3);
-			const unsigned char *group = sqlite3_column_text(stmt, 4);
-			const unsigned char *mode = sqlite3_column_text(stmt, 5);
-
-			e->data = (data == NULL) ? NULL : strdup((char *) data);
-			if (checksum != NULL)
-				strlcpy(e->checksum, checksum, 65);
-			if (owner != NULL)
-				strlcpy(e->owner, owner, MAXLOGNAME);
-			if (group != NULL)
-				strlcpy(e->group, group, MAXLOGNAME * 2);
-			if (mode != NULL)
-				strlcpy(e->mode, mode, 5);
-
-			STAILQ_INSERT_TAIL(alist, e, next);
+		if (ret == SQLITE_BUSY || ret == SQLITE_LOCKED) {
+			sleep(5);
+			ret = sqlite3_step(stmt);
 		}
 
-		sqlite3_finalize(stmt);
+		if (ret == SQLITE_DONE)
+			break;
+
+		if (ret != SQLITE_ROW) {
+			err = (char *)sqlite3_errmsg(mport->db);
+			result = MPORT_ERR_FATAL;
+			break; // we finalize below
+		}
+
+		e = (mportAssetListEntry *)calloc(1, sizeof(mportAssetListEntry));
+
+		if (e == NULL) {
+			err = "Out of memory";
+			result = MPORT_ERR_FATAL;
+			break; // we finalize below
+		}
+
+		e->type = (mportAssetListEntryType)sqlite3_column_int(stmt, 0);
+		const unsigned char *data = sqlite3_column_text(stmt, 1);
+		const unsigned char *checksum = sqlite3_column_text(stmt, 2);
+		const unsigned char *owner = sqlite3_column_text(stmt, 3);
+		const unsigned char *group = sqlite3_column_text(stmt, 4);
+		const unsigned char *mode = sqlite3_column_text(stmt, 5);
+
+		e->data = (data == NULL) ? NULL : strdup((char *)data);
+		if (checksum != NULL)
+			strlcpy(e->checksum, checksum, 65);
+		if (owner != NULL)
+			strlcpy(e->owner, owner, MAXLOGNAME);
+		if (group != NULL)
+			strlcpy(e->group, group, MAXLOGNAME * 2);
+		if (mode != NULL)
+			strlcpy(e->mode, mode, 5);
+
+		STAILQ_INSERT_TAIL(alist, e, next);
+	}
+
+	sqlite3_finalize(stmt);
 
 	if (result == MPORT_ERR_FATAL)
 		SET_ERRORX(result, "Error reading assets %s", err);
@@ -734,300 +742,373 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	if (create_annotations(mport, pkg) != MPORT_OK)
 		goto ERROR;
 
-	/* Insert the assets into the master table. We do this one by one because we want to insert file assets as absolute paths. */
+	/* Insert the assets into the master table. We do this one by one because we want to insert
+	 * file assets as absolute paths. */
 	if (mport_db_prepare(mport->db, &insert,
-	                     "INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) values (%Q,?,?,?,?,?,?)",
-	                     pkg->name) != MPORT_OK)
+		"INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) values (%Q,?,?,?,?,?,?)",
+		pkg->name) != MPORT_OK)
 		goto ERROR;
 
-	(void) strlcpy(cwd, pkg->prefix, sizeof(cwd));
+	(void)strlcpy(cwd, pkg->prefix, sizeof(cwd));
 
 	if (mport_chdir(mport, cwd) != MPORT_OK)
 		goto ERROR;
 
 	mport_db_do(mport->db, "BEGIN TRANSACTION");
 
-	STAILQ_FOREACH(e, alist, next)
-	{
+	STAILQ_FOREACH (e, alist, next) {
 		switch (e->type) {
-			case ASSET_CWD:
-				(void) strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
-				if (mport_chdir(mport, cwd) != MPORT_OK)
-					goto ERROR;
-				break;
-			case ASSET_CHMOD:
-				if (mode != NULL)
-					free(mode);
-				/* TODO: should we reset the mode rather than NULL here */
-				if (e->data == NULL)
-					mode = NULL;
-				else
-					mode = strdup(e->data);
-				break;
-			case ASSET_CHOWN:
-				owner = mport_get_uid(e->data);
-				break;
-			case ASSET_CHGRP:
-				group = mport_get_gid(e->data);
-				break;
-			case ASSET_DIR:
-			case ASSET_DIRRM:
-			case ASSET_DIRRMTRY:
-			case ASSET_DIR_OWNER_MODE:
-				{
-					int dirfd = -1;
-					if (create_dir_asset_fd(mport, cwd, e->data, S_IRWXU | S_IRWXG | S_IRWXO, &dirfd) != MPORT_OK)
-						goto ERROR;
-					if (apply_dir_asset_attrs(dirfd, e, owner, group) != MPORT_OK) {
-						close(dirfd);
+		case ASSET_CWD:
+			(void)strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
+			if (mport_chdir(mport, cwd) != MPORT_OK)
+				goto ERROR;
+			break;
+		case ASSET_CHMOD:
+			if (mode != NULL)
+				free(mode);
+			/* TODO: should we reset the mode rather than NULL here */
+			if (e->data == NULL)
+				mode = NULL;
+			else
+				mode = strdup(e->data);
+			break;
+		case ASSET_CHOWN:
+			owner = mport_get_uid(e->data);
+			break;
+		case ASSET_CHGRP:
+			group = mport_get_gid(e->data);
+			break;
+		case ASSET_DIR:
+		case ASSET_DIRRM:
+		case ASSET_DIRRMTRY:
+		case ASSET_DIR_OWNER_MODE: {
+			int dirfd = -1;
+			if (create_dir_asset_fd(mport, cwd, e->data, S_IRWXU | S_IRWXG | S_IRWXO,
+				&dirfd) != MPORT_OK)
+				goto ERROR;
+			if (apply_dir_asset_attrs(dirfd, e, owner, group) != MPORT_OK) {
+				close(dirfd);
+				goto ERROR;
+			}
+			close(dirfd);
+		} break;
+		case ASSET_EXEC:
+			if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
+				goto ERROR;
+			break;
+		case ASSET_FILE_OWNER_MODE:
+			/* FALLS THROUGH */
+		case ASSET_FILE:
+			/* FALLS THROUGH */
+		case ASSET_SHELL:
+			/* FALLS THROUGH */
+		case ASSET_SAMPLE:
+			/* FALLS THROUGH */
+		case ASSET_INFO:
+			/* FALLS THROUGH */
+		case ASSET_SAMPLE_OWNER_MODE:
+			if (mport_bundle_read_next_entry(bundle, &entry) != MPORT_OK)
+				goto ERROR;
+
+			if (e->data[0] == '/') {
+				(void)snprintf(file, FILENAME_MAX, "%s", e->data);
+			} else {
+				(void)snprintf(
+				    file, FILENAME_MAX, "%s%s/%s", mport->root, cwd, e->data);
+			}
+
+			if (e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE)
+				for (int ch = 0; ch < FILENAME_MAX; ch++) {
+					if (file[ch] == '\0')
+						break;
+					if (file[ch] == ' ' || file[ch] == '\t') {
+						file[ch] = '\0';
+						break;
+					}
+				}
+
+			if (entry == NULL) {
+				SET_ERROR(MPORT_ERR_FATAL, "Unexpected EOF with archive file");
+				goto ERROR;
+			}
+
+			archive_entry_set_pathname(entry, file);
+
+			if (mport_bundle_read_extract_next_file(bundle, entry) != MPORT_OK)
+				goto ERROR;
+
+			if (e->checksum != NULL && e->checksum[0] != '\0') {
+				char hash[65];
+				if (strlen(e->checksum) < 34) {
+					if (MD5File(file, hash) == NULL) {
+						SET_ERRORX(MPORT_ERR_FATAL, "Could not MD5 %s: %s",
+						    file, strerror(errno));
 						goto ERROR;
 					}
-					close(dirfd);
-				}
-				break;
-			case ASSET_EXEC:
-				if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
-					goto ERROR;
-				break;
-			case ASSET_FILE_OWNER_MODE:
-				/* FALLS THROUGH */
-			case ASSET_FILE:
-				/* FALLS THROUGH */
-			case ASSET_SHELL:
-				/* FALLS THROUGH */
-			case ASSET_SAMPLE:
-				/* FALLS THROUGH */
-			case ASSET_INFO:
-				/* FALLS THROUGH */
-			case ASSET_SAMPLE_OWNER_MODE:
-				if (mport_bundle_read_next_entry(bundle, &entry) != MPORT_OK)
-					goto ERROR;
-
-				if (e->data[0] == '/') {
-					(void) snprintf(file, FILENAME_MAX, "%s", e->data);
 				} else {
-					(void) snprintf(file, FILENAME_MAX, "%s%s/%s", mport->root, cwd, e->data);
-				}
-
-				if (e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE)
-					for (int ch = 0; ch < FILENAME_MAX; ch++) {
-						if (file[ch] == '\0')
-							break;
-						if (file[ch] == ' ' || file[ch] == '\t') {
-							file[ch] = '\0';
-							break;
-						}
-					}
-
-				if (entry == NULL) {
-					SET_ERROR(MPORT_ERR_FATAL, "Unexpected EOF with archive file");
-					goto ERROR;
-				}
-
-				archive_entry_set_pathname(entry, file);
-
-				if (mport_bundle_read_extract_next_file(bundle, entry) != MPORT_OK)
-					goto ERROR;
-
-				if (e->checksum != NULL && e->checksum[0] != '\0') {
-					char hash[65];
-					if (strlen(e->checksum) < 34) {
-						if (MD5File(file, hash) == NULL) {
-							SET_ERRORX(MPORT_ERR_FATAL, "Could not MD5 %s: %s", file, strerror(errno));
-							goto ERROR;
-						}
-					} else {
-						if (SHA256_File(file, hash) == NULL) {
-							SET_ERRORX(MPORT_ERR_FATAL, "Could not SHA256 %s: %s", file, strerror(errno));
-							goto ERROR;
-						}
-					}
-					if (strcmp(hash, e->checksum) != 0) {
-						SET_ERRORX(MPORT_ERR_FATAL, "Checksum mismatch for %s: expected %s but got %s", file, e->checksum, hash);
+					if (SHA256_File(file, hash) == NULL) {
+						SET_ERRORX(MPORT_ERR_FATAL,
+						    "Could not SHA256 %s: %s", file,
+						    strerror(errno));
 						goto ERROR;
 					}
 				}
-
-				/*
-				 * Open the freshly extracted file with O_NOFOLLOW before
-				 * touching its ownership or mode. Operating on the file
-				 * descriptor (fchown/fchmod) instead of re-resolving the
-				 * path closes a symlink TOCTOU: an attacker who replaces the
-				 * file with a symlink after extraction cannot redirect the
-				 * privileged chown/chmod at another file. O_NONBLOCK avoids
-				 * blocking if the path was swapped for a FIFO. This mirrors
-				 * the fd-based directory handling in apply_dir_asset_attrs().
-				 * A symlink final component (EMLINK/ELOOP) or any other
-				 * non-regular file is left unmodified, as before, but is
-				 * still recorded in the database below.
-				 */
-				filefd = open(file, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
-				if (filefd == -1 && errno != EMLINK && errno != ELOOP) {
-					SET_ERRORX(MPORT_ERR_FATAL, "Unable to open file %s: %s", file,
-					    strerror(errno));
+				if (strcmp(hash, e->checksum) != 0) {
+					SET_ERRORX(MPORT_ERR_FATAL,
+					    "Checksum mismatch for %s: expected %s but got %s",
+					    file, e->checksum, hash);
 					goto ERROR;
 				}
-				if (filefd != -1 && fstat(filefd, &sb) != 0) {
-					SET_ERRORX(MPORT_ERR_FATAL, "Unable to stat file %s", file);
-					goto ERROR;
-				}
+			}
 
-				if (filefd != -1 && S_ISREG(sb.st_mode)) {
-					if (e->type == ASSET_FILE_OWNER_MODE || e->type == ASSET_SAMPLE_OWNER_MODE) {
-						/* Test for owner and group settings, otherwise roll with our default. */
-						if (e->owner != NULL && e->group != NULL && e->owner[0] != '\0' &&
-						    e->group[0] != '\0') {
+			/*
+			 * Open the freshly extracted file with O_NOFOLLOW before
+			 * touching its ownership or mode. Operating on the file
+			 * descriptor (fchown/fchmod) instead of re-resolving the
+			 * path closes a symlink TOCTOU: an attacker who replaces the
+			 * file with a symlink after extraction cannot redirect the
+			 * privileged chown/chmod at another file. O_NONBLOCK avoids
+			 * blocking if the path was swapped for a FIFO. This mirrors
+			 * the fd-based directory handling in apply_dir_asset_attrs().
+			 * A symlink final component (EMLINK/ELOOP) or any other
+			 * non-regular file is left unmodified, as before, but is
+			 * still recorded in the database below.
+			 */
+			filefd = open(file, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+			if (filefd == -1 && errno != EMLINK && errno != ELOOP) {
+				SET_ERRORX(MPORT_ERR_FATAL, "Unable to open file %s: %s", file,
+				    strerror(errno));
+				goto ERROR;
+			}
+			if (filefd != -1 && fstat(filefd, &sb) != 0) {
+				SET_ERRORX(MPORT_ERR_FATAL, "Unable to stat file %s", file);
+				goto ERROR;
+			}
+
+			if (filefd != -1 && S_ISREG(sb.st_mode)) {
+				if (e->type == ASSET_FILE_OWNER_MODE ||
+				    e->type == ASSET_SAMPLE_OWNER_MODE) {
+					/* Test for owner and group settings, otherwise roll with
+					 * our default. */
+					if (e->owner != NULL && e->group != NULL &&
+					    e->owner[0] != '\0' && e->group[0] != '\0') {
 #ifdef DEBUG
-							mport_call_msg_cb(mport, "owner %s and group %s\n", e->owner, e->group);
+						mport_call_msg_cb(mport, "owner %s and group %s\n",
+						    e->owner, e->group);
 #endif
-							if (fchown(filefd, mport_get_uid(e->owner),
-							          mport_get_gid(e->group)) == -1) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
-								goto ERROR;
-							}
-						} else if (e->owner != NULL && e->owner[0] != '\0') {
+						if (fchown(filefd, mport_get_uid(e->owner),
+							mport_get_gid(e->group)) == -1) {
+							SET_ERROR(MPORT_ERR_FATAL,
+							    "Unable to change owner");
+							goto ERROR;
+						}
+					} else if (e->owner != NULL && e->owner[0] != '\0') {
 #ifdef DEBUG
-							mport_call_msg_cb(mport, "owner %s\n", e->owner);
+						mport_call_msg_cb(mport, "owner %s\n", e->owner);
 #endif
-							if (fchown(filefd, mport_get_uid(e->owner), group) == -1) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
-								goto ERROR;
-							}
-						} else if (e->group != NULL && e->group[0] != '\0') {
+						if (fchown(filefd, mport_get_uid(e->owner),
+							group) == -1) {
+							SET_ERROR(MPORT_ERR_FATAL,
+							    "Unable to change owner");
+							goto ERROR;
+						}
+					} else if (e->group != NULL && e->group[0] != '\0') {
 #ifdef DEBUG
-							mport_call_msg_cb(mport, "group %s\n", e->group);
+						mport_call_msg_cb(mport, "group %s\n", e->group);
 #endif
-							if (fchown(filefd, owner, mport_get_gid(e->group)) == -1) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
-								goto ERROR;
-							}
-						} else {
-							// use default.
-							if (fchown(filefd, owner, group) == -1) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to change owner");
-								goto ERROR;
-							}
+						if (fchown(filefd, owner,
+							mport_get_gid(e->group)) == -1) {
+							SET_ERROR(MPORT_ERR_FATAL,
+							    "Unable to change owner");
+							goto ERROR;
 						}
 					} else {
-						/* Set the owner and group */
+						// use default.
 						if (fchown(filefd, owner, group) == -1) {
-							SET_ERRORX(MPORT_ERR_FATAL,
-							           "Unable to set permissions on file %s", file);
+							SET_ERROR(MPORT_ERR_FATAL,
+							    "Unable to change owner");
 							goto ERROR;
 						}
 					}
-
-					/* Set the file permissions, assumes non NFSv4 */
-					if (mode != NULL || (e->mode != NULL && e->mode[0] != '\0' &&
-					                     (e->type == ASSET_SAMPLE_OWNER_MODE || e->type == ASSET_FILE_OWNER_MODE))) {
-						if (fstat(filefd, &sb)) {
-							SET_ERRORX(MPORT_ERR_FATAL, "Unable to stat file %s", file);
-							goto ERROR;
-						}
-						if ((e->type == ASSET_SAMPLE_OWNER_MODE || e->type == ASSET_FILE_OWNER_MODE)
-						    && e->mode != NULL && e->mode[0] != '\0') {
-#ifdef DEBUG
-							mport_call_msg_cb(mport, "sample or file owner mode %s\n", e->mode);
-#endif
-							if ((set = setmode(e->mode)) == NULL) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to set mode");
-								goto ERROR;
-							}
-						} else {
-#ifdef DEBUG
-							mport_call_msg_cb(mport, "mode %s\n", e->mode);
-#endif
-							if ((set = setmode(mode)) == NULL) {
-								SET_ERROR(MPORT_ERR_FATAL, "Unable to set mode");
-								goto ERROR;
-							}
-						}
-						newmode = getmode(set, sb.st_mode);
-						free(set);
-
-						if (fchmod(filefd, newmode)) {
-							SET_ERROR(MPORT_ERR_FATAL, "Unable to set file permissions");
-							goto ERROR;
-						}
-					}
-
-					/* shell registration */
-					if (e->type == ASSET_SHELL && mport_shell_register(file) != MPORT_OK) {
+				} else {
+					/* Set the owner and group */
+					if (fchown(filefd, owner, group) == -1) {
+						SET_ERRORX(MPORT_ERR_FATAL,
+						    "Unable to set permissions on file %s", file);
 						goto ERROR;
 					}
+				}
 
-					/* age restriction */
-					char *age_annotation = NULL;
-					if (mport_annotation_get(mport, pkg->name, "age", &age_annotation) == MPORT_OK && age_annotation != NULL) {
-						if (strncmp(file, "/usr/local/bin/", 15) == 0 || strncmp(file, "/usr/local/sbin/", 16) == 0) {
-							char *endptr = NULL;
-							long parsed_age;
-							int required_age;
+				/* Set the file permissions, assumes non NFSv4 */
+				if (mode != NULL ||
+				    (e->mode != NULL && e->mode[0] != '\0' &&
+					(e->type == ASSET_SAMPLE_OWNER_MODE ||
+					    e->type == ASSET_FILE_OWNER_MODE))) {
+					if (fstat(filefd, &sb)) {
+						SET_ERRORX(MPORT_ERR_FATAL,
+						    "Unable to stat file %s", file);
+						goto ERROR;
+					}
+					if ((e->type == ASSET_SAMPLE_OWNER_MODE ||
+						e->type == ASSET_FILE_OWNER_MODE) &&
+					    e->mode != NULL && e->mode[0] != '\0') {
+#ifdef DEBUG
+						mport_call_msg_cb(mport,
+						    "sample or file owner mode %s\n", e->mode);
+#endif
+						if ((set = setmode(e->mode)) == NULL) {
+							SET_ERROR(
+							    MPORT_ERR_FATAL, "Unable to set mode");
+							goto ERROR;
+						}
+					} else {
+#ifdef DEBUG
+						mport_call_msg_cb(mport, "mode %s\n", e->mode);
+#endif
+						if ((set = setmode(mode)) == NULL) {
+							SET_ERROR(
+							    MPORT_ERR_FATAL, "Unable to set mode");
+							goto ERROR;
+						}
+					}
+					newmode = getmode(set, sb.st_mode);
+					free(set);
 
-							errno = 0;
-							parsed_age = strtol(age_annotation, &endptr, 10);
+					if (fchmod(filefd, newmode)) {
+						SET_ERROR(MPORT_ERR_FATAL,
+						    "Unable to set file permissions");
+						goto ERROR;
+					}
+				}
 
-							if (errno != 0 || endptr == age_annotation || *endptr != '\0' || parsed_age < 0 || parsed_age > INT_MAX) {
-								mport_call_msg_cb(mport, "Invalid age annotation '%s' for package %s, skipping ACLs.", age_annotation, pkg->name);
-							} else {
-								required_age = (int)parsed_age;
-								const char *age_groups[] = {"age4p", "age13p", "age16p", "age18p"};
-								const int ages[] = {4, 13, 16, 18};
+				/* shell registration */
+				if (e->type == ASSET_SHELL &&
+				    mport_shell_register(file) != MPORT_OK) {
+					goto ERROR;
+				}
 
-								for (size_t i = 0; i < sizeof(ages) / sizeof(ages[0]); i++) {
-									if (ages[i] < required_age) {
-										pid_t pid;
-										int ret;
-										char acl_spec[32];
+				/* age restriction */
+				char *age_annotation = NULL;
+				if (mport_annotation_get(
+					mport, pkg->name, "age", &age_annotation) == MPORT_OK &&
+				    age_annotation != NULL) {
+					if (strncmp(file, "/usr/local/bin/", 15) == 0 ||
+					    strncmp(file, "/usr/local/sbin/", 16) == 0) {
+						char *endptr = NULL;
+						long parsed_age;
+						int required_age;
 
-										/* ZFS ACL */
-										snprintf(acl_spec, sizeof(acl_spec), "g:%s:r-x:deny", age_groups[i]);
-										char *const zfs_args[] = {"/usr/bin/setfacl", "-m", acl_spec, (char *)file, NULL};
-										if ((ret = posix_spawn(&pid, "/usr/bin/setfacl", NULL, NULL, zfs_args, NULL)) == 0) {
-											waitpid(pid, &ret, 0);
-										}
+						errno = 0;
+						parsed_age = strtol(age_annotation, &endptr, 10);
 
-										if (ret != 0) {
-											/* UFS ACL */
-											snprintf(acl_spec, sizeof(acl_spec), "group:%s:---", age_groups[i]);
-											char *const ufs_args[] = {"/usr/bin/setfacl", "-m", acl_spec, (char *)file, NULL};
-											if ((ret = posix_spawn(&pid, "/usr/bin/setfacl", NULL, NULL, ufs_args, NULL)) == 0) {
-												waitpid(pid, &ret, 0);
-												if (ret != 0) {
-													mport_call_msg_cb(mport, "Could not set ACLs for age restriction on %s for group %s", file, age_groups[i]);
-												}
-											} else {
-												mport_call_msg_cb(mport, "Could not set ACLs for age restriction on %s for group %s", file, age_groups[i]);
+						if (errno != 0 || endptr == age_annotation ||
+						    *endptr != '\0' || parsed_age < 0 ||
+						    parsed_age > INT_MAX) {
+							mport_call_msg_cb(mport,
+							    "Invalid age annotation '%s' for package %s, skipping ACLs.",
+							    age_annotation, pkg->name);
+						} else {
+							required_age = (int)parsed_age;
+							const char *age_groups[] = { "age4p",
+								"age13p", "age16p", "age18p" };
+							const int ages[] = { 4, 13, 16, 18 };
+
+							for (size_t i = 0;
+							    i < sizeof(ages) / sizeof(ages[0]);
+							    i++) {
+								if (ages[i] < required_age) {
+									pid_t pid;
+									int ret;
+									char acl_spec[32];
+
+									/* ZFS ACL */
+									snprintf(acl_spec,
+									    sizeof(acl_spec),
+									    "g:%s:r-x:deny",
+									    age_groups[i]);
+									char *const zfs_args[] = {
+										"/usr/bin/setfacl",
+										"-m", acl_spec,
+										(char *)file, NULL
+									};
+									if ((ret = posix_spawn(&pid,
+										 "/usr/bin/setfacl",
+										 NULL, NULL,
+										 zfs_args, NULL)) ==
+									    0) {
+										waitpid(
+										    pid, &ret, 0);
+									}
+
+									if (ret != 0) {
+										/* UFS ACL */
+										snprintf(acl_spec,
+										    sizeof(
+											acl_spec),
+										    "group:%s:---",
+										    age_groups[i]);
+										char *const ufs_args
+										    [] = { "/usr/bin/setfacl",
+											    "-m",
+											    acl_spec,
+											    (char *)
+												file,
+											    NULL };
+										if ((ret = posix_spawn(
+											 &pid,
+											 "/usr/bin/setfacl",
+											 NULL, NULL,
+											 ufs_args,
+											 NULL)) ==
+										    0) {
+											waitpid(pid,
+											    &ret,
+											    0);
+											if (ret !=
+											    0) {
+												mport_call_msg_cb(
+												    mport,
+												    "Could not set ACLs for age restriction on %s for group %s",
+												    file,
+												    age_groups
+													[i]);
 											}
+										} else {
+											mport_call_msg_cb(
+											    mport,
+											    "Could not set ACLs for age restriction on %s for group %s",
+											    file,
+											    age_groups
+												[i]);
 										}
 									}
 								}
 							}
 						}
-						free(age_annotation);
 					}
+					free(age_annotation);
 				}
+			}
 
-				if (filefd != -1) {
-					close(filefd);
-					filefd = -1;
-				}
+			if (filefd != -1) {
+				close(filefd);
+				filefd = -1;
+			}
 
-				/* for sample files, if we don't have an existing file, make a new one */
-				if ((e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE) &&
-				    create_sample_file(mport, cwd, e->data) != MPORT_OK) {
-					SET_ERRORX(MPORT_ERR_FATAL, "Unable to create sample file from %s",
-					           file);
-					goto ERROR;
-				}
+			/* for sample files, if we don't have an existing file, make a new one */
+			if ((e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE) &&
+			    create_sample_file(mport, cwd, e->data) != MPORT_OK) {
+				SET_ERRORX(
+				    MPORT_ERR_FATAL, "Unable to create sample file from %s", file);
+				goto ERROR;
+			}
 
+			(mport->progress_step_cb)(++file_count, file_total, file);
 
-				(mport->progress_step_cb)(++file_count, file_total, file);
-
-				break;
-			default:
-				/* do nothing */
-				break;
+			break;
+		default:
+			/* do nothing */
+			break;
 		}
 
 		/* insert this asset into the master database */
@@ -1035,26 +1116,29 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 		char *cwdPtr = strdup(cwd);
 
 		char dir[FILENAME_MAX];
-		if (sqlite3_bind_int(insert, 1, (int) e->type) != SQLITE_OK) {
+		if (sqlite3_bind_int(insert, 1, (int)e->type) != SQLITE_OK) {
 			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 			goto ERROR;
 		}
 		if (e->type == ASSET_FILE || e->type == ASSET_SAMPLE || e->type == ASSET_SHELL ||
-		    e->type == ASSET_FILE_OWNER_MODE || e->type == ASSET_SAMPLE_OWNER_MODE || e->type == ASSET_INFO) {
+		    e->type == ASSET_FILE_OWNER_MODE || e->type == ASSET_SAMPLE_OWNER_MODE ||
+		    e->type == ASSET_INFO) {
 			/* don't put the root in the database! */
-			if (sqlite3_bind_text(insert, 2, filePtr + strlen(mport->root), -1, SQLITE_STATIC) !=
+			if (sqlite3_bind_text(insert, 2, filePtr + strlen(mport->root), -1,
+				SQLITE_STATIC) != SQLITE_OK) {
+				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+				goto ERROR;
+			}
+
+			if (sqlite3_bind_text(insert, 3, e->checksum, -1, SQLITE_STATIC) !=
 			    SQLITE_OK) {
 				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 				goto ERROR;
 			}
 
-			if (sqlite3_bind_text(insert, 3, e->checksum, -1, SQLITE_STATIC) != SQLITE_OK) {
-				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-				goto ERROR;
-			}
-
 			if (e->owner != NULL) {
-				if (sqlite3_bind_text(insert, 4, e->owner, -1, SQLITE_STATIC) != SQLITE_OK) {
+				if (sqlite3_bind_text(insert, 4, e->owner, -1, SQLITE_STATIC) !=
+				    SQLITE_OK) {
 					SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 					goto ERROR;
 				}
@@ -1066,7 +1150,8 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 			}
 
 			if (e->group != NULL) {
-				if (sqlite3_bind_text(insert, 5, e->group, -1, SQLITE_STATIC) != SQLITE_OK) {
+				if (sqlite3_bind_text(insert, 5, e->group, -1, SQLITE_STATIC) !=
+				    SQLITE_OK) {
 					SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 					goto ERROR;
 				}
@@ -1078,7 +1163,8 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 			}
 
 			if (e->mode != NULL) {
-				if (sqlite3_bind_text(insert, 6, e->mode, -1, SQLITE_STATIC) != SQLITE_OK) {
+				if (sqlite3_bind_text(insert, 6, e->mode, -1, SQLITE_STATIC) !=
+				    SQLITE_OK) {
 					SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 					goto ERROR;
 				}
@@ -1088,12 +1174,14 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 					goto ERROR;
 				}
 			}
-		} else if (e->type == ASSET_DIR || e->type == ASSET_DIRRM || e->type == ASSET_DIRRMTRY) {
-			/* if data starts with /, it's most likely an absolute path. Don't prepend cwd */
+		} else if (e->type == ASSET_DIR || e->type == ASSET_DIRRM ||
+		    e->type == ASSET_DIRRMTRY) {
+			/* if data starts with /, it's most likely an absolute path. Don't prepend
+			 * cwd */
 			if (e->data != NULL && e->data[0] == '/')
-				(void) snprintf(dir, FILENAME_MAX, "%s", e->data);
+				(void)snprintf(dir, FILENAME_MAX, "%s", e->data);
 			else
-				(void) snprintf(dir, FILENAME_MAX, "%s/%s", cwdPtr, e->data);
+				(void)snprintf(dir, FILENAME_MAX, "%s/%s", cwdPtr, e->data);
 
 			if (sqlite3_bind_text(insert, 2, dir, -1, SQLITE_STATIC) != SQLITE_OK) {
 				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
@@ -1167,38 +1255,40 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	mport_pkgmeta_logevent(mport, pkg, "Installed");
 
 	(mport->progress_free_cb)();
-	(void) mport_chdir(NULL, orig_cwd);
+	(void)mport_chdir(NULL, orig_cwd);
 	free(orig_cwd);
 	mport_assetlist_free(alist);
 	return (MPORT_OK);
 
-	ERROR:
-		if (filefd != -1)
-			close(filefd);
-		sqlite3_finalize(insert);
-		(mport->progress_free_cb)();
-		free(orig_cwd);
-		mport_assetlist_free(alist);
+ERROR:
+	if (filefd != -1)
+		close(filefd);
+	sqlite3_finalize(insert);
+	(mport->progress_free_cb)();
+	free(orig_cwd);
+	mport_assetlist_free(alist);
 
 	RETURN_CURRENT_ERROR;
 }
 
-
 static int
-copy_metafile(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg, char *type) 
+copy_metafile(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg, char *type)
 {
 	char from[FILENAME_MAX];
 	char to[FILENAME_MAX];
 	char todir[FILENAME_MAX];
-	
-	(void)snprintf(from, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR, pkg->name, pkg->version, type);
-    if (mport_file_exists(from)) {
-		(void)snprintf(todir, FILENAME_MAX, "%s%s/%s-%s", mport->root, MPORT_INST_INFRA_DIR, pkg->name, pkg->version);
-		(void)snprintf(to, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_INST_INFRA_DIR, pkg->name, pkg->version, type);
-        if (mport_mkdir(todir) != MPORT_OK)
-            RETURN_CURRENT_ERROR;
-        if (mport_copy_file(from, to) != MPORT_OK)
-    	    RETURN_CURRENT_ERROR; 
+
+	(void)snprintf(from, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR,
+	    pkg->name, pkg->version, type);
+	if (mport_file_exists(from)) {
+		(void)snprintf(todir, FILENAME_MAX, "%s%s/%s-%s", mport->root, MPORT_INST_INFRA_DIR,
+		    pkg->name, pkg->version);
+		(void)snprintf(to, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_INST_INFRA_DIR,
+		    pkg->name, pkg->version, type);
+		if (mport_mkdir(todir) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		if (mport_copy_file(from, to) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
 	}
 	return (MPORT_OK);
 }
@@ -1206,7 +1296,8 @@ copy_metafile(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *p
 static int
 mark_complete(mportInstance *mport, mportPackageMeta *pkg)
 {
-	if (mport_db_do(mport->db, "UPDATE packages SET status='clean' WHERE pkg=%Q", pkg->name) != MPORT_OK) {
+	if (mport_db_do(mport->db, "UPDATE packages SET status='clean' WHERE pkg=%Q", pkg->name) !=
+	    MPORT_OK) {
 		SET_ERROR(MPORT_ERR_FATAL, "Unable to mark package clean");
 		RETURN_CURRENT_ERROR;
 	}
@@ -1214,11 +1305,10 @@ mark_complete(mportInstance *mport, mportPackageMeta *pkg)
 	return (MPORT_OK);
 }
 
-
 static int
 do_post_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
 {
-	
+
 	copy_metafile(mport, bundle, pkg, MPORT_MTREE_FILE);
 	copy_metafile(mport, bundle, pkg, MPORT_INSTALL_FILE);
 	copy_metafile(mport, bundle, pkg, MPORT_DEINSTALL_FILE);
@@ -1241,7 +1331,6 @@ do_post_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta 
 	return mark_complete(mport, pkg);
 }
 
-
 static int
 run_postexec(mportInstance *mport, mportPackageMeta *pkg)
 {
@@ -1254,13 +1343,12 @@ run_postexec(mportInstance *mport, mportPackageMeta *pkg)
 	if (mport_bundle_read_get_assetlist(mport, pkg, &alist, POSTINSTALL) != MPORT_OK)
 		goto ERROR;
 
-	(void) strlcpy(cwd, pkg->prefix, sizeof(cwd));
+	(void)strlcpy(cwd, pkg->prefix, sizeof(cwd));
 
 	if (mport_chdir(mport, cwd) != MPORT_OK)
 		goto ERROR;
 
-	STAILQ_FOREACH(e, alist, next)
-	{
+	STAILQ_FOREACH (e, alist, next) {
 		char file[FILENAME_MAX];
 		if (e->data == NULL) {
 			snprintf(file, sizeof(file), "%s", mport->root);
@@ -1271,85 +1359,92 @@ run_postexec(mportInstance *mport, mportPackageMeta *pkg)
 		}
 
 		switch (e->type) {
-			case ASSET_CWD:
-				(void) strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
-				if (mport_chdir(mport, cwd) != MPORT_OK)
-					goto ERROR;
-				break;
-			case ASSET_POSTEXEC:
-				if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
-					goto ERROR;
-				break;
-			case ASSET_LDCONFIG:
-				if (mport_xsystem(mport, "/usr/sbin/service ldconfig restart > /dev/null") != MPORT_OK) {
-					goto ERROR;
-				}
-				break;
-			case ASSET_LDCONFIG_LINUX:
-				if (!is_linux_module_loaded()) {
-					/* load the linux module */
-					mport_call_msg_cb(mport, "Loading Linux kernel module.  To make this permanent, follow instructions in man LINUX(4)");
+		case ASSET_CWD:
+			(void)strlcpy(cwd, e->data == NULL ? pkg->prefix : e->data, sizeof(cwd));
+			if (mport_chdir(mport, cwd) != MPORT_OK)
+				goto ERROR;
+			break;
+		case ASSET_POSTEXEC:
+			if (mport_run_asset_exec(mport, e->data, cwd, file) != MPORT_OK)
+				goto ERROR;
+			break;
+		case ASSET_LDCONFIG:
+			if (mport_xsystem(mport,
+				"/usr/sbin/service ldconfig restart > /dev/null") != MPORT_OK) {
+				goto ERROR;
+			}
+			break;
+		case ASSET_LDCONFIG_LINUX:
+			if (!is_linux_module_loaded()) {
+				/* load the linux module */
+				mport_call_msg_cb(mport,
+				    "Loading Linux kernel module.  To make this permanent, follow instructions in man LINUX(4)");
 #if defined(__amd64__)
-					if (mport_xsystem(mport, "/sbin/kldload linux64") != MPORT_OK) {
-						goto ERROR;
-					}
+				if (mport_xsystem(mport, "/sbin/kldload linux64") != MPORT_OK) {
+					goto ERROR;
+				}
 #elif defined(__i386__)
-					if (mport_xsystem(mport, "/sbin/kldload linux") != MPORT_OK) {
-                        goto ERROR;
-                    }
+				if (mport_xsystem(mport, "/sbin/kldload linux") != MPORT_OK) {
+					goto ERROR;
+				}
 #endif
-				}
+			}
 
-				if (e->data == NULL) {
-					if (mport_xsystem(mport, "/compat/linux/sbin/ldconfig") != MPORT_OK) {
-						goto ERROR;
-					}
-				} else {
-					if (mport_exec_linux_ldconfig(mport, e->data) != MPORT_OK) {
-						goto ERROR;
-					}
-				}
-				break;
-			case ASSET_GLIB_SCHEMAS:
-				if (mport_file_exists("/usr/local/bin/glib-compile-schemas") &&
-					mport_exec_glib_compile_schemas(mport, e->data == NULL ? pkg->prefix : e->data) != MPORT_OK) {
+			if (e->data == NULL) {
+				if (mport_xsystem(mport, "/compat/linux/sbin/ldconfig") !=
+				    MPORT_OK) {
 					goto ERROR;
 				}
-				break;
-			case ASSET_INFO:
-				if (e->data != NULL) {
-					strlcpy(in, e->data, sizeof(in));
-				} else {
-					strlcpy(in, "/usr/local/share/info", sizeof(in));
-				}
-				char *abs_path = realpath(in, NULL);
-				if (abs_path == NULL)
-					goto ERROR;
-				char *info_dir = dirname(abs_path);
-				if (info_dir != NULL && mport_file_exists("/usr/local/bin/indexinfo") &&
-					mport_exec_indexinfo(mport, info_dir) != MPORT_OK) {
-					free(abs_path);
+			} else {
+				if (mport_exec_linux_ldconfig(mport, e->data) != MPORT_OK) {
 					goto ERROR;
 				}
+			}
+			break;
+		case ASSET_GLIB_SCHEMAS:
+			if (mport_file_exists("/usr/local/bin/glib-compile-schemas") &&
+			    mport_exec_glib_compile_schemas(
+				mport, e->data == NULL ? pkg->prefix : e->data) != MPORT_OK) {
+				goto ERROR;
+			}
+			break;
+		case ASSET_INFO:
+			if (e->data != NULL) {
+				strlcpy(in, e->data, sizeof(in));
+			} else {
+				strlcpy(in, "/usr/local/share/info", sizeof(in));
+			}
+			char *abs_path = realpath(in, NULL);
+			if (abs_path == NULL)
+				goto ERROR;
+			char *info_dir = dirname(abs_path);
+			if (info_dir != NULL && mport_file_exists("/usr/local/bin/indexinfo") &&
+			    mport_exec_indexinfo(mport, info_dir) != MPORT_OK) {
 				free(abs_path);
-				break;
-			case ASSET_KLD:
-				if (mport_exec_kldxref(mport, file) != MPORT_OK) {
-					goto ERROR;
-				}
-				break;
-			case ASSET_DESKTOP_FILE_UTILS:
-				if (mport_file_exists("/usr/local/bin/update-desktop-database") && mport_xsystem(mport, "/usr/local/bin/update-desktop-database -q > /dev/null || true") != MPORT_OK) {
-					goto ERROR;
-				}
-				break;
-			case ASSET_TOUCH:
-			    if (mport_xsystem(mport, "/usr/bin/touch %s", file)!= MPORT_OK) {
-                    goto ERROR;
-                }
-			default:
-				/* do nothing */
-				break;
+				goto ERROR;
+			}
+			free(abs_path);
+			break;
+		case ASSET_KLD:
+			if (mport_exec_kldxref(mport, file) != MPORT_OK) {
+				goto ERROR;
+			}
+			break;
+		case ASSET_DESKTOP_FILE_UTILS:
+			if (mport_file_exists("/usr/local/bin/update-desktop-database") &&
+			    mport_xsystem(mport,
+				"/usr/local/bin/update-desktop-database -q > /dev/null || true") !=
+				MPORT_OK) {
+				goto ERROR;
+			}
+			break;
+		case ASSET_TOUCH:
+			if (mport_xsystem(mport, "/usr/bin/touch %s", file) != MPORT_OK) {
+				goto ERROR;
+			}
+		default:
+			/* do nothing */
+			break;
 		}
 	}
 
@@ -1358,22 +1453,22 @@ run_postexec(mportInstance *mport, mportPackageMeta *pkg)
 
 	return MPORT_OK;
 
-	ERROR:
+ERROR:
 	// TODO: asset list free
 	RETURN_CURRENT_ERROR;
 }
 
-static bool 
-is_linux_module_loaded(void) {
-    size_t len;
+static bool
+is_linux_module_loaded(void)
+{
+	size_t len;
 
-    if (sysctlbyname("compat.linux.osrelease", NULL, &len, NULL, 0) == -1) {
+	if (sysctlbyname("compat.linux.osrelease", NULL, &len, NULL, 0) == -1) {
 		return false;
-    }
+	}
 
 	return true;
 }
-
 
 static int
 run_mtree(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
@@ -1382,11 +1477,12 @@ run_mtree(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
 	int ret;
 	pid_t pid;
 
-	(void) snprintf(file, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR, pkg->name,
-		pkg->version, MPORT_MTREE_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR,
+	    pkg->name, pkg->version, MPORT_MTREE_FILE);
 
-	char *const args[] = {MPORT_MTREE_BIN, "-U", "-f", file, "-d", "-e", "-p", pkg->prefix, NULL};
-	char *const envp[] = {NULL};
+	char *const args[] = { MPORT_MTREE_BIN, "-U", "-f", file, "-d", "-e", "-p", pkg->prefix,
+		NULL };
+	char *const envp[] = { NULL };
 
 	if (mport_file_exists(file)) {
 		ret = posix_spawn(&pid, MPORT_MTREE_BIN, NULL, NULL, args, envp);
@@ -1394,40 +1490,46 @@ run_mtree(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
 		if (ret == 0) {
 			int status;
 			if (waitpid(pid, &status, 0) == -1) {
-				RETURN_ERRORX(MPORT_ERR_FATAL, "waitpid failed: %s", strerror(errno));
+				RETURN_ERRORX(
+				    MPORT_ERR_FATAL, "waitpid failed: %s", strerror(errno));
 			}
 			if (WIFEXITED(status)) {
-                ret = WEXITSTATUS(status);
-                if (ret != 0) {
-                    RETURN_ERRORX(MPORT_ERR_FATAL, "%s returned non-zero: %i", MPORT_MTREE_BIN, ret);
-                }
-            } else {
-                RETURN_ERRORX(MPORT_ERR_FATAL, "%s terminated abnormally", MPORT_MTREE_BIN);
-            }
+				ret = WEXITSTATUS(status);
+				if (ret != 0) {
+					RETURN_ERRORX(MPORT_ERR_FATAL, "%s returned non-zero: %i",
+					    MPORT_MTREE_BIN, ret);
+				}
+			} else {
+				RETURN_ERRORX(
+				    MPORT_ERR_FATAL, "%s terminated abnormally", MPORT_MTREE_BIN);
+			}
 		} else {
-			RETURN_ERRORX(MPORT_ERR_FATAL, "%s returned non-zero: %i", MPORT_MTREE_BIN, ret);
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "%s returned non-zero: %i", MPORT_MTREE_BIN, ret);
 		}
 	}
 
 	return (MPORT_OK);
 }
 
-
 static int
-run_pkg_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg, const char *mode)
+run_pkg_install(
+    mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg, const char *mode)
 {
 	char file[FILENAME_MAX];
 	int ret;
 
-	(void) snprintf(file, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR, pkg->name,
-	                pkg->version, MPORT_INSTALL_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s/%s/%s-%s/%s", bundle->tmpdir, MPORT_STUB_INFRA_DIR,
+	    pkg->name, pkg->version, MPORT_INSTALL_FILE);
 
 	if (mport_file_exists(file)) {
 		if (chmod(file, 750) != 0)
 			RETURN_ERRORX(MPORT_ERR_FATAL, "chmod(%s, 750): %s", file, strerror(errno));
 
-		if ((ret = mport_xsystem(mport, "PKG_PREFIX=%s %s %s %s", pkg->prefix, file, pkg->name, mode)) != 0)
-			RETURN_ERRORX(MPORT_ERR_FATAL, "%s %s returned non-zero: %i", MPORT_INSTALL_FILE, mode, ret);
+		if ((ret = mport_xsystem(
+			 mport, "PKG_PREFIX=%s %s %s %s", pkg->prefix, file, pkg->name, mode)) != 0)
+			RETURN_ERRORX(MPORT_ERR_FATAL, "%s %s returned non-zero: %i",
+			    MPORT_INSTALL_FILE, mode, ret);
 	}
 
 	return (MPORT_OK);

--- a/libmport/bundle_read_update_pkg.c
+++ b/libmport/bundle_read_update_pkg.c
@@ -42,7 +42,8 @@ static int build_create_extras(mportInstance *, mportPackageMeta *, char *, mpor
 static int build_create_extras_copy_metafiles(const mportPackageMeta *, mportCreateExtras *);
 static int build_create_extras_depends(mportInstance *, mportPackageMeta *, mportCreateExtras *);
 
-int mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
+int
+mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, mportPackageMeta *pkg)
 {
 	char tmpfile2[] = _PATH_TMP "mport.XXXXXXXX";
 	int fd;
@@ -52,7 +53,7 @@ int mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, 
 	if ((fd = mkstemp(tmpfile2)) == -1) {
 		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't make tmp file: %s", strerror(errno));
 	}
-  
+
 	close(fd);
 
 	if (make_backup_bundle(mport, pkg, tmpfile2) != MPORT_OK) {
@@ -62,178 +63,185 @@ int mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, 
 	}
 
 	pkg->action = MPORT_ACTION_UPDATE;
-	if (
-        (mport_delete_primative(mport, pkg, 1) != MPORT_OK) ||
-        (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)
-	) 
-	{
-    	if (install_backup_bundle(mport, tmpfile2) == MPORT_OK) {
-          (void)mport_rmtree(tmpfile2);
+	if ((mport_delete_primative(mport, pkg, 1) != MPORT_OK) ||
+	    (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
+		if (install_backup_bundle(mport, tmpfile2) == MPORT_OK) {
+			(void)mport_rmtree(tmpfile2);
 		} else {
 			mport_call_msg_cb(mport, "Error restoring backup package %s", pkg->name);
 		}
 		RETURN_CURRENT_ERROR;
-	}           
-  
+	}
+
 	/* if we can't delete the tmpfile, just move on. */
 	(void)mport_rmtree(tmpfile2);
-  
+
 	return (MPORT_OK);
 }
-  
-  
-static int make_backup_bundle(mportInstance *mport, mportPackageMeta *pkg, char *tempfile)
+
+static int
+make_backup_bundle(mportInstance *mport, mportPackageMeta *pkg, char *tempfile)
 {
-  mportAssetList *alist;
-  mportCreateExtras *extra;
-  int ret;
- 
-  if (mport_asset_get_assetlist(mport, pkg, &alist) != MPORT_OK) {
-    RETURN_CURRENT_ERROR;
-  }
+	mportAssetList *alist;
+	mportCreateExtras *extra;
+	int ret;
 
-  if (build_create_extras(mport, pkg, tempfile, &extra) != MPORT_OK) {
-    RETURN_CURRENT_ERROR;
-  }
+	if (mport_asset_get_assetlist(mport, pkg, &alist) != MPORT_OK) {
+		RETURN_CURRENT_ERROR;
+	}
 
-  extra->is_backup = true;
+	if (build_create_extras(mport, pkg, tempfile, &extra) != MPORT_OK) {
+		RETURN_CURRENT_ERROR;
+	}
 
-  ret = mport_create_primative(mport, alist, pkg, extra);
+	extra->is_backup = true;
 
-  mport_assetlist_free(alist);
-  mport_createextras_free(extra);
+	ret = mport_create_primative(mport, alist, pkg, extra);
 
-  return (ret);
-}        
+	mport_assetlist_free(alist);
+	mport_createextras_free(extra);
 
-
-static int install_backup_bundle(mportInstance *mport, char *filename) 
-{
-  /* at some point we might want to look into making this more forceful, but
-   * this will do for the moment.  Wrap in a function for this future. */
-  
-  return mport_install_primative(mport, filename, NULL, 0);
+	return (ret);
 }
 
-
-
-static int build_create_extras(mportInstance *mport, mportPackageMeta *pkg, char *tempfile, mportCreateExtras **extra_p)
+static int
+install_backup_bundle(mportInstance *mport, char *filename)
 {
-  mportCreateExtras *extra;
- 
-  extra = mport_createextras_new();
-  *extra_p = extra;
- 
-  strlcpy(extra->pkg_filename, tempfile, FILENAME_MAX);
-  extra->sourcedir[0] = '\0';
- 
-  if (build_create_extras_depends(mport, pkg, extra) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
- 
-  if (build_create_extras_copy_metafiles(pkg, extra) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
+	/* at some point we might want to look into making this more forceful, but
+	 * this will do for the moment.  Wrap in a function for this future. */
 
-  extra->is_backup = false;
-  
-  return MPORT_OK;
+	return mport_install_primative(mport, filename, NULL, 0);
 }
 
-static int build_create_extras_copy_metafiles(const mportPackageMeta *pkg, mportCreateExtras *extra) 
+static int
+build_create_extras(
+    mportInstance *mport, mportPackageMeta *pkg, char *tempfile, mportCreateExtras **extra_p)
 {
-  char file[FILENAME_MAX];
-  
-  if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name, pkg->version, MPORT_MTREE_FILE) < 0)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-   
-  if (mport_file_exists(file)) {
-    if ((extra->mtree = strdup(file)) == NULL) 
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  }
-    
-  if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name, pkg->version, MPORT_INSTALL_FILE) < 0)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-   
-  if (mport_file_exists(file)) {
-    if ((extra->pkginstall = strdup(file)) == NULL) 
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  }
-    
-  if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name, pkg->version, MPORT_DEINSTALL_FILE) < 0)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-   
-  if (mport_file_exists(file)) {
-    if ((extra->pkgdeinstall = strdup(file)) == NULL) 
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  }
-    
-  if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name, pkg->version, MPORT_MESSAGE_FILE) < 0)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-   
-  if (mport_file_exists(file)) {
-    if ((extra->pkgmessage = strdup(file)) == NULL)
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  }
+	mportCreateExtras *extra;
 
-  return 0;
+	extra = mport_createextras_new();
+	*extra_p = extra;
+
+	strlcpy(extra->pkg_filename, tempfile, FILENAME_MAX);
+	extra->sourcedir[0] = '\0';
+
+	if (build_create_extras_depends(mport, pkg, extra) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	if (build_create_extras_copy_metafiles(pkg, extra) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	extra->is_backup = false;
+
+	return MPORT_OK;
 }
 
-static int build_create_extras_depends(mportInstance *mport, mportPackageMeta *pkg, mportCreateExtras *extra) 
+static int
+build_create_extras_copy_metafiles(const mportPackageMeta *pkg, mportCreateExtras *extra)
 {
-  int count, ret, i;
-  sqlite3_stmt *stmt;
-  char *entry;
- 
-  if (mport_db_prepare(mport->db, &stmt, "SELECT COUNT(*) FROM depends WHERE pkg=%Q", pkg->name) != MPORT_OK) {
-	  sqlite3_finalize(stmt);
-	  RETURN_CURRENT_ERROR;
-  }
-    
-  ret = sqlite3_step(stmt);
-   
-  switch (ret) {
-    case SQLITE_ROW:
-      count = sqlite3_column_int(stmt, 0);
-      sqlite3_finalize(stmt);
-      break;
-    case SQLITE_DONE:
-      sqlite3_finalize(stmt);
-      RETURN_ERROR(MPORT_ERR_FATAL, "SQLite returned no rows for a COUNT(*) select.");
-    default:
-      sqlite3_finalize(stmt);
-      RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-  }
+	char file[FILENAME_MAX];
 
-  if ((extra->depends = (char **)calloc(count + 1, sizeof(char *))) == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  extra->depends_count = count;
- 
-  if (mport_db_prepare(mport->db, &stmt, "SELECT depend_pkgname, depend_pkgversion, depend_port FROM depends WHERE pkg=%Q", pkg->name) != MPORT_OK) {
-	  sqlite3_finalize(stmt);
-	  RETURN_CURRENT_ERROR;
-  }
-  
-  i = 0;
-  while (1) {
-    ret = sqlite3_step(stmt);
-   
-    if (ret == SQLITE_ROW) {
-      if (asprintf(&entry, "%s:%s:%s", sqlite3_column_text(stmt, 0), sqlite3_column_text(stmt, 2), sqlite3_column_text(stmt, 1)) == -1) {
-        sqlite3_finalize(stmt);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");  
-      }
-        
-      extra->depends[i] = entry;
-      i++;
-    } else if (ret == SQLITE_DONE) {
-      extra->depends[i] = NULL;
-      break;
-    } else {
-      sqlite3_finalize(stmt);
-      RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-    }
-  }
-  
-  sqlite3_finalize(stmt);
-  
-  return (MPORT_OK);
+	if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name,
+		pkg->version, MPORT_MTREE_FILE) < 0)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+
+	if (mport_file_exists(file)) {
+		if ((extra->mtree = strdup(file)) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	}
+
+	if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name,
+		pkg->version, MPORT_INSTALL_FILE) < 0)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+
+	if (mport_file_exists(file)) {
+		if ((extra->pkginstall = strdup(file)) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	}
+
+	if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name,
+		pkg->version, MPORT_DEINSTALL_FILE) < 0)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+
+	if (mport_file_exists(file)) {
+		if ((extra->pkgdeinstall = strdup(file)) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	}
+
+	if (snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pkg->name,
+		pkg->version, MPORT_MESSAGE_FILE) < 0)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+
+	if (mport_file_exists(file)) {
+		if ((extra->pkgmessage = strdup(file)) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	}
+
+	return 0;
+}
+
+static int
+build_create_extras_depends(mportInstance *mport, mportPackageMeta *pkg, mportCreateExtras *extra)
+{
+	int count, ret, i;
+	sqlite3_stmt *stmt;
+	char *entry;
+
+	if (mport_db_prepare(mport->db, &stmt, "SELECT COUNT(*) FROM depends WHERE pkg=%Q",
+		pkg->name) != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	ret = sqlite3_step(stmt);
+
+	switch (ret) {
+	case SQLITE_ROW:
+		count = sqlite3_column_int(stmt, 0);
+		sqlite3_finalize(stmt);
+		break;
+	case SQLITE_DONE:
+		sqlite3_finalize(stmt);
+		RETURN_ERROR(MPORT_ERR_FATAL, "SQLite returned no rows for a COUNT(*) select.");
+	default:
+		sqlite3_finalize(stmt);
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+	}
+
+	if ((extra->depends = (char **)calloc(count + 1, sizeof(char *))) == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	extra->depends_count = count;
+
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT depend_pkgname, depend_pkgversion, depend_port FROM depends WHERE pkg=%Q",
+		pkg->name) != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	i = 0;
+	while (1) {
+		ret = sqlite3_step(stmt);
+
+		if (ret == SQLITE_ROW) {
+			if (asprintf(&entry, "%s:%s:%s", sqlite3_column_text(stmt, 0),
+				sqlite3_column_text(stmt, 2), sqlite3_column_text(stmt, 1)) == -1) {
+				sqlite3_finalize(stmt);
+				RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+			}
+
+			extra->depends[i] = entry;
+			i++;
+		} else if (ret == SQLITE_DONE) {
+			extra->depends[i] = NULL;
+			break;
+		} else {
+			sqlite3_finalize(stmt);
+			RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		}
+	}
+
+	sqlite3_finalize(stmt);
+
+	return (MPORT_OK);
 }

--- a/libmport/bundle_write.c
+++ b/libmport/bundle_write.c
@@ -28,13 +28,13 @@
 
 #include <sys/cdefs.h>
 
-/* Portions of this code (the hardlink handling) were inspired by and/or copied 
+/* Portions of this code (the hardlink handling) were inspired by and/or copied
  * from write.c in bsdtar by Tim Kientzle. Copyright (c) 2003-2007 Tim Kientzle.
- * 
+ *
  * The code referenced above was released under the same 2-clause BSD license as
  * libmport.
  */
- 
+
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,44 +50,42 @@
 #include "mport.h"
 #include "mport_private.h"
 
-
-#define	LINK_TABLE_SIZE 1024
-#define BUFF_SIZE       (BUFSIZ * 16)
+#define LINK_TABLE_SIZE 1024
+#define BUFF_SIZE (BUFSIZ * 16)
 
 struct links_table {
-  size_t nbuckets;
-  size_t nentries;
-  struct link_node **buckets;
+	size_t nbuckets;
+	size_t nentries;
+	struct link_node **buckets;
 };
 
 struct link_node {
-  int links;
-  dev_t dev;
-  ino_t ino;
-  struct link_node *next;
-  struct link_node *previous;
-  char *name;
+	int links;
+	dev_t dev;
+	ino_t ino;
+	struct link_node *next;
+	struct link_node *previous;
+	char *name;
 };
-
 
 static int lookup_hardlink(mportBundleWrite *, struct archive_entry *, const struct stat *);
 static void free_linktable(struct links_table *);
 
-/* 
- * mport_bundle_write_new() 
+/*
+ * mport_bundle_write_new()
  *
  * allocate a new write bundle struct.  Returns null if no
- * memory could be had 
+ * memory could be had
  */
-mportBundleWrite* mport_bundle_write_new(void) 
+mportBundleWrite *
+mport_bundle_write_new(void)
 {
-  return (mportBundleWrite *)calloc(1, sizeof(mportBundleWrite));
+	return (mportBundleWrite *)calloc(1, sizeof(mportBundleWrite));
 }
- 
 
 /*
  * mport_bundle_write_init(bundle, filename)
- * 
+ *
  * set up a bundle for adding files.  Sets the bundle file to
  * filename.
  */
@@ -126,30 +124,30 @@ mport_bundle_write_init(mportBundleWrite *bundle, const char *filename)
 	return MPORT_OK;
 }
 
-/* 
+/*
  * mport_bundle_write_finish(bundle)
  *
  * Finish the bundle file, and then free any memory used by the mportBundle struct.
  *
  */
-int mport_bundle_write_finish(mportBundleWrite *bundle)
+int
+mport_bundle_write_finish(mportBundleWrite *bundle)
 {
-  int ret = MPORT_OK;
+	int ret = MPORT_OK;
 
-  if (bundle == NULL)
-      RETURN_ERROR(MPORT_ERR_FATAL, "mport bundle is missing");
- 
-  if (archive_write_free(bundle->archive) != ARCHIVE_OK)
-    ret = SET_ERROR(MPORT_ERR_FATAL, strdup(archive_error_string(bundle->archive)));
+	if (bundle == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "mport bundle is missing");
 
-  free_linktable(bundle->links);
- 
-  free(bundle->filename);
-  free(bundle);
-  
-  return ret;
+	if (archive_write_free(bundle->archive) != ARCHIVE_OK)
+		ret = SET_ERROR(MPORT_ERR_FATAL, strdup(archive_error_string(bundle->archive)));
+
+	free_linktable(bundle->links);
+
+	free(bundle->filename);
+	free(bundle);
+
+	return ret;
 }
-
 
 /*
  * mport_bundle_write_add_file(bundle, filename, path)
@@ -157,7 +155,8 @@ int mport_bundle_write_finish(mportBundleWrite *bundle)
  * Add a single file to the bundle.  filename is the name of the file
  * in the system, while path is where the file should be put in the bundle.
  */
-int mport_bundle_write_add_file(mportBundleWrite *bundle, const char *filename, const char *path)
+int
+mport_bundle_write_add_file(mportBundleWrite *bundle, const char *filename, const char *path)
 {
 	struct archive_entry *entry = NULL;
 	struct stat st;
@@ -172,207 +171,207 @@ int mport_bundle_write_add_file(mportBundleWrite *bundle, const char *filename, 
 	entry = archive_entry_new();
 	archive_entry_set_pathname(entry, path);
 
-  if (!S_ISDIR(st.st_mode) && (st.st_nlink > 1))
-    if (lookup_hardlink(bundle, entry, &st) != MPORT_OK)
-      RETURN_CURRENT_ERROR;
-  
-  if (S_ISLNK(st.st_mode)) {
-    /* we have us a symlink */
-    ssize_t linklen;
-    char linkdata[PATH_MAX + 1];
-    
-    linklen = readlink(filename, linkdata, PATH_MAX);
-    
-    if (linklen < 0) 
-      RETURN_ERROR(MPORT_ERR_FATAL, strerror(errno));
-      
-    linkdata[linklen] = '\0';
-    
-    archive_entry_set_symlink(entry, linkdata);
-  }
- 
-  #if defined(__MidnightBSD__) || defined(__FreeBSD__)
-  if (st.st_flags != 0) 
-    archive_entry_set_fflags(entry, st.st_flags, 0);
-  #endif
-    
-  archive_entry_copy_stat(entry, &st);
- 
-  /* non-regular files get archived with zero size */
-  if (!S_ISREG(st.st_mode)) {
-    archive_entry_set_size(entry, 0);
-  }
-  /* make sure we can open the file before its header is put in the archive */
-  else if ((fd = open(filename, O_RDONLY)) == -1) {
-   RETURN_ERROR(MPORT_ERR_FATAL, strerror(errno));
-  }
-   
-  if (archive_write_header(bundle->archive, entry) != ARCHIVE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
-  
-  /* write the data to the archive if there is data to write */
-  if (archive_entry_size(entry) > 0 && fd > -1) {
-    len = read(fd, buff, sizeof(buff));
-    while (len > 0) {
-      if (archive_write_data(bundle->archive, buff, len) != len) {
-        ret = SET_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
-        break;
-      }
-      len = read(fd, buff, sizeof(buff));
-    }
-  }
-   
-  archive_entry_free(entry);
- 
-  if (fd > -1)
-    close(fd);
+	if (!S_ISDIR(st.st_mode) && (st.st_nlink > 1))
+		if (lookup_hardlink(bundle, entry, &st) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
 
-  return ret;  
+	if (S_ISLNK(st.st_mode)) {
+		/* we have us a symlink */
+		ssize_t linklen;
+		char linkdata[PATH_MAX + 1];
+
+		linklen = readlink(filename, linkdata, PATH_MAX);
+
+		if (linklen < 0)
+			RETURN_ERROR(MPORT_ERR_FATAL, strerror(errno));
+
+		linkdata[linklen] = '\0';
+
+		archive_entry_set_symlink(entry, linkdata);
+	}
+
+#if defined(__MidnightBSD__) || defined(__FreeBSD__)
+	if (st.st_flags != 0)
+		archive_entry_set_fflags(entry, st.st_flags, 0);
+#endif
+
+	archive_entry_copy_stat(entry, &st);
+
+	/* non-regular files get archived with zero size */
+	if (!S_ISREG(st.st_mode)) {
+		archive_entry_set_size(entry, 0);
+	}
+	/* make sure we can open the file before its header is put in the archive */
+	else if ((fd = open(filename, O_RDONLY)) == -1) {
+		RETURN_ERROR(MPORT_ERR_FATAL, strerror(errno));
+	}
+
+	if (archive_write_header(bundle->archive, entry) != ARCHIVE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
+
+	/* write the data to the archive if there is data to write */
+	if (archive_entry_size(entry) > 0 && fd > -1) {
+		len = read(fd, buff, sizeof(buff));
+		while (len > 0) {
+			if (archive_write_data(bundle->archive, buff, len) != len) {
+				ret = SET_ERROR(
+				    MPORT_ERR_FATAL, archive_error_string(bundle->archive));
+				break;
+			}
+			len = read(fd, buff, sizeof(buff));
+		}
+	}
+
+	archive_entry_free(entry);
+
+	if (fd > -1)
+		close(fd);
+
+	return ret;
 }
-
 
 /* mport_bundle_write_add_entry(bundle, readBundle, entry)
- * 
- * Add an entry from another archive to the bundle.  The archive struct must be a read 
+ *
+ * Add an entry from another archive to the bundle.  The archive struct must be a read
  * archive, and the entry must represent the current data segment of the archive.
  */
-int mport_bundle_write_add_entry(mportBundleWrite *bundle, mportBundleRead *inbundle, struct archive_entry *entry)
+int
+mport_bundle_write_add_entry(
+    mportBundleWrite *bundle, mportBundleRead *inbundle, struct archive_entry *entry)
 {
-  char buff[BUFF_SIZE];
-  size_t size, bytes_to_write;
+	char buff[BUFF_SIZE];
+	size_t size, bytes_to_write;
 
-  if (archive_write_header(bundle->archive, entry) != ARCHIVE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
+	if (archive_write_header(bundle->archive, entry) != ARCHIVE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
 
-  size = archive_entry_size(entry);
+	size = archive_entry_size(entry);
 
-  while (size > 0) {  
-    if (archive_read_data(inbundle->archive, buff, sizeof(buff)) < ARCHIVE_OK) 
-      RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(inbundle->archive));
+	while (size > 0) {
+		if (archive_read_data(inbundle->archive, buff, sizeof(buff)) < ARCHIVE_OK)
+			RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(inbundle->archive));
 
-    /* don't write the whole buffer if it isn't full */
-    bytes_to_write = size < sizeof(buff) ? size : sizeof(buff);
+		/* don't write the whole buffer if it isn't full */
+		bytes_to_write = size < sizeof(buff) ? size : sizeof(buff);
 
-    if (archive_write_data(bundle->archive, buff, bytes_to_write) < 0)
-      RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
+		if (archive_write_data(bundle->archive, buff, bytes_to_write) < 0)
+			RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(bundle->archive));
 
-    size -= bytes_to_write;
-  }  
-  
-  return MPORT_OK;
+		size -= bytes_to_write;
+	}
+
+	return MPORT_OK;
 }
-
 
 /* lookup a file with more than one link in the link table.  If we find an entry
  * for the inode in the table, mark this incoming file as a hardlink to the prior file.
  * Otherwise, insert the new file into the table.
  */
-static int lookup_hardlink(mportBundleWrite *bundle, struct archive_entry *entry, const struct stat *st)
+static int
+lookup_hardlink(mportBundleWrite *bundle, struct archive_entry *entry, const struct stat *st)
 {
-  struct links_table *links = bundle->links;
-  struct link_node *node, **new_buckets;
-  int hash;
-  size_t i, new_size;
+	struct links_table *links = bundle->links;
+	struct link_node *node, **new_buckets;
+	int hash;
+	size_t i, new_size;
 
-  if (links == NULL) {
-    if ((bundle->links = calloc(1, sizeof(struct links_table))) == NULL)
-      RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate links table");
-    
-    links = bundle->links;
-    links->nbuckets = LINK_TABLE_SIZE;
-    links->nentries = 0;
-    links->buckets  = calloc(links->nbuckets, sizeof(links->buckets[0]));
-    
-    if (links->buckets == NULL) {
-      RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate links table mapping");
-    }
-  }
+	if (links == NULL) {
+		if ((bundle->links = calloc(1, sizeof(struct links_table))) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate links table");
 
-  if (links->buckets == NULL) {
-    return MPORT_OK; /* just to be safe */ 
-  }
+		links = bundle->links;
+		links->nbuckets = LINK_TABLE_SIZE;
+		links->nentries = 0;
+		links->buckets = calloc(links->nbuckets, sizeof(links->buckets[0]));
 
-  /* if the number of entries is twice the number of buckets, increase the table size */
-  if (links->nentries > links->nbuckets * 2) {
-    new_size = links->nbuckets * 2;
-    new_buckets = calloc(new_size, sizeof(links->buckets[0]));
-    
-    if (new_buckets != NULL) {
-      for (i = 0; i < links->nbuckets; i++) {
-        if (links->buckets[i] != NULL) {
-          /* remove old from bucket */
-          node = links->buckets[i];
-                
-          hash = (node->dev ^ node->ino) % new_size;
-          if (new_buckets[hash] != NULL)
-            new_buckets[hash]->previous = node;    
-          
-          node->next = new_buckets[hash];
-          node->previous = NULL;
-          new_buckets[hash] = node;
-        }
-      }
-      free(links->buckets);
-      links->buckets  = new_buckets;
-      links->nbuckets = new_size;
-    } else {
-      RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't expand hard links hash table.");
-    }
-  }
-   
+		if (links->buckets == NULL) {
+			RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate links table mapping");
+		}
+	}
 
-  /* ok, we're done with maintence of the hash table, we can now go on to trying
-     to find the location of this entry */ 
-  hash = (st->st_dev ^ st->st_ino) % links->nbuckets;
-   
-  for (node = links->buckets[hash]; node != NULL; node = node->next) {
-    if (node->dev == st->st_dev && node->ino == st->st_ino) {
-      /* we found it!  we're out of here */
-      archive_entry_copy_hardlink(entry, node->name);
-      
-      node->links--;
-      
-      /* no reason to keep this in the table, we've archived all the links */
-      if (node->links <= 0) {
-        if (node->previous != NULL)
-          node->previous->next = node->next;
-        if (node->next != NULL)
-          node->next->previous = node->previous;
-        if (links->buckets[hash] == node)
-          links->buckets[hash] = node->next;
-        if (node->name != NULL)
-          free(node->name);
-        links->nentries--;
-        free(node);
-      }
-          
-      return MPORT_OK;    
-    }
-  }
- 
-   /* we didn't find any match to this file, so this is the first time we've seen
-      it.  Put it in the table */
-  node = calloc(1, sizeof(struct link_node));
-  if (node != NULL)
-    node->name = strdup(archive_entry_pathname(entry));
-  if ((node == NULL) || (node->name == NULL))
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't add file to the links hashtable.");
-  
-  if (links->buckets[hash] != NULL)
-    links->buckets[hash]->previous = node;
-  
-  links->nentries++;
-  node->next = links->buckets[hash];
-  node->previous = NULL;
-  node->dev   = st->st_dev;
-  node->ino   = st->st_ino;
-  node->links = st->st_nlink - 1;
-  
-  links->buckets[hash] = node;
-  
-  return MPORT_OK;
+	if (links->buckets == NULL) {
+		return MPORT_OK; /* just to be safe */
+	}
+
+	/* if the number of entries is twice the number of buckets, increase the table size */
+	if (links->nentries > links->nbuckets * 2) {
+		new_size = links->nbuckets * 2;
+		new_buckets = calloc(new_size, sizeof(links->buckets[0]));
+
+		if (new_buckets != NULL) {
+			for (i = 0; i < links->nbuckets; i++) {
+				if (links->buckets[i] != NULL) {
+					/* remove old from bucket */
+					node = links->buckets[i];
+
+					hash = (node->dev ^ node->ino) % new_size;
+					if (new_buckets[hash] != NULL)
+						new_buckets[hash]->previous = node;
+
+					node->next = new_buckets[hash];
+					node->previous = NULL;
+					new_buckets[hash] = node;
+				}
+			}
+			free(links->buckets);
+			links->buckets = new_buckets;
+			links->nbuckets = new_size;
+		} else {
+			RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't expand hard links hash table.");
+		}
+	}
+
+	/* ok, we're done with maintence of the hash table, we can now go on to trying
+	   to find the location of this entry */
+	hash = (st->st_dev ^ st->st_ino) % links->nbuckets;
+
+	for (node = links->buckets[hash]; node != NULL; node = node->next) {
+		if (node->dev == st->st_dev && node->ino == st->st_ino) {
+			/* we found it!  we're out of here */
+			archive_entry_copy_hardlink(entry, node->name);
+
+			node->links--;
+
+			/* no reason to keep this in the table, we've archived all the links */
+			if (node->links <= 0) {
+				if (node->previous != NULL)
+					node->previous->next = node->next;
+				if (node->next != NULL)
+					node->next->previous = node->previous;
+				if (links->buckets[hash] == node)
+					links->buckets[hash] = node->next;
+				if (node->name != NULL)
+					free(node->name);
+				links->nentries--;
+				free(node);
+			}
+
+			return MPORT_OK;
+		}
+	}
+
+	/* we didn't find any match to this file, so this is the first time we've seen
+	   it.  Put it in the table */
+	node = calloc(1, sizeof(struct link_node));
+	if (node != NULL)
+		node->name = strdup(archive_entry_pathname(entry));
+	if ((node == NULL) || (node->name == NULL))
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't add file to the links hashtable.");
+
+	if (links->buckets[hash] != NULL)
+		links->buckets[hash]->previous = node;
+
+	links->nentries++;
+	node->next = links->buckets[hash];
+	node->previous = NULL;
+	node->dev = st->st_dev;
+	node->ino = st->st_ino;
+	node->links = st->st_nlink - 1;
+
+	links->buckets[hash] = node;
+
+	return MPORT_OK;
 }
-
 
 static void
 free_linktable(struct links_table *links)
@@ -398,4 +397,3 @@ free_linktable(struct links_table *links)
 	free(links->buckets);
 	links->buckets = NULL;
 }
-

--- a/libmport/check_preconditions.c
+++ b/libmport/check_preconditions.c
@@ -48,20 +48,20 @@ static int check_file_conflicts(mportInstance *, mportPackageMeta *);
  *
  * Flags:
  *   MPORT_PRECHECK_MOVED      -- Fail if the package has been moved to another location
- *   MPORT_PRECHECK_DEPRECATED -- Fail if the package has been deprecated and print the expiration date
- *   MPORT_PRECHECK_INSTALLED  -- Fail if the package is installed
- *   MPORT_PRECHECK_UPGRADABLE -- Fail if an older version is not installed
- *   MPORT_PRECHECK_CONFLICTS  -- Fail if the package has a conflict
- *   MPORT_PRECHECK_DEPENDS    -- Fail if the dependencies are not resolved
- *   MPORT_PRECHECK_OS	       -- Fail if the os version of the installed is older
+ *   MPORT_PRECHECK_DEPRECATED -- Fail if the package has been deprecated and print the expiration
+ * date MPORT_PRECHECK_INSTALLED  -- Fail if the package is installed MPORT_PRECHECK_UPGRADABLE --
+ * Fail if an older version is not installed MPORT_PRECHECK_CONFLICTS  -- Fail if the package has a
+ * conflict MPORT_PRECHECK_DEPENDS    -- Fail if the dependencies are not resolved MPORT_PRECHECK_OS
+ * -- Fail if the os version of the installed is older
  *
  * The checks are run in the order listed above.  The first failure
- * encountered is the one reported.   
+ * encountered is the one reported.
  *
  * This function expects that the stub database for the given package is
  * connected.
  */
-int mport_check_preconditions(mportInstance *mport, mportPackageMeta *pack, long flags)
+int
+mport_check_preconditions(mportInstance *mport, mportPackageMeta *pack, long flags)
 {
 	if (flags & MPORT_PRECHECK_MOVED && check_if_moved(mport, pack) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
@@ -83,7 +83,8 @@ int mport_check_preconditions(mportInstance *mport, mportPackageMeta *pack, long
 	return MPORT_OK;
 }
 
-static int check_if_moved(mportInstance *mport, mportPackageMeta *pack)
+static int
+check_if_moved(mportInstance *mport, mportPackageMeta *pack)
 {
 	mportIndexMovedEntry **movedEntries;
 
@@ -92,22 +93,24 @@ static int check_if_moved(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (movedEntries == NULL || *movedEntries!= NULL) {
+	if (movedEntries == NULL || *movedEntries != NULL) {
 		return MPORT_OK;
 	}
 
 	if ((*movedEntries)->date[0] != '\0')
 		return MPORT_OK; // it expired, not moved
 
-	if ((*movedEntries)->moved_to != NULL && (*movedEntries)->moved_to[0]!= '\0') {
-		SET_ERRORX(MPORT_ERR_FATAL, "The package %s has been moved to %s", pack->name, (*movedEntries)->moved_to);
-        RETURN_CURRENT_ERROR;
+	if ((*movedEntries)->moved_to != NULL && (*movedEntries)->moved_to[0] != '\0') {
+		SET_ERRORX(MPORT_ERR_FATAL, "The package %s has been moved to %s", pack->name,
+		    (*movedEntries)->moved_to);
+		RETURN_CURRENT_ERROR;
 	}
 
 	return MPORT_OK; // just pass it if it didn't match either scenario
 }
 
-static int check_if_deprecated(mportInstance *mport, mportPackageMeta *pack)
+static int
+check_if_deprecated(mportInstance *mport, mportPackageMeta *pack)
 {
 	mportIndexMovedEntry **movedEntries;
 
@@ -116,7 +119,7 @@ static int check_if_deprecated(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (movedEntries == NULL || *movedEntries!= NULL) {
+	if (movedEntries == NULL || *movedEntries != NULL) {
 		return MPORT_OK;
 	}
 
@@ -125,10 +128,11 @@ static int check_if_deprecated(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-	return MPORT_OK;	
+	return MPORT_OK;
 }
 
-static int check_if_installed(mportInstance *mport, mportPackageMeta *pack)
+static int
+check_if_installed(mportInstance *mport, mportPackageMeta *pack)
 {
 	sqlite3_stmt *stmt;
 	const char *inst_version;
@@ -136,13 +140,14 @@ static int check_if_installed(mportInstance *mport, mportPackageMeta *pack)
 	char *system_os_release;
 
 	/* check if the package is already installed */
-	if (mport_db_prepare(mport->db, &stmt, "SELECT version, os_release FROM packages WHERE pkg=%Q", pack->name) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT version, os_release FROM packages WHERE pkg=%Q", pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
-	/* it's possible that the default package with a flavor does not have a prefix, but will appear that way during
-	 * dependency calculation.
+	/* it's possible that the default package with a flavor does not have a prefix, but will
+	 * appear that way during dependency calculation.
 	 */
 	int step = sqlite3_step(stmt);
 	if (step == SQLITE_DONE) {
@@ -151,8 +156,9 @@ static int check_if_installed(mportInstance *mport, mportPackageMeta *pack)
 			if (asprintf(&full_name, "%s-%s", pack->flavor, pack->name) == -1)
 				RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
 			if (full_name != NULL) {
-				if (mport_db_prepare(mport->db, &stmt, "SELECT version, os_release FROM packages WHERE pkg=%Q", full_name) !=
-				    MPORT_OK) {
+				if (mport_db_prepare(mport->db, &stmt,
+					"SELECT version, os_release FROM packages WHERE pkg=%Q",
+					full_name) != MPORT_OK) {
 					sqlite3_finalize(stmt);
 					RETURN_CURRENT_ERROR;
 				}
@@ -163,45 +169,47 @@ static int check_if_installed(mportInstance *mport, mportPackageMeta *pack)
 	}
 
 	switch (step) {
-		case SQLITE_DONE:
-			/* No row found. */
-			break;
-		case SQLITE_ROW:
-			/* Row was found */
-			inst_version = sqlite3_column_text(stmt, 0);
-			os_release = sqlite3_column_text(stmt, 1);
-			system_os_release = (char *) mport_get_osrelease(mport);
+	case SQLITE_DONE:
+		/* No row found. */
+		break;
+	case SQLITE_ROW:
+		/* Row was found */
+		inst_version = sqlite3_column_text(stmt, 0);
+		os_release = sqlite3_column_text(stmt, 1);
+		system_os_release = (char *)mport_get_osrelease(mport);
 
-			/* Different os release version should not be considered the same package */
-			if (strcmp(os_release, system_os_release) != 0) {
-				free(system_os_release);
-				break;
-			}
+		/* Different os release version should not be considered the same package */
+		if (strcmp(os_release, system_os_release) != 0) {
 			free(system_os_release);
+			break;
+		}
+		free(system_os_release);
 
-			SET_ERRORX(MPORT_ERR_FATAL, "%s (version %s) is already installed.", pack->name, inst_version);
-			sqlite3_finalize(stmt);
-			RETURN_CURRENT_ERROR;
-		default:
-			/* Some sort of sqlite error */
-			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			sqlite3_finalize(stmt);
-			RETURN_CURRENT_ERROR;
+		SET_ERRORX(MPORT_ERR_FATAL, "%s (version %s) is already installed.", pack->name,
+		    inst_version);
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	default:
+		/* Some sort of sqlite error */
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
 	}
 
 	sqlite3_finalize(stmt);
 	return MPORT_OK;
 }
 
-static int check_conflicts(mportInstance *mport, mportPackageMeta *pack)
+static int
+check_conflicts(mportInstance *mport, mportPackageMeta *pack)
 {
 	sqlite3_stmt *stmt;
 	int ret;
 	const char *inst_name, *inst_version;
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT packages.pkg, packages.version FROM stub.conflicts LEFT JOIN packages ON packages.pkg GLOB stub.conflicts.conflict_pkg AND packages.version GLOB stub.conflicts.conflict_version WHERE stub.conflicts.pkg=%Q AND packages.pkg IS NOT NULL",
-	                     pack->name) != MPORT_OK) {
+		"SELECT packages.pkg, packages.version FROM stub.conflicts LEFT JOIN packages ON packages.pkg GLOB stub.conflicts.conflict_pkg AND packages.version GLOB stub.conflicts.conflict_version WHERE stub.conflicts.pkg=%Q AND packages.pkg IS NOT NULL",
+		pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -210,11 +218,11 @@ static int check_conflicts(mportInstance *mport, mportPackageMeta *pack)
 		ret = sqlite3_step(stmt);
 
 		if (ret == SQLITE_ROW) {
-			inst_name = (const char *) sqlite3_column_text(stmt, 0);
-			inst_version = (const char *) sqlite3_column_text(stmt, 1);
+			inst_name = (const char *)sqlite3_column_text(stmt, 0);
+			inst_version = (const char *)sqlite3_column_text(stmt, 1);
 
-			SET_ERRORX(MPORT_ERR_FATAL, "Installed package %s-%s conflicts with %s", inst_name, inst_version,
-			           pack->name);
+			SET_ERRORX(MPORT_ERR_FATAL, "Installed package %s-%s conflicts with %s",
+			    inst_name, inst_version, pack->name);
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;
 		} else if (ret == SQLITE_DONE) {
@@ -231,8 +239,8 @@ static int check_conflicts(mportInstance *mport, mportPackageMeta *pack)
 	return MPORT_OK;
 }
 
-
-static int check_depends(mportInstance *mport, mportPackageMeta *pack)
+static int
+check_depends(mportInstance *mport, mportPackageMeta *pack)
 {
 	sqlite3 *db = mport->db;
 	sqlite3_stmt *stmt, *lookup;
@@ -242,20 +250,23 @@ static int check_depends(mportInstance *mport, mportPackageMeta *pack)
 	int ret;
 
 	/* check for depends */
-	if (mport_db_prepare(mport->db, &stmt, "SELECT depend_pkgname, depend_pkgversion FROM stub.depends WHERE pkg=%Q",
-	                     pack->name) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT depend_pkgname, depend_pkgversion FROM stub.depends WHERE pkg=%Q",
+		pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
-	/* package name on dependencies can contain the flavor prefix. native-binutils but there is no guarnatee we stored it as native-bintuils in master. check for binutils also. */
-	if (mport_db_prepare(db, &lookup, "SELECT version, os_release, flavor FROM packages WHERE (pkg=? or (flavor is not null and flavor != '' and pkg=substr(?, length(flavor) + 2) )) AND status='clean'") !=
+	/* package name on dependencies can contain the flavor prefix. native-binutils but there is
+	 * no guarnatee we stored it as native-bintuils in master. check for binutils also. */
+	if (mport_db_prepare(db, &lookup,
+		"SELECT version, os_release, flavor FROM packages WHERE (pkg=? or (flavor is not null and flavor != '' and pkg=substr(?, length(flavor) + 2) )) AND status='clean'") !=
 	    MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
-	system_os_release = (char *) mport_get_osrelease(mport);
+	system_os_release = (char *)mport_get_osrelease(mport);
 
 	if (system_os_release == NULL) {
 		sqlite3_finalize(stmt);
@@ -269,7 +280,10 @@ static int check_depends(mportInstance *mport, mportPackageMeta *pack)
 			depend_pkg = sqlite3_column_text(stmt, 0);
 			depend_version = sqlite3_column_text(stmt, 1);
 
-			if (sqlite3_bind_text(lookup, 1, depend_pkg, -1, SQLITE_STATIC) != SQLITE_OK || sqlite3_bind_text(lookup, 2, depend_pkg, -1, SQLITE_STATIC) != SQLITE_OK) {
+			if (sqlite3_bind_text(lookup, 1, depend_pkg, -1, SQLITE_STATIC) !=
+				SQLITE_OK ||
+			    sqlite3_bind_text(lookup, 2, depend_pkg, -1, SQLITE_STATIC) !=
+				SQLITE_OK) {
 				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 				sqlite3_finalize(lookup);
 				sqlite3_finalize(stmt);
@@ -280,56 +294,60 @@ static int check_depends(mportInstance *mport, mportPackageMeta *pack)
 			}
 
 			switch (sqlite3_step(lookup)) {
-				case SQLITE_ROW:
-					inst_version = sqlite3_column_text(lookup, 0);
-					os_release = sqlite3_column_text(lookup, 1);
-					int ok;
+			case SQLITE_ROW:
+				inst_version = sqlite3_column_text(lookup, 0);
+				os_release = sqlite3_column_text(lookup, 1);
+				int ok;
 
-					if (strcmp(os_release, system_os_release) != 0) {
-						SET_ERRORX(MPORT_ERR_FATAL,
-						           "%s depends on %s version %s.  Version %s for MidnightBSD %s is installed.",
-						           pack->name, depend_pkg, depend_version == NULL ? "<any>" : depend_version,
-						           inst_version, os_release);
-						sqlite3_finalize(lookup);
-						sqlite3_finalize(stmt);
-						free(system_os_release);
-						RETURN_CURRENT_ERROR;
-					}
+				if (strcmp(os_release, system_os_release) != 0) {
+					SET_ERRORX(MPORT_ERR_FATAL,
+					    "%s depends on %s version %s.  Version %s for MidnightBSD %s is installed.",
+					    pack->name, depend_pkg,
+					    depend_version == NULL ? "<any>" : depend_version,
+					    inst_version, os_release);
+					sqlite3_finalize(lookup);
+					sqlite3_finalize(stmt);
+					free(system_os_release);
+					RETURN_CURRENT_ERROR;
+				}
 
-					if (depend_version == NULL)
-						/* no minimum version */
-						break;
-
-					ok = mport_version_require_check(inst_version, depend_version);
-
-					if (ok > 0) {
-						sqlite3_finalize(lookup);
-						sqlite3_finalize(stmt);
-						free(system_os_release);
-						RETURN_CURRENT_ERROR;
-					} else if (ok == -1) {
-						SET_ERRORX(MPORT_ERR_FATAL, "%s depends on %s version %s.  Version %s is installed.",
-						           pack->name, depend_pkg, depend_version, inst_version);
-						sqlite3_finalize(lookup);
-						sqlite3_finalize(stmt);
-						free(system_os_release);
-						RETURN_CURRENT_ERROR;
-					}
-
+				if (depend_version == NULL)
+					/* no minimum version */
 					break;
-				case SQLITE_DONE:
-					/* this dependency isn't installed. */
-					SET_ERRORX(MPORT_ERR_FATAL, "%s depends on %s, which is not installed.", pack->name, depend_pkg);
+
+				ok = mport_version_require_check(inst_version, depend_version);
+
+				if (ok > 0) {
 					sqlite3_finalize(lookup);
 					sqlite3_finalize(stmt);
 					free(system_os_release);
 					RETURN_CURRENT_ERROR;
-				default:
-					SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
+				} else if (ok == -1) {
+					SET_ERRORX(MPORT_ERR_FATAL,
+					    "%s depends on %s version %s.  Version %s is installed.",
+					    pack->name, depend_pkg, depend_version, inst_version);
 					sqlite3_finalize(lookup);
 					sqlite3_finalize(stmt);
 					free(system_os_release);
 					RETURN_CURRENT_ERROR;
+				}
+
+				break;
+			case SQLITE_DONE:
+				/* this dependency isn't installed. */
+				SET_ERRORX(MPORT_ERR_FATAL,
+				    "%s depends on %s, which is not installed.", pack->name,
+				    depend_pkg);
+				sqlite3_finalize(lookup);
+				sqlite3_finalize(stmt);
+				free(system_os_release);
+				RETURN_CURRENT_ERROR;
+			default:
+				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
+				sqlite3_finalize(lookup);
+				sqlite3_finalize(stmt);
+				free(system_os_release);
+				RETURN_CURRENT_ERROR;
 			}
 
 			sqlite3_reset(lookup);
@@ -367,23 +385,23 @@ check_if_older_installed(mportInstance *mport, mportPackageMeta *pkg)
 		return SET_ERROR(MPORT_ERR_FATAL, "Unable to determine OS release");
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT os_release FROM packages WHERE pkg=%Q and ((mport_version_cmp(version, %Q) < 0 and os_release=%Q) or os_release != %Q)",
-	                     pkg->name, pkg->version, os_release, os_release) != MPORT_OK) {
-		free((char*)os_release);
+		"SELECT os_release FROM packages WHERE pkg=%Q and ((mport_version_cmp(version, %Q) < 0 and os_release=%Q) or os_release != %Q)",
+		pkg->name, pkg->version, os_release, os_release) != MPORT_OK) {
+		free((char *)os_release);
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
 	switch (sqlite3_step(stmt)) {
-		case SQLITE_ROW:
-			ret = MPORT_OK;
-			break;
-		case SQLITE_DONE:
-			ret = SET_ERRORX(MPORT_ERR_FATAL, "No older version of %s installed", pkg->name);
-			break;
-		default:
-			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			break;
+	case SQLITE_ROW:
+		ret = MPORT_OK;
+		break;
+	case SQLITE_DONE:
+		ret = SET_ERRORX(MPORT_ERR_FATAL, "No older version of %s installed", pkg->name);
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
 	}
 
 	sqlite3_finalize(stmt);
@@ -405,27 +423,28 @@ check_if_older_os(mportInstance *mport, mportPackageMeta *pkg)
 		return SET_ERROR(MPORT_ERR_FATAL, "Unable to determine OS release");
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT os_release FROM packages WHERE pkg=%Q and mport_version_cmp(os_release, %Q) < 0",
-	                     pkg->name, os_release) != MPORT_OK) {
-		free((char*)os_release);
+		"SELECT os_release FROM packages WHERE pkg=%Q and mport_version_cmp(os_release, %Q) < 0",
+		pkg->name, os_release) != MPORT_OK) {
+		free((char *)os_release);
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
 	switch (sqlite3_step(stmt)) {
-		case SQLITE_ROW:
-			ret = MPORT_OK;
-			break;
-		case SQLITE_DONE:
-			ret = SET_ERRORX(MPORT_ERR_FATAL, "No older os release version of %s installed", pkg->name);
-			break;
-		default:
-			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			break;
+	case SQLITE_ROW:
+		ret = MPORT_OK;
+		break;
+	case SQLITE_DONE:
+		ret = SET_ERRORX(
+		    MPORT_ERR_FATAL, "No older os release version of %s installed", pkg->name);
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
 	}
 
 	sqlite3_finalize(stmt);
-	free((char*) os_release);
+	free((char *)os_release);
 
 	return ret;
 }
@@ -446,14 +465,14 @@ check_file_conflicts(mportInstance *mport, mportPackageMeta *pack)
 	strlcpy(cwd, pack->prefix, sizeof(cwd));
 
 	if (mport_db_prepare(mport->db, &stmt,
-	    "SELECT type, data FROM stub.assets WHERE pkg=%Q ORDER BY rowid",
-	    pack->name) != MPORT_OK) {
+		"SELECT type, data FROM stub.assets WHERE pkg=%Q ORDER BY rowid",
+		pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (mport_db_prepare(mport->db, &lookup,
-	    "SELECT pkg FROM assets WHERE data=? AND pkg!=?") != MPORT_OK) {
+	if (mport_db_prepare(
+		mport->db, &lookup, "SELECT pkg FROM assets WHERE data=? AND pkg!=?") != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		sqlite3_finalize(lookup);
 		RETURN_CURRENT_ERROR;
@@ -500,7 +519,8 @@ check_file_conflicts(mportInstance *mport, mportPackageMeta *pack)
 
 		strlcpy(datastr, data, sizeof(datastr));
 		if (type == ASSET_SAMPLE || type == ASSET_SAMPLE_OWNER_MODE) {
-			/* sample entries may have a destination separated by whitespace; use only the source */
+			/* sample entries may have a destination separated by whitespace; use only
+			 * the source */
 			char *sp = datastr;
 			while (*sp != '\0' && *sp != ' ' && *sp != '\t')
 				sp++;
@@ -534,14 +554,15 @@ check_file_conflicts(mportInstance *mport, mportPackageMeta *pack)
 		int lret = sqlite3_step(lookup);
 		if (lret == SQLITE_ROW) {
 			const char *owner = sqlite3_column_text(lookup, 0);
-			SET_ERRORX(MPORT_ERR_FATAL,
-			    "%s is owned by %s; use -f to overwrite.", fullpath, owner);
+			SET_ERRORX(MPORT_ERR_FATAL, "%s is owned by %s; use -f to overwrite.",
+			    fullpath, owner);
 			sqlite3_finalize(lookup);
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;
 		} else if (lret == SQLITE_DONE) {
 			SET_ERRORX(MPORT_ERR_FATAL,
-			    "%s already exists but is not managed by mport; use -f to overwrite.", fullpath);
+			    "%s already exists but is not managed by mport; use -f to overwrite.",
+			    fullpath);
 			sqlite3_finalize(lookup);
 			sqlite3_finalize(stmt);
 			RETURN_CURRENT_ERROR;

--- a/libmport/clean.c
+++ b/libmport/clean.c
@@ -62,7 +62,6 @@ mport_clean_oldpackages(mportInstance *mport)
 {
 	int error_code = MPORT_OK;
 
-
 	int deleted = 0;
 	int dfd;
 	struct dirent *de;
@@ -70,16 +69,16 @@ mport_clean_oldpackages(mportInstance *mport)
 
 	dfd = open(MPORT_FETCH_STAGING_DIR, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 	if (dfd == -1) {
-		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s", MPORT_FETCH_STAGING_DIR,
-		                        strerror(errno));
+		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s",
+		    MPORT_FETCH_STAGING_DIR, strerror(errno));
 		return error_code;
 	}
 
 	d = fdopendir(dfd);
 	if (d == NULL) {
 		close(dfd);
-		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s", MPORT_FETCH_STAGING_DIR,
-		                        strerror(errno));
+		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s",
+		    MPORT_FETCH_STAGING_DIR, strerror(errno));
 		return error_code;
 	}
 
@@ -89,7 +88,8 @@ mport_clean_oldpackages(mportInstance *mport)
 		if (strcmp(".", de->d_name) == 0 || strcmp("..", de->d_name) == 0)
 			continue;
 
-		if (mport_index_search(mport, &indexEntry, "bundlefile=%Q", de->d_name) != MPORT_OK) {
+		if (mport_index_search(mport, &indexEntry, "bundlefile=%Q", de->d_name) !=
+		    MPORT_OK) {
 			mport_call_msg_cb(mport, "failed to search index %s: ", mport_err_string());
 			continue;
 		}
@@ -104,8 +104,8 @@ mport_clean_oldpackages(mportInstance *mport)
 
 		if (indexEntry == NULL || *indexEntry == NULL) {
 			if (unlinkat(dfd, de->d_name, 0) < 0) {
-				error_code = SET_ERRORX(MPORT_ERR_FATAL, "Could not delete file %s: %s",
-				                        path, strerror(errno));
+				error_code = SET_ERRORX(MPORT_ERR_FATAL,
+				    "Could not delete file %s: %s", path, strerror(errno));
 				mport_call_msg_cb(mport, "%s\n", mport_err_string());
 			} else {
 				deleted++;
@@ -117,20 +117,27 @@ mport_clean_oldpackages(mportInstance *mport)
 
 			fd = openat(dfd, de->d_name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
 			if (fd == -1) {
-				mport_call_msg_cb(mport, "Could not open %s: %s", path, strerror(errno));
+				mport_call_msg_cb(
+				    mport, "Could not open %s: %s", path, strerror(errno));
 			} else if (fstat(fd, &st) == -1) {
-				mport_call_msg_cb(mport, "Could not stat %s: %s", path, strerror(errno));
+				mport_call_msg_cb(
+				    mport, "Could not stat %s: %s", path, strerror(errno));
 				close(fd);
 			} else if (!S_ISREG(st.st_mode)) {
 				close(fd);
 			} else if (verify_hash_fd(fd, (*indexEntry)->hash) == 0) {
 				if (fstatat(dfd, de->d_name, &current, AT_SYMLINK_NOFOLLOW) == -1) {
-					error_code = SET_ERRORX(MPORT_ERR_FATAL, "Could not stat file %s: %s", path, strerror(errno));
+					error_code = SET_ERRORX(MPORT_ERR_FATAL,
+					    "Could not stat file %s: %s", path, strerror(errno));
 					mport_call_msg_cb(mport, "%s\n", mport_err_string());
-				} else if (current.st_dev == st.st_dev && current.st_ino == st.st_ino) {
+				} else if (current.st_dev == st.st_dev &&
+				    current.st_ino == st.st_ino) {
 					if (unlinkat(dfd, de->d_name, 0) < 0) {
-						error_code = SET_ERRORX(MPORT_ERR_FATAL, "Could not delete file %s: %s", path, strerror(errno));
-						mport_call_msg_cb(mport, "%s\n", mport_err_string());
+						error_code = SET_ERRORX(MPORT_ERR_FATAL,
+						    "Could not delete file %s: %s", path,
+						    strerror(errno));
+						mport_call_msg_cb(
+						    mport, "%s\n", mport_err_string());
 					} else {
 						deleted++;
 					}
@@ -197,10 +204,10 @@ mport_clean_oldmtree(mportInstance *mport)
 	int deleted = 0;
 	struct dirent *de;
 	DIR *d = opendir(MPORT_INST_INFRA_DIR);
-	
+
 	if (d == NULL) {
-		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s", MPORT_INST_INFRA_DIR,
-		                        strerror(errno));
+		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s",
+		    MPORT_INST_INFRA_DIR, strerror(errno));
 		return error_code;
 	}
 
@@ -219,7 +226,8 @@ mport_clean_oldmtree(mportInstance *mport)
 		}
 
 		if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", packageName) != MPORT_OK) {
-			mport_call_msg_cb(mport, "failed to search master database for %s: ", mport_err_string());
+			mport_call_msg_cb(
+			    mport, "failed to search master database for %s: ", mport_err_string());
 			continue;
 		}
 
@@ -233,7 +241,8 @@ mport_clean_oldmtree(mportInstance *mport)
 
 		if (packs == NULL || *packs == NULL) {
 			if (mport_rmtree(path) != MPORT_OK) {
-				error_code = SET_ERRORX(MPORT_ERR_FATAL, "Could not delete file %s: %s", path, strerror(errno));
+				error_code = SET_ERRORX(MPORT_ERR_FATAL,
+				    "Could not delete file %s: %s", path, strerror(errno));
 				mport_call_msg_cb(mport, "%s\n", mport_err_string());
 			} else {
 				deleted++;
@@ -262,10 +271,10 @@ mport_clean_tempfiles(mportInstance *mport)
 	int deleted = 0;
 	struct dirent *de;
 	DIR *d = opendir(_PATH_TMP);
-	
+
 	if (d == NULL) {
-		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s", MPORT_INST_INFRA_DIR,
-		                        strerror(errno));
+		error_code = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't open directory %s: %s",
+		    MPORT_INST_INFRA_DIR, strerror(errno));
 		return error_code;
 	}
 
@@ -275,8 +284,7 @@ mport_clean_tempfiles(mportInstance *mport)
 			continue;
 
 		if (!mport_starts_with("mport.", de->d_name))
-	       		continue;
-
+			continue;
 
 		if (asprintf(&path, "%s%s", _PATH_TMP, de->d_name) == -1) {
 			continue;
@@ -285,12 +293,13 @@ mport_clean_tempfiles(mportInstance *mport)
 		int result = unlink(path);
 
 		if (result != 0) {
-			error_code = SET_ERRORX(MPORT_ERR_FATAL, "Could not delete file %s: %s", path, strerror(errno));
+			error_code = SET_ERRORX(
+			    MPORT_ERR_FATAL, "Could not delete file %s: %s", path, strerror(errno));
 			mport_call_msg_cb(mport, "%s\n", mport_err_string());
 		} else {
 			deleted++;
 		}
-	 
+
 		free(path);
 		path = NULL;
 	}

--- a/libmport/create_primative.c
+++ b/libmport/create_primative.c
@@ -63,14 +63,16 @@ static int archive_files(mportAssetList *, mportPackageMeta *, mportCreateExtras
 
 static int archive_metafiles(mportBundleWrite *, mportPackageMeta *, mportCreateExtras *);
 
-static int archive_assetlistfiles(mportBundleWrite *, mportPackageMeta *, mportCreateExtras *, mportAssetList *);
+static int archive_assetlistfiles(
+    mportBundleWrite *, mportPackageMeta *, mportCreateExtras *, mportAssetList *);
 
 static int clean_up(const char *);
 
 static int checked_snprintf(char *, size_t, const char *, ...);
 
 MPORT_PUBLIC_API int
-mport_create_primative(mportInstance *mport, mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtras *extra)
+mport_create_primative(mportInstance *mport, mportAssetList *assetlist, mportPackageMeta *pack,
+    mportCreateExtras *extra)
 {
 	int error_code = MPORT_OK;
 	sqlite3 *db = NULL;
@@ -104,14 +106,14 @@ mport_create_primative(mportInstance *mport, mportAssetList *assetlist, mportPac
 		goto CLEANUP;
 	}
 
-	error_code = archive_files(assetlist, pack, extra, tmpdir); /* cleanup will run next which is the desired action */
+	error_code = archive_files(
+	    assetlist, pack, extra, tmpdir); /* cleanup will run next which is the desired action */
 
-	CLEANUP:
+CLEANUP:
 	clean_up(tmpdir);
 
 	return error_code;
 }
-
 
 static int
 create_stub_db(mportInstance *mport, sqlite3 **db, const char *tmpdir)
@@ -119,7 +121,7 @@ create_stub_db(mportInstance *mport, sqlite3 **db, const char *tmpdir)
 	int error_code = MPORT_OK;
 
 	char file[FILENAME_MAX];
-	(void) snprintf(file, FILENAME_MAX, "%s/%s", tmpdir, MPORT_STUB_DB_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s/%s", tmpdir, MPORT_STUB_DB_FILE);
 	if (sqlite3_open(file, db) != SQLITE_OK) {
 		sqlite3_close(*db);
 		error_code = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
@@ -133,11 +135,13 @@ create_stub_db(mportInstance *mport, sqlite3 **db, const char *tmpdir)
 }
 
 static int
-insert_assetlist(sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtras *extra)
+insert_assetlist(
+    sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtras *extra)
 {
 	mportAssetListEntry *e = NULL;
 	sqlite3_stmt *stmnt = NULL;
-	char sql[] = "INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) VALUES (?,?,?,?,?,?,?)";
+	char sql[] =
+	    "INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) VALUES (?,?,?,?,?,?,?)";
 	char hash[65];
 	char file[FILENAME_MAX];
 	char cwd[FILENAME_MAX];
@@ -149,8 +153,7 @@ insert_assetlist(sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack,
 	if (mport_db_prepare(db, &stmnt, sql) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
-	STAILQ_FOREACH(e, assetlist, next)
-	{
+	STAILQ_FOREACH (e, assetlist, next) {
 		if (e->type == ASSET_COMMENT)
 			continue;
 
@@ -194,8 +197,8 @@ insert_assetlist(sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack,
 					RETURN_CURRENT_ERROR;
 				}
 			} else {
-				if (checked_snprintf(file, FILENAME_MAX, "%s/%s", cwd,
-					e->data) != MPORT_OK) {
+				if (checked_snprintf(file, FILENAME_MAX, "%s/%s", cwd, e->data) !=
+				    MPORT_OK) {
 					sqlite3_finalize(stmnt);
 					RETURN_CURRENT_ERROR;
 				}
@@ -218,14 +221,16 @@ insert_assetlist(sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack,
 					goto reset;
 				}
 				sqlite3_finalize(stmnt);
-				RETURN_ERRORX(MPORT_ERR_FATAL, "Could not stat %s: %s", file, strerror(errno));
+				RETURN_ERRORX(MPORT_ERR_FATAL, "Could not stat %s: %s", file,
+				    strerror(errno));
 			}
 
 			if (S_ISREG(st.st_mode)) {
 				if (SHA256_File(file, hash) == NULL)
 					RETURN_ERRORX(MPORT_ERR_FATAL, "File not found: %s", file);
 
-				if (sqlite3_bind_text(stmnt, 4, hash, -1, SQLITE_STATIC) != SQLITE_OK)
+				if (sqlite3_bind_text(stmnt, 4, hash, -1, SQLITE_STATIC) !=
+				    SQLITE_OK)
 					RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 
 				pack->flatsize += st.st_size;
@@ -242,7 +247,7 @@ insert_assetlist(sqlite3 *db, mportAssetList *assetlist, mportPackageMeta *pack,
 			RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 		}
 
-		reset:
+	reset:
 		sqlite3_clear_bindings(stmnt);
 		sqlite3_reset(stmnt);
 	}
@@ -259,7 +264,8 @@ insert_meta(mportInstance *mport, sqlite3 *db, mportPackageMeta *pack, mportCrea
 
 	sqlite3_stmt *stmnt = NULL;
 	const char *rest = 0;
-	char sql[] = "INSERT INTO packages (pkg, version, origin, lang, prefix, comment, os_release, cpe, deprecated, expiration_date, no_provide_shlib, flavor, type, flatsize) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+	char sql[] =
+	    "INSERT INTO packages (pkg, version, origin, lang, prefix, comment, os_release, cpe, deprecated, expiration_date, no_provide_shlib, flavor, type, flatsize) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
 	char *os_release = mport_get_osrelease(mport);
 	if (pack->cpe == NULL) {
@@ -359,7 +365,6 @@ insert_meta(mportInstance *mport, sqlite3 *db, mportPackageMeta *pack, mportCrea
 	return error_code;
 }
 
-
 static int
 insert_categories(sqlite3 *db, mportPackageMeta *pkg)
 {
@@ -371,14 +376,16 @@ insert_categories(sqlite3 *db, mportPackageMeta *pkg)
 	if (pkg->categories == NULL)
 		return MPORT_OK;
 
-	if (mport_db_prepare(db, &stmt, "INSERT INTO categories (pkg, category) VALUES (?,?)") != MPORT_OK)
+	if (mport_db_prepare(db, &stmt, "INSERT INTO categories (pkg, category) VALUES (?,?)") !=
+	    MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	while (pkg->categories[i] != NULL) {
 		if (sqlite3_bind_text(stmt, 1, pkg->name, -1, SQLITE_STATIC) != SQLITE_OK) {
 			error_code = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 		}
-		if (sqlite3_bind_text(stmt, 2, pkg->categories[i], -1, SQLITE_STATIC) != SQLITE_OK) {
+		if (sqlite3_bind_text(stmt, 2, pkg->categories[i], -1, SQLITE_STATIC) !=
+		    SQLITE_OK) {
 			error_code = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 		}
 
@@ -394,19 +401,18 @@ insert_categories(sqlite3 *db, mportPackageMeta *pkg)
 	return error_code;
 }
 
-
-	/* conflict examples:
-	apache-1.4
-	viewvc-1.[12].[0-9]*
-	subversion-1.[0-9].[0-9]*
-	subversion-1.[^9].[0-9]* 
-	p5-Moo-[01]* 
-	p5-Moo-2.00[0-2]*
-	py*-ipython5
-	py311-django[0-9][0-9]
-	p5-HTTP-Server-Simple-PSGI-0.16
-	p5-HTTP-Server-Simple-PSGI
-	*/
+/* conflict examples:
+apache-1.4
+viewvc-1.[12].[0-9]*
+subversion-1.[0-9].[0-9]*
+subversion-1.[^9].[0-9]*
+p5-Moo-[01]*
+p5-Moo-2.00[0-2]*
+py*-ipython5
+py311-django[0-9][0-9]
+p5-HTTP-Server-Simple-PSGI-0.16
+p5-HTTP-Server-Simple-PSGI
+*/
 static int
 insert_conflicts(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 {
@@ -478,7 +484,6 @@ insert_conflicts(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 	return error_code;
 }
 
-
 static int
 insert_depends(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 {
@@ -492,7 +497,7 @@ insert_depends(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 		return MPORT_OK;
 
 	if (mport_db_prepare(db, &stmnt,
-	                     "INSERT INTO depends (pkg, depend_pkgname, depend_pkgversion, depend_port) VALUES (?,?,?,?)") !=
+		"INSERT INTO depends (pkg, depend_pkgname, depend_pkgversion, depend_port) VALUES (?,?,?,?)") !=
 	    MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
@@ -531,7 +536,8 @@ insert_depends(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 		if (pkgversion != NULL) {
 			*pkgversion = '\0';
 			pkgversion++;
-			if (sqlite3_bind_text(stmnt, 3, pkgversion, -1, SQLITE_STATIC) != SQLITE_OK) {
+			if (sqlite3_bind_text(stmnt, 3, pkgversion, -1, SQLITE_STATIC) !=
+			    SQLITE_OK) {
 				error_code = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
 				return error_code;
 			}
@@ -562,7 +568,6 @@ insert_depends(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 	return error_code;
 }
 
-
 static int
 insert_annotations(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra)
 {
@@ -572,10 +577,12 @@ insert_annotations(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra
 	if (tll_length(extra->annotations) == 0)
 		return MPORT_OK;
 
-	if (mport_db_prepare(db, &stmt, "INSERT INTO annotation (pkg, tag, val) VALUES (?,?,?)") != MPORT_OK)
+	if (mport_db_prepare(db, &stmt, "INSERT INTO annotation (pkg, tag, val) VALUES (?,?,?)") !=
+	    MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
-	tll_foreach(extra->annotations, s) {
+	tll_foreach(extra->annotations, s)
+	{
 		char *annotation_copy = strdup(s->item);
 		if (annotation_copy == NULL) {
 			error_code = SET_ERROR(MPORT_ERR_FATAL, "Out of memory");
@@ -590,7 +597,8 @@ insert_annotations(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra
 
 		if (sep == NULL) {
 			free(annotation_copy);
-			error_code = SET_ERRORX(MPORT_ERR_WARN, "malformed annotation (missing ':'): %s", s->item);
+			error_code = SET_ERRORX(
+			    MPORT_ERR_WARN, "malformed annotation (missing ':'): %s", s->item);
 			continue;
 		}
 
@@ -620,9 +628,9 @@ insert_annotations(sqlite3 *db, mportPackageMeta *pack, mportCreateExtras *extra
 	return error_code;
 }
 
-
 static int
-archive_files(mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtras *extra, const char *tmpdir)
+archive_files(
+    mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtras *extra, const char *tmpdir)
 {
 	mportBundleWrite *bundle;
 	char filename[FILENAME_MAX];
@@ -633,7 +641,7 @@ archive_files(mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtr
 		RETURN_CURRENT_ERROR;
 
 	/* First step - +CONTENTS.db ALWAYS GOES FIRST!!! */
-	(void) snprintf(filename, FILENAME_MAX, "%s/%s", tmpdir, MPORT_STUB_DB_FILE);
+	(void)snprintf(filename, FILENAME_MAX, "%s/%s", tmpdir, MPORT_STUB_DB_FILE);
 	if (mport_bundle_write_add_file(bundle, filename, MPORT_STUB_DB_FILE))
 		RETURN_CURRENT_ERROR;
 
@@ -650,60 +658,64 @@ archive_files(mportAssetList *assetlist, mportPackageMeta *pack, mportCreateExtr
 	return MPORT_OK;
 }
 
-
 static int
 archive_metafiles(mportBundleWrite *bundle, mportPackageMeta *pack, mportCreateExtras *extra)
 {
 	char filename[FILENAME_MAX];
 	char dir[FILENAME_MAX];
 
-	(void) snprintf(dir, FILENAME_MAX, "%s/%s-%s", MPORT_STUB_INFRA_DIR, pack->name, pack->version);
+	(void)snprintf(
+	    dir, FILENAME_MAX, "%s/%s-%s", MPORT_STUB_INFRA_DIR, pack->name, pack->version);
 
 	if (extra->mtree != NULL && mport_file_exists(extra->mtree)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_MTREE_FILE);
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_MTREE_FILE);
 		if (mport_bundle_write_add_file(bundle, extra->mtree, filename) != MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->pkginstall != NULL && mport_file_exists(extra->pkginstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_INSTALL_FILE);
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_INSTALL_FILE);
 		if (mport_bundle_write_add_file(bundle, extra->pkginstall, filename) != MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->pkgdeinstall != NULL && mport_file_exists(extra->pkgdeinstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_DEINSTALL_FILE);
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_DEINSTALL_FILE);
 		if (mport_bundle_write_add_file(bundle, extra->pkgdeinstall, filename) != MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->pkgmessage != NULL && mport_file_exists(extra->pkgmessage)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_MESSAGE_FILE);
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_MESSAGE_FILE);
 		if (mport_bundle_write_add_file(bundle, extra->pkgmessage, filename) != MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->luapkgpreinstall != NULL && mport_file_exists(extra->luapkgpreinstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_PRE_INSTALL_FILE);
-		if (mport_bundle_write_add_file(bundle, extra->luapkgpreinstall, filename) != MPORT_OK)
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_PRE_INSTALL_FILE);
+		if (mport_bundle_write_add_file(bundle, extra->luapkgpreinstall, filename) !=
+		    MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->luapkgpostinstall != NULL && mport_file_exists(extra->luapkgpostinstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_POST_INSTALL_FILE);
-		if (mport_bundle_write_add_file(bundle, extra->luapkgpostinstall, filename) != MPORT_OK)
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_POST_INSTALL_FILE);
+		if (mport_bundle_write_add_file(bundle, extra->luapkgpostinstall, filename) !=
+		    MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->luapkgpredeinstall != NULL && mport_file_exists(extra->luapkgpredeinstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_PRE_DEINSTALL_FILE);
-		if (mport_bundle_write_add_file(bundle, extra->luapkgpredeinstall, filename) != MPORT_OK)
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_PRE_DEINSTALL_FILE);
+		if (mport_bundle_write_add_file(bundle, extra->luapkgpredeinstall, filename) !=
+		    MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
 	if (extra->luapkgpostdeinstall != NULL && mport_file_exists(extra->luapkgpostdeinstall)) {
-		(void) snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_POST_DEINSTALL_FILE);
-		if (mport_bundle_write_add_file(bundle, extra->luapkgpostdeinstall, filename) != MPORT_OK)
+		(void)snprintf(filename, FILENAME_MAX, "%s/%s", dir, MPORT_LUA_POST_DEINSTALL_FILE);
+		if (mport_bundle_write_add_file(bundle, extra->luapkgpostdeinstall, filename) !=
+		    MPORT_OK)
 			RETURN_CURRENT_ERROR;
 	}
 
@@ -712,19 +724,19 @@ archive_metafiles(mportBundleWrite *bundle, mportPackageMeta *pack, mportCreateE
 
 static int
 archive_assetlistfiles(mportBundleWrite *bundle, mportPackageMeta *pack, mportCreateExtras *extra,
-                       mportAssetList *assetlist)
+    mportAssetList *assetlist)
 {
 	mportAssetListEntry *e = NULL;
 	char filename[FILENAME_MAX];
 	char *cwd = pack->prefix;
 
-	STAILQ_FOREACH(e, assetlist, next)
-	{
+	STAILQ_FOREACH (e, assetlist, next) {
 		if (e->type == ASSET_CWD)
 			cwd = e->data == NULL ? pack->prefix : e->data;
 
-		if (e->type != ASSET_FILE && e->type != ASSET_SAMPLE && e->type != ASSET_SAMPLE_OWNER_MODE &&
-		    e->type != ASSET_SHELL && e->type != ASSET_FILE_OWNER_MODE && e->type != ASSET_INFO) {
+		if (e->type != ASSET_FILE && e->type != ASSET_SAMPLE &&
+		    e->type != ASSET_SAMPLE_OWNER_MODE && e->type != ASSET_SHELL &&
+		    e->type != ASSET_FILE_OWNER_MODE && e->type != ASSET_INFO) {
 			continue;
 		}
 
@@ -757,7 +769,6 @@ archive_assetlistfiles(mportBundleWrite *bundle, mportPackageMeta *pack, mportCr
 
 	return MPORT_OK;
 }
-
 
 static int
 clean_up(const char *tmpdir)

--- a/libmport/db.c
+++ b/libmport/db.c
@@ -49,9 +49,9 @@ static int mport_upgrade_master_schema_13to14(sqlite3 *);
 static int insert_meta_values(sqlite3 *db, char *key, char *value);
 
 /* mport_db_do(sqlite3 *db, const char *sql, ...)
- * 
+ *
  * A wrapper for executing a single sql query.  Takes a sqlite3 struct
- * pointer, a format string and a list of args.  See the documentation for 
+ * pointer, a format string and a list of args.  See the documentation for
  * sqlite3_vmprintf() for format information.
  */
 int
@@ -76,11 +76,11 @@ mport_db_do(sqlite3 *db, const char *fmt, ...)
 	if (sqlcode == SQLITE_BUSY || sqlcode == SQLITE_LOCKED) {
 		sleep(1);
 		if (sqlite3_exec(db, sql, 0, 0, 0) != SQLITE_OK) {
-			err = (char *) sqlite3_errmsg(db);
+			err = (char *)sqlite3_errmsg(db);
 			result = MPORT_ERR_FATAL;
 		}
 	} else if (sqlcode != SQLITE_OK) {
-		err = (char *) sqlite3_errmsg(db);
+		err = (char *)sqlite3_errmsg(db);
 		result = MPORT_ERR_FATAL;
 	}
 
@@ -93,11 +93,10 @@ mport_db_do(sqlite3 *db, const char *fmt, ...)
 	return result;
 }
 
-
 /* mport_db_prepare(sqlite3 *, sqlite3_stmt **, const char *, ...)
- * 
+ *
  * A wrapper for preparing sqlite statements into statement structs.
- * This function returns MPORT_OK on success.  The sqlite3_stmt pointer 
+ * This function returns MPORT_OK on success.  The sqlite3_stmt pointer
  * may be null if this function does not return MPORT_OK.
  */
 int
@@ -119,11 +118,11 @@ mport_db_prepare(sqlite3 *db, sqlite3_stmt **stmt, const char *fmt, ...)
 	if (sqlcode == SQLITE_BUSY || sqlcode == SQLITE_LOCKED) {
 		sleep(1);
 		if (sqlite3_prepare_v2(db, sql, -1, stmt, NULL) != SQLITE_OK) {
-			err = (char *) sqlite3_errmsg(db);
+			err = (char *)sqlite3_errmsg(db);
 			result = MPORT_ERR_FATAL;
 		}
 	} else if (sqlcode != SQLITE_OK) {
-		err = (char *) sqlite3_errmsg(db);
+		err = (char *)sqlite3_errmsg(db);
 		result = MPORT_ERR_FATAL;
 	}
 
@@ -162,11 +161,11 @@ mport_db_count(sqlite3 *db, int *count, const char *fmt, ...)
 	if (sqlcode == SQLITE_BUSY || sqlcode == SQLITE_LOCKED) {
 		sleep(2);
 		if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
-			err = (char *) sqlite3_errmsg(db);
+			err = (char *)sqlite3_errmsg(db);
 			result = MPORT_ERR_FATAL;
 		}
 	} else if (sqlcode != SQLITE_OK) {
-		err = (char *) sqlite3_errmsg(db);
+		err = (char *)sqlite3_errmsg(db);
 		result = MPORT_ERR_FATAL;
 	}
 
@@ -191,10 +190,9 @@ mport_db_count(sqlite3 *db, int *count, const char *fmt, ...)
 	return result;
 }
 
-
-/* mport_attach_stub_db(sqlite *db, const char *tmpdir) 
+/* mport_attach_stub_db(sqlite *db, const char *tmpdir)
  *
- * Attaches tmpdir/MPORT_STUB_DB_FILE to the given database handle as 
+ * Attaches tmpdir/MPORT_STUB_DB_FILE to the given database handle as
  * 'stub'.  (stub.table to access a table in the stub db)
  *
  * Returns MPORT_OK on success.
@@ -228,8 +226,7 @@ mport_attach_stub_db(sqlite3 *db, const char *dir)
 	return (MPORT_OK);
 }
 
-
-/* mport_detach_stub_db(sqlite *db) 
+/* mport_detach_stub_db(sqlite *db)
  *
  * The inverse of mport_attach_stub_db().
  *
@@ -249,13 +246,13 @@ mport_detach_stub_db(sqlite3 *db)
 	return (MPORT_OK);
 }
 
-
-#define RUN_SQL(db, sql) \
-  if (mport_db_do(db, sql) != MPORT_OK) \
-    RETURN_CURRENT_ERROR
+#define RUN_SQL(db, sql)                      \
+	if (mport_db_do(db, sql) != MPORT_OK) \
+	RETURN_CURRENT_ERROR
 
 static int
-insert_meta_values(sqlite3 *db, char *key, char *value) {
+insert_meta_values(sqlite3 *db, char *key, char *value)
+{
 	return mport_db_do(db, "INSERT INTO meta VALUES (%Q, %Q)", key, value);
 }
 
@@ -283,13 +280,13 @@ mport_generate_stub_schema(mportInstance *mport, sqlite3 *db)
 	ptr = NULL;
 
 	RUN_SQL(db,
-	        "CREATE TABLE assets (pkg text not NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text)");
+	    "CREATE TABLE assets (pkg text not NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text)");
 	RUN_SQL(db,
-	        "CREATE TABLE packages (pkg text NOT NULL, version text NOT NULL, origin text NOT NULL, lang text, options text, prefix text NOT NULL, comment text, os_release text NOT NULL, cpe text NOT NULL, deprecated text, expiration_date int64, no_provide_shlib int NOT NULL, flavor text, type int NOT NULL, flatsize int64 NOT NULL)");
+	    "CREATE TABLE packages (pkg text NOT NULL, version text NOT NULL, origin text NOT NULL, lang text, options text, prefix text NOT NULL, comment text, os_release text NOT NULL, cpe text NOT NULL, deprecated text, expiration_date int64, no_provide_shlib int NOT NULL, flavor text, type int NOT NULL, flatsize int64 NOT NULL)");
 	RUN_SQL(db,
-	        "CREATE TABLE conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
+	    "CREATE TABLE conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
 	RUN_SQL(db,
-	        "CREATE TABLE depends (pkg text NOT NULL, depend_pkgname text NOT NULL, depend_pkgversion text, depend_port text NOT NULL)");
+	    "CREATE TABLE depends (pkg text NOT NULL, depend_pkgname text NOT NULL, depend_pkgversion text, depend_port text NOT NULL)");
 	RUN_SQL(db, "CREATE TABLE categories (pkg text NOT NULL, category text NOT NULL)");
 
 	return (MPORT_OK);
@@ -302,61 +299,61 @@ mport_upgrade_master_schema(sqlite3 *db, int databaseVersion)
 		return MPORT_OK;
 
 	switch (databaseVersion) {
-		case 0:
-		case 1:
-			mport_upgrade_master_schema_0to2(db);
-			mport_upgrade_master_schema_2to3(db);
-			mport_upgrade_master_schema_4to6(db);
-			mport_upgrade_master_schema_6to7(db);
-			mport_upgrade_master_schema_7to8(db);
-			mport_upgrade_master_schema_8to9(db);
-			mport_upgrade_master_schema_9to10(db);
-			mport_upgrade_master_schema_10to11(db);
-			mport_upgrade_master_schema_11to12(db);
-			mport_upgrade_master_schema_12to13(db);
-			mport_upgrade_master_schema_13to14(db);
-			mport_set_database_version(db);
-			break;
-		case 2:
-			mport_upgrade_master_schema_2to3(db);
-			/* falls through */
-		case 3:
-			mport_upgrade_master_schema_3to4(db);
-			/* falls through */
-		case 4:
-			/* falls through */
-		case 5:
-			mport_upgrade_master_schema_4to6(db);
-			/* falls through */
-		case 6:
-			/* falls through */
-			mport_upgrade_master_schema_6to7(db);
-		case 7:
-			/* falls through */
-            mport_upgrade_master_schema_7to8(db);
-        case 8:
-	        /* falls through */
-	        mport_upgrade_master_schema_8to9(db);
-		case 9:
-			/* falls through */
-	        mport_upgrade_master_schema_9to10(db);
-		case 10:
-			/* falls through */
-			mport_upgrade_master_schema_10to11(db);
-		case 11:
-			/* falls through */
-            mport_upgrade_master_schema_11to12(db);
-		case 12:
-		    /* falls through */
-			mport_upgrade_master_schema_12to13(db);
-		case 13:
-		    /* falls through */
-			mport_upgrade_master_schema_13to14(db);
-			mport_set_database_version(db);
-		case 14:
-			break;
-		default:
-			RETURN_ERROR(MPORT_ERR_FATAL, "Invalid master database version");
+	case 0:
+	case 1:
+		mport_upgrade_master_schema_0to2(db);
+		mport_upgrade_master_schema_2to3(db);
+		mport_upgrade_master_schema_4to6(db);
+		mport_upgrade_master_schema_6to7(db);
+		mport_upgrade_master_schema_7to8(db);
+		mport_upgrade_master_schema_8to9(db);
+		mport_upgrade_master_schema_9to10(db);
+		mport_upgrade_master_schema_10to11(db);
+		mport_upgrade_master_schema_11to12(db);
+		mport_upgrade_master_schema_12to13(db);
+		mport_upgrade_master_schema_13to14(db);
+		mport_set_database_version(db);
+		break;
+	case 2:
+		mport_upgrade_master_schema_2to3(db);
+		/* falls through */
+	case 3:
+		mport_upgrade_master_schema_3to4(db);
+		/* falls through */
+	case 4:
+		/* falls through */
+	case 5:
+		mport_upgrade_master_schema_4to6(db);
+		/* falls through */
+	case 6:
+		/* falls through */
+		mport_upgrade_master_schema_6to7(db);
+	case 7:
+		/* falls through */
+		mport_upgrade_master_schema_7to8(db);
+	case 8:
+		/* falls through */
+		mport_upgrade_master_schema_8to9(db);
+	case 9:
+		/* falls through */
+		mport_upgrade_master_schema_9to10(db);
+	case 10:
+		/* falls through */
+		mport_upgrade_master_schema_10to11(db);
+	case 11:
+		/* falls through */
+		mport_upgrade_master_schema_11to12(db);
+	case 12:
+		/* falls through */
+		mport_upgrade_master_schema_12to13(db);
+	case 13:
+		/* falls through */
+		mport_upgrade_master_schema_13to14(db);
+		mport_set_database_version(db);
+	case 14:
+		break;
+	default:
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid master database version");
 	}
 
 	return (MPORT_OK);
@@ -416,15 +413,14 @@ mport_upgrade_master_schema_6to7(sqlite3 *db)
 	return (MPORT_OK);
 }
 
-
 static int
 mport_upgrade_master_schema_7to8(sqlite3 *db)
 {
-    RUN_SQL(db, "ALTER TABLE packages ADD COLUMN automatic int");
+	RUN_SQL(db, "ALTER TABLE packages ADD COLUMN automatic int");
 
-    RUN_SQL(db, "update packages set automatic = 0");
+	RUN_SQL(db, "update packages set automatic = 0");
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 static int
@@ -460,8 +456,12 @@ mport_upgrade_master_schema_10to11(sqlite3 *db)
 static int
 mport_upgrade_master_schema_11to12(sqlite3 *db)
 {
-	RUN_SQL(db, "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_HANDLE_RC_SCRIPTS "\", \"yes\")");
-	RUN_SQL(db, "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_REPO_AUTOUPDATE "\", \"yes\")");
+	RUN_SQL(db,
+	    "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_HANDLE_RC_SCRIPTS
+	    "\", \"yes\")");
+	RUN_SQL(db,
+	    "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_REPO_AUTOUPDATE
+	    "\", \"yes\")");
 
 	return (MPORT_OK);
 }
@@ -469,11 +469,13 @@ mport_upgrade_master_schema_11to12(sqlite3 *db)
 static int
 mport_upgrade_master_schema_12to13(sqlite3 *db)
 {
-	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
+	RUN_SQL(db,
+	    "CREATE TABLE IF NOT EXISTS conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS conflicts_pkg ON conflicts (pkg, conflict_pkg)");
 	RUN_SQL(db, "DROP INDEX IF EXISTS settings_name");
 	RUN_SQL(db, "BEGIN TRANSACTION;");
-	RUN_SQL(db, "CREATE TABLE temp_settings AS SELECT MIN(rowid) as rowid, name, val FROM settings GROUP BY name;");
+	RUN_SQL(db,
+	    "CREATE TABLE temp_settings AS SELECT MIN(rowid) as rowid, name, val FROM settings GROUP BY name;");
 	RUN_SQL(db, "DELETE FROM settings WHERE rowid NOT IN (SELECT rowid FROM temp_settings);");
 	RUN_SQL(db, "DROP TABLE temp_settings;");
 	RUN_SQL(db, "COMMIT;");
@@ -485,7 +487,8 @@ mport_upgrade_master_schema_12to13(sqlite3 *db)
 static int
 mport_upgrade_master_schema_13to14(sqlite3 *db)
 {
-	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS annotation (pkg text NOT NULL, tag TEXT NOT NULL, val TEXT NOT NULL, PRIMARY KEY (pkg, tag))");
+	RUN_SQL(db,
+	    "CREATE TABLE IF NOT EXISTS annotation (pkg text NOT NULL, tag TEXT NOT NULL, val TEXT NOT NULL, PRIMARY KEY (pkg, tag))");
 
 	return (MPORT_OK);
 }
@@ -495,37 +498,44 @@ mport_generate_master_schema(sqlite3 *db)
 {
 
 	RUN_SQL(db,
-	        "CREATE TABLE IF NOT EXISTS packages (pkg text NOT NULL, version text NOT NULL, origin text NOT NULL, prefix text NOT NULL, lang text, options text, status text default 'dirty', comment text, os_release text NOT NULL default '1.0', cpe text, locked int NOT NULL default '0', deprecated text default '', expiration_date int64 NOT NULL default '0', no_provide_shlib int default '0', flavor text default '', automatic int default '0', install_date int64 NOT NULL default '0', type int NOT NULL default '0', flatsize int64 NOT NULL default '0')");
+	    "CREATE TABLE IF NOT EXISTS packages (pkg text NOT NULL, version text NOT NULL, origin text NOT NULL, prefix text NOT NULL, lang text, options text, status text default 'dirty', comment text, os_release text NOT NULL default '1.0', cpe text, locked int NOT NULL default '0', deprecated text default '', expiration_date int64 NOT NULL default '0', no_provide_shlib int default '0', flavor text default '', automatic int default '0', install_date int64 NOT NULL default '0', type int NOT NULL default '0', flatsize int64 NOT NULL default '0')");
 	RUN_SQL(db, "CREATE UNIQUE INDEX IF NOT EXISTS packages_pkg ON packages (pkg)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS packages_origin ON packages (origin)");
 
 	RUN_SQL(db,
-	        "CREATE TABLE IF NOT EXISTS depends (pkg text NOT NULL, depend_pkgname text NOT NULL, depend_pkgversion text, depend_port text NOT NULL)");
+	    "CREATE TABLE IF NOT EXISTS depends (pkg text NOT NULL, depend_pkgname text NOT NULL, depend_pkgversion text, depend_port text NOT NULL)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS depends_pkg ON depends (pkg)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS depends_dependpkgname ON depends (depend_pkgname)");
 
 	RUN_SQL(db,
-	        "CREATE TABLE IF NOT EXISTS log (pkg text NOT NULL, version text NOT NULL, date int NOT NULL, msg text NOT NULL)");
+	    "CREATE TABLE IF NOT EXISTS log (pkg text NOT NULL, version text NOT NULL, date int NOT NULL, msg text NOT NULL)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS log_pkg ON log (pkg, version)");
 
 	RUN_SQL(db,
-	        "CREATE TABLE IF NOT EXISTS assets (pkg text NOT NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text)");
+	    "CREATE TABLE IF NOT EXISTS assets (pkg text NOT NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS assets_pkg ON assets (pkg)");
 
-	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS categories (pkg text NOT NULL, category text NOT NULL)");
+	RUN_SQL(db,
+	    "CREATE TABLE IF NOT EXISTS categories (pkg text NOT NULL, category text NOT NULL)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS categories_pkg ON categories (pkg, category)");
 
-	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
+	RUN_SQL(db,
+	    "CREATE TABLE IF NOT EXISTS conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL)");
 	RUN_SQL(db, "CREATE INDEX IF NOT EXISTS conflicts_pkg ON conflicts (pkg, conflict_pkg)");
 
 	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS settings (name text NOT NULL, val text NOT NULL)");
 	RUN_SQL(db, "CREATE UNIQUE INDEX IF NOT EXISTS settings_name_unique ON settings (name)");
 
-	RUN_SQL(db, "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_HANDLE_RC_SCRIPTS "\", \"yes\")");
-	RUN_SQL(db, "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_REPO_AUTOUPDATE "\", \"yes\")");
+	RUN_SQL(db,
+	    "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_HANDLE_RC_SCRIPTS
+	    "\", \"yes\")");
+	RUN_SQL(db,
+	    "INSERT OR IGNORE INTO settings VALUES (\"" MPORT_SETTING_REPO_AUTOUPDATE
+	    "\", \"yes\")");
 
-	RUN_SQL(db, "CREATE TABLE IF NOT EXISTS annotation (pkg text NOT NULL, tag TEXT NOT NULL, val TEXT NOT NULL, PRIMARY KEY (pkg, tag))");
-	
+	RUN_SQL(db,
+	    "CREATE TABLE IF NOT EXISTS annotation (pkg text NOT NULL, tag TEXT NOT NULL, val TEXT NOT NULL, PRIMARY KEY (pkg, tag))");
+
 	mport_set_database_version(db);
 
 	return (MPORT_OK);

--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -38,237 +38,239 @@
 #include "mport.h"
 #include "mport_private.h"
 
-#define KNRM  "\x1B[0m"
-#define KRED  "\x1B[31m"
-#define KGRN  "\x1B[32m"
-#define KYEL  "\x1B[33m"
-#define KBLU  "\x1B[34m"
-#define KMAG  "\x1B[35m"
-#define KCYN  "\x1B[36m"
-#define KWHT  "\x1B[37m"
+#define KNRM "\x1B[0m"
+#define KRED "\x1B[31m"
+#define KGRN "\x1B[32m"
+#define KYEL "\x1B[33m"
+#define KBLU "\x1B[34m"
+#define KMAG "\x1B[35m"
+#define KCYN "\x1B[36m"
+#define KWHT "\x1B[37m"
 
-void mport_default_msg_cb(const char *msg) 
+void
+mport_default_msg_cb(const char *msg)
 {
-  (void)printf("%s\n", msg);
+	(void)printf("%s\n", msg);
 }
 
-bool mport_is_terminal(void) {
-    const char *term = getenv("TERM");
-    const char *magus = getenv("MAGUS");
-    return (magus == NULL && term != NULL && isatty(fileno(stdout)));
+bool
+mport_is_terminal(void)
+{
+	const char *term = getenv("TERM");
+	const char *magus = getenv("MAGUS");
+	return (magus == NULL && term != NULL && isatty(fileno(stdout)));
 }
 
-bool mport_is_color_terminal(void)
+bool
+mport_is_color_terminal(void)
 {
-  const char *term = getenv("TERM");
-  const char *colorterm = getenv("COLORTERM");
-  const char *clicolor = getenv("CLICOLOR");
+	const char *term = getenv("TERM");
+	const char *colorterm = getenv("COLORTERM");
+	const char *clicolor = getenv("CLICOLOR");
 
-  if (!mport_is_terminal()) {
-    return false; // Not a terminal or TERM not set
-  }
+	if (!mport_is_terminal()) {
+		return false; // Not a terminal or TERM not set
+	}
 
-  // Check if the terminal supports colors
-  bool term_supports_color =
-    strcmp(term, "dumb") != 0 &&
-    strcmp(term, "cons25") != 0;
+	// Check if the terminal supports colors
+	bool term_supports_color = strcmp(term, "dumb") != 0 && strcmp(term, "cons25") != 0;
 
-  bool term_is_256color =
-    strcmp(term, "xterm-256color") == 0 ||
-    strcmp(term, "screen-256color") == 0 ||
-    strcmp(term, "tmux-256color") == 0;
+	bool term_is_256color = strcmp(term, "xterm-256color") == 0 ||
+	    strcmp(term, "screen-256color") == 0 || strcmp(term, "tmux-256color") == 0;
 
-  bool colorterm_support =
-    colorterm != NULL &&
-    (strcmp(colorterm, "truecolor") == 0 ||
-     strcmp(colorterm, "24bit") == 0 ||
-     strcmp(colorterm, "yes") == 0);
-  bool clicolor_support = clicolor != NULL;
-  
-  return colorterm_support || term_supports_color || term_is_256color || clicolor_support;
+	bool colorterm_support = colorterm != NULL &&
+	    (strcmp(colorterm, "truecolor") == 0 || strcmp(colorterm, "24bit") == 0 ||
+		strcmp(colorterm, "yes") == 0);
+	bool clicolor_support = clicolor != NULL;
+
+	return colorterm_support || term_supports_color || term_is_256color || clicolor_support;
 }
 
-int mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int def)
+int
+mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int def)
 {
-  size_t len;
-  char *ans;
-  bool color_terminal = mport_is_color_terminal();
-  
-  if (getenv("ASSUME_ALWAYS_YES") != NULL || getenv("MAGUS") != NULL) {
-    return (MPORT_OK);
-  }
+	size_t len;
+	char *ans;
+	bool color_terminal = mport_is_color_terminal();
 
-  if(color_terminal) {
-    (void)fprintf(stderr, "%s%s (Y/N) [%s]:%s ", KCYN, msg, def == 1 ? yes : no, KNRM);
-  } else {
-    (void)fprintf(stderr, "%s (Y/N) [%s]: ", msg, def == 1 ? yes : no);
-  }
-  
-  while (1) {
-    /* get answer, if just \n, then default. */
-    ans = fgetln(stdin, &len);
-    if (ans == NULL) {
-      mport_set_errx(MPORT_ERR_FATAL, "Unable to read confirmation response.");
-      return mport_err_code();
-    }
+	if (getenv("ASSUME_ALWAYS_YES") != NULL || getenv("MAGUS") != NULL) {
+		return (MPORT_OK);
+	}
 
-    if (len == 1) { 
-      /* user just hit return */
-      return def == 1 ? MPORT_OK : -1;
-    }  
+	if (color_terminal) {
+		(void)fprintf(stderr, "%s%s (Y/N) [%s]:%s ", KCYN, msg, def == 1 ? yes : no, KNRM);
+	} else {
+		(void)fprintf(stderr, "%s (Y/N) [%s]: ", msg, def == 1 ? yes : no);
+	}
 
-    bool answer = mport_check_answer_bool(ans);
-    
-    if (answer) 
-      return (MPORT_OK);
-    if (*ans == 'N' || *ans == 'n')
-      return (-1);
-    
-    if (color_terminal) {
-      (void)fprintf(stderr, "%sPlease enter yes or no:%s ", KRED, KNRM);
-    } else {  
-      (void)fprintf(stderr, "Please enter yes or no: ");   
-    }
-  }
-  
-  /* Not reached */
-  return (MPORT_OK);
+	while (1) {
+		/* get answer, if just \n, then default. */
+		ans = fgetln(stdin, &len);
+		if (ans == NULL) {
+			mport_set_errx(MPORT_ERR_FATAL, "Unable to read confirmation response.");
+			return mport_err_code();
+		}
+
+		if (len == 1) {
+			/* user just hit return */
+			return def == 1 ? MPORT_OK : -1;
+		}
+
+		bool answer = mport_check_answer_bool(ans);
+
+		if (answer)
+			return (MPORT_OK);
+		if (*ans == 'N' || *ans == 'n')
+			return (-1);
+
+		if (color_terminal) {
+			(void)fprintf(stderr, "%sPlease enter yes or no:%s ", KRED, KNRM);
+		} else {
+			(void)fprintf(stderr, "Please enter yes or no: ");
+		}
+	}
+
+	/* Not reached */
+	return (MPORT_OK);
 }
 
 int
 mport_default_select_cb(const char *msg, mportIndexEntry **choices, int def)
 {
-  size_t len;
-  char *ans;
-  char *endptr;
-  int count = 0;
-  bool color_terminal = mport_is_color_terminal();
+	size_t len;
+	char *ans;
+	char *endptr;
+	int count = 0;
+	bool color_terminal = mport_is_color_terminal();
 
-  if (choices == NULL || *choices == NULL)
-    return -1;
+	if (choices == NULL || *choices == NULL)
+		return -1;
 
-  while (choices[count] != NULL) {
-    count++;
-  }
+	while (choices[count] != NULL) {
+		count++;
+	}
 
-  if (getenv("ASSUME_ALWAYS_YES") != NULL || getenv("MAGUS") != NULL) {
-    return def >= 0 ? def : 0;
-  }
+	if (getenv("ASSUME_ALWAYS_YES") != NULL || getenv("MAGUS") != NULL) {
+		return def >= 0 ? def : 0;
+	}
 
-  if (color_terminal) {
-    (void)fprintf(stderr, "%s%s%s\n", KCYN, msg, KNRM);
-  } else {
-    (void)fprintf(stderr, "%s\n", msg);
-  }
+	if (color_terminal) {
+		(void)fprintf(stderr, "%s%s%s\n", KCYN, msg, KNRM);
+	} else {
+		(void)fprintf(stderr, "%s\n", msg);
+	}
 
-  for (int i = 0; i < count; i++) {
-    const char *comment = choices[i]->comment == NULL ? "" : choices[i]->comment;
-    (void)fprintf(stderr, " %d. %s-%s%s%s\n", i + 1,
-        choices[i]->pkgname, choices[i]->version,
-        comment[0] == '\0' ? "" : " - ", comment);
-  }
+	for (int i = 0; i < count; i++) {
+		const char *comment = choices[i]->comment == NULL ? "" : choices[i]->comment;
+		(void)fprintf(stderr, " %d. %s-%s%s%s\n", i + 1, choices[i]->pkgname,
+		    choices[i]->version, comment[0] == '\0' ? "" : " - ", comment);
+	}
 
-  while (1) {
-    if (color_terminal) {
-      (void)fprintf(stderr, "%sSelect package [1-%d]%s: ", KCYN, count, KNRM);
-    } else {
-      (void)fprintf(stderr, "Select package [1-%d]: ", count);
-    }
+	while (1) {
+		if (color_terminal) {
+			(void)fprintf(stderr, "%sSelect package [1-%d]%s: ", KCYN, count, KNRM);
+		} else {
+			(void)fprintf(stderr, "Select package [1-%d]: ", count);
+		}
 
-    ans = fgetln(stdin, &len);
-    if (ans == NULL)
-      return -1;
-    if (len == 1)
-      return def;
+		ans = fgetln(stdin, &len);
+		if (ans == NULL)
+			return -1;
+		if (len == 1)
+			return def;
 
-    errno = 0;
-    long choice = strtol(ans, &endptr, 10);
-    while (endptr != NULL && (*endptr == '\n' || *endptr == '\r' || *endptr == ' ' || *endptr == '\t'))
-      endptr++;
+		errno = 0;
+		long choice = strtol(ans, &endptr, 10);
+		while (endptr != NULL &&
+		    (*endptr == '\n' || *endptr == '\r' || *endptr == ' ' || *endptr == '\t'))
+			endptr++;
 
-    if (errno == 0 && endptr != ans && (*endptr == '\0' || *endptr == '\n') &&
-        choice >= 1 && choice <= count) {
-      return (int)choice - 1;
-    }
+		if (errno == 0 && endptr != ans && (*endptr == '\0' || *endptr == '\n') &&
+		    choice >= 1 && choice <= count) {
+			return (int)choice - 1;
+		}
 
-    if (color_terminal) {
-      (void)fprintf(stderr, "%sPlease enter a number between 1 and %d.%s\n", KRED, count, KNRM);
-    } else {
-      (void)fprintf(stderr, "Please enter a number between 1 and %d.\n", count);
-    }
-  }
+		if (color_terminal) {
+			(void)fprintf(stderr, "%sPlease enter a number between 1 and %d.%s\n", KRED,
+			    count, KNRM);
+		} else {
+			(void)fprintf(stderr, "Please enter a number between 1 and %d.\n", count);
+		}
+	}
 }
 
-
-void mport_default_progress_init_cb(const char *title)
+void
+mport_default_progress_init_cb(const char *title)
 {
-  /* do nothing */
-  (void)puts(title);
-  return;
+	/* do nothing */
+	(void)puts(title);
+	return;
 }
-
 
 #define ESC "\x1b"
 #define BACK ESC "[%iD"
-#define UP   ESC "[A"
-#define DEL  ESC "[2K"
+#define UP ESC "[A"
+#define DEL ESC "[2K"
 
-void mport_default_progress_step_cb(int current, int total, const char *msg)
+void
+mport_default_progress_step_cb(int current, int total, const char *msg)
 {
-  struct termios term;
-  struct winsize win;
-  int width, bar_width, bar_on, bar_off;
-  double percent;
-  char *bar = NULL;
+	struct termios term;
+	struct winsize win;
+	int width, bar_width, bar_on, bar_off;
+	double percent;
+	char *bar = NULL;
 
-  if (current > total)
-    current = total;
+	if (current > total)
+		current = total;
 
-  if (!mport_is_terminal() || (tcgetattr(STDIN_FILENO, &term) < 0) || (ioctl(STDIN_FILENO, TIOCGWINSZ, &win) < 0)) {
-    /* not a terminal or couldn't get terminal width*/
-    (void)printf("%s\n", msg);
-    return;
-  }
+	if (!mport_is_terminal() || (tcgetattr(STDIN_FILENO, &term) < 0) ||
+	    (ioctl(STDIN_FILENO, TIOCGWINSZ, &win) < 0)) {
+		/* not a terminal or couldn't get terminal width*/
+		(void)printf("%s\n", msg);
+		return;
+	}
 
-  width = win.ws_col;
-  if (width > 10) {
-    bar_width = width - 10;
-  } else {
-    bar_width = 10;
-  }
+	width = win.ws_col;
+	if (width > 10) {
+		bar_width = width - 10;
+	} else {
+		bar_width = 10;
+	}
 
-	  if ((bar = (char *)calloc((size_t)bar_width + 1, sizeof(char))) == NULL) {
-	    /* no memory, we're outa here */
-	    (void)printf("%s\n", msg);
-	    return;
-  }
+	if ((bar = (char *)calloc((size_t)bar_width + 1, sizeof(char))) == NULL) {
+		/* no memory, we're outa here */
+		(void)printf("%s\n", msg);
+		return;
+	}
 
-  percent = (double)current / (double)total;
-  
-  bar_on = (int)(percent * (bar_width - 2));
-  bar_off = bar_width - 2 - bar_on;
+	percent = (double)current / (double)total;
 
-  bar[0] = '[';
-  (void)memset(&(bar[1]), '=', bar_on);
-  (void)memset(&(bar[1 + bar_on]), ' ', bar_off);
-  bar[1 + bar_on + bar_off] = ']';
-  bar[2 + bar_on + bar_off] = 0;
-  
-  (void)printf(BACK DEL, width);
-//  (void)printf("%s\n", msg);
-  if (mport_is_color_terminal()) {
-    (void)printf("%s%s %3i/100%%%s", KCYN, bar, (int)(percent * 100), KNRM);
-  } else {
-    (void)printf("%s %3i/100%%", bar, (int)(percent * 100));
-  }
-  (void)fflush(stdout);
-  
-  free(bar);
-  bar = NULL;
+	bar_on = (int)(percent * (bar_width - 2));
+	bar_off = bar_width - 2 - bar_on;
+
+	bar[0] = '[';
+	(void)memset(&(bar[1]), '=', bar_on);
+	(void)memset(&(bar[1 + bar_on]), ' ', bar_off);
+	bar[1 + bar_on + bar_off] = ']';
+	bar[2 + bar_on + bar_off] = 0;
+
+	(void)printf(BACK DEL, width);
+	//  (void)printf("%s\n", msg);
+	if (mport_is_color_terminal()) {
+		(void)printf("%s%s %3i/100%%%s", KCYN, bar, (int)(percent * 100), KNRM);
+	} else {
+		(void)printf("%s %3i/100%%", bar, (int)(percent * 100));
+	}
+	(void)fflush(stdout);
+
+	free(bar);
+	bar = NULL;
 }
 
-void mport_default_progress_free_cb(void) 
+void
+mport_default_progress_free_cb(void)
 {
-  (void)printf("\n");
-  (void)fflush(stdout);
+	(void)printf("\n");
+	(void)fflush(stdout);
 }

--- a/libmport/delete_primative.c
+++ b/libmport/delete_primative.c
@@ -74,19 +74,35 @@ static bool is_safe_to_delete_dir(mportInstance *, mportPackageMeta *, const cha
 static bool is_system_dir(const char *path);
 
 static const char *system_dirs[] = {
-	"/boot", 
-	_PATH_ETC, "/etc/rc.d", 
+	"/boot",
+	_PATH_ETC,
+	"/etc/rc.d",
 	"/root",
 	_PATH_TMP,
-    "/usr/lib", "/usr/bin", "/usr/sbin", _PATH_MAN, _PATH_LOCALE, _PATH_FIRMWARE,
-    "/usr/share", 
-	"/usr/local", "/usr/local/bin", "/usr/local/sbin",
-	"/usr/local/share", "/usr/local/lib", "/usr/local/libexec",
-    "/usr/local/include", 
-	"/var", "/var/lib", "/var/log", "/var/spool", "/var/empty", 
-	_PATH_VARDB, _PATH_VARRUN, _PATH_VARTMP, _PATH_MAILDIR,
+	"/usr/lib",
+	"/usr/bin",
+	"/usr/sbin",
+	_PATH_MAN,
+	_PATH_LOCALE,
+	_PATH_FIRMWARE,
+	"/usr/share",
+	"/usr/local",
+	"/usr/local/bin",
+	"/usr/local/sbin",
+	"/usr/local/share",
+	"/usr/local/lib",
+	"/usr/local/libexec",
+	"/usr/local/include",
+	"/var",
+	"/var/lib",
+	"/var/log",
+	"/var/spool",
+	"/var/empty",
+	_PATH_VARDB,
+	_PATH_VARRUN,
+	_PATH_VARTMP,
+	_PATH_MAILDIR,
 };
-
 
 MPORT_PUBLIC_API int
 mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
@@ -260,19 +276,30 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 							if (fileargv[1] != NULL) {
 								/* Case 2: @sample src dest */
 								if (fileargv[1][0] == '/')
-									strlcpy(dest_path, fileargv[1], FILENAME_MAX);
+									strlcpy(dest_path,
+									    fileargv[1],
+									    FILENAME_MAX);
 								else
-									(void) snprintf(dest_path, FILENAME_MAX, "%s%s/%s", mport->root, cwd, fileargv[1]);
+									(void)snprintf(dest_path,
+									    FILENAME_MAX, "%s%s/%s",
+									    mport->root, cwd,
+									    fileargv[1]);
 								dest_path_set = true;
 							} else if (fileargv[0] != NULL) {
 								/* Case 1: @sample file.sample */
 								char nonSample[FILENAME_MAX];
-								strlcpy(nonSample, file, FILENAME_MAX);
-								
-								char *sptr = strcasestr(nonSample, ".sample");
+								strlcpy(
+								    nonSample, file, FILENAME_MAX);
+
+								char *sptr = strcasestr(
+								    nonSample, ".sample");
 								if (sptr != NULL) {
-									sptr[0] = '\0'; /* hack off .sample */
-									strlcpy(dest_path, nonSample, FILENAME_MAX);
+									sptr[0] =
+									    '\0'; /* hack off
+										     .sample */
+									strlcpy(dest_path,
+									    nonSample,
+									    FILENAME_MAX);
 									dest_path_set = true;
 								}
 							}
@@ -284,20 +311,28 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 					if (dest_path_set && mport_file_exists(dest_path)) {
 						bool hashes_match = false;
 						if (strlen(checksum) < 34) {
-							if (MD5File(dest_path, sample_hash) != NULL && strcmp(sample_hash, hash) == 0) {
+							if (MD5File(dest_path, sample_hash) !=
+								NULL &&
+							    strcmp(sample_hash, hash) == 0) {
 								hashes_match = true;
 							}
 						} else {
-							if (SHA256_File(dest_path, sample_hash) != NULL && strcmp(sample_hash, hash) == 0) {
+							if (SHA256_File(dest_path, sample_hash) !=
+								NULL &&
+							    strcmp(sample_hash, hash) == 0) {
 								hashes_match = true;
 							}
 						}
 
 						if (hashes_match) {
 							if (unlink(dest_path) != 0)
-								mport_call_msg_cb(mport, "Could not unlink %s: %s", dest_path, strerror(errno));
+								mport_call_msg_cb(mport,
+								    "Could not unlink %s: %s",
+								    dest_path, strerror(errno));
 						} else {
-							mport_call_msg_cb(mport, "File does not match sample, remove file %s manually.", dest_path);
+							mport_call_msg_cb(mport,
+							    "File does not match sample, remove file %s manually.",
+							    dest_path);
 						}
 					}
 				}
@@ -334,11 +369,13 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 			if (is_safe_to_delete_dir(mport, pack, file)) {
 				mport_removeflags(mport->root, file);
 				if (mport_rmdir(file, type == ASSET_DIRRMTRY ? 1 : 0) != MPORT_OK) {
-					mport_call_msg_cb(mport, "Could not remove directory '%s': %s",
-				    	file, mport_err_string());
+					mport_call_msg_cb(mport,
+					    "Could not remove directory '%s': %s", file,
+					    mport_err_string());
 				}
 			} else if (type != ASSET_DIRRMTRY) {
-				mport_call_msg_cb(mport, "Directory in use by another package? '%s'", file);
+				mport_call_msg_cb(
+				    mport, "Directory in use by another package? '%s'", file);
 			}
 
 			break;
@@ -403,31 +440,36 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 	return (MPORT_OK);
 }
 
-static bool is_system_dir(const char *path) {
-    for (size_t i = 0; i < sizeof(system_dirs) / sizeof(system_dirs[0]); i++) {
-        if (strcmp(path, system_dirs[i]) == 0) {
-            return true;
-        }
-    }
-    return false;
+static bool
+is_system_dir(const char *path)
+{
+	for (size_t i = 0; i < sizeof(system_dirs) / sizeof(system_dirs[0]); i++) {
+		if (strcmp(path, system_dirs[i]) == 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
-bool is_safe_to_delete_dir(mportInstance *mport, mportPackageMeta *pack, const char *path) 
+bool
+is_safe_to_delete_dir(mportInstance *mport, mportPackageMeta *pack, const char *path)
 {
 	sqlite3_stmt *stmt;
 	int count;
-    
+
 	if (mport == NULL || pack == NULL || path == NULL) {
 		return false;
 	}
 
 	/* Don't delete the root or the package prefix directories */
 	if (mport->root != NULL && strcmp(mport->root, path) == 0) {
-		mport_call_msg_cb(mport, "Skipping removal of root (DESTDIR) directory: '%s'", path);
+		mport_call_msg_cb(
+		    mport, "Skipping removal of root (DESTDIR) directory: '%s'", path);
 		return false;
 	}
 	if (pack->prefix != NULL && strcmp(pack->prefix, path) == 0) {
-		mport_call_msg_cb(mport, "Skipping removal of package prefix directory: '%s'", path);
+		mport_call_msg_cb(
+		    mport, "Skipping removal of package prefix directory: '%s'", path);
 		return false;
 	}
 
@@ -435,11 +477,12 @@ bool is_safe_to_delete_dir(mportInstance *mport, mportPackageMeta *pack, const c
 	if (pack->type == MPORT_TYPE_APP && is_system_dir(path)) {
 		mport_call_msg_cb(mport, "Skipping removal of system directory: '%s'", path);
 		return false;
-	}	
+	}
 
 	if (mport_db_prepare(mport->db, &stmt,
 		"SELECT count(*) from assets where pkg!=%Q and type in (%d, %d, %d, %d) and data=%Q",
-		pack->name, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE, path) != MPORT_OK) {
+		pack->name, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
+		path) != MPORT_OK) {
 		return false;
 	}
 
@@ -500,18 +543,19 @@ run_unldconfig(mportInstance *mport, mportPackageMeta *pkg)
 				goto UNLDCONFIG_ERROR;
 			}
 			break;
-			case ASSET_LDCONFIG_LINUX:
-				if (data == NULL) {
-					if (mport_xsystem(mport, "/compat/linux/sbin/ldconfig") !=
-					    MPORT_OK) {
-						goto UNLDCONFIG_ERROR;
-					}
-				} else {
-					if (mport_exec_linux_ldconfig(mport, (const char *)data) != MPORT_OK) {
-						goto UNLDCONFIG_ERROR;
-					}
+		case ASSET_LDCONFIG_LINUX:
+			if (data == NULL) {
+				if (mport_xsystem(mport, "/compat/linux/sbin/ldconfig") !=
+				    MPORT_OK) {
+					goto UNLDCONFIG_ERROR;
 				}
-				break;
+			} else {
+				if (mport_exec_linux_ldconfig(mport, (const char *)data) !=
+				    MPORT_OK) {
+					goto UNLDCONFIG_ERROR;
+				}
+			}
+			break;
 		default:
 			break;
 		}
@@ -564,33 +608,34 @@ run_special_unexec(mportInstance *mport, mportPackageMeta *pkg)
 		data = sqlite3_column_text(assets, 1);
 
 		switch (type) {
-			case ASSET_GLIB_SCHEMAS:
-				if (mport_file_exists("/usr/local/bin/glib-compile-schemas") &&
-				    mport_exec_glib_compile_schemas(mport, data == NULL ? pkg->prefix : (const char *)data) != MPORT_OK) {
-					goto SPECIAL_ERROR;
-				}
-				break;
+		case ASSET_GLIB_SCHEMAS:
+			if (mport_file_exists("/usr/local/bin/glib-compile-schemas") &&
+			    mport_exec_glib_compile_schemas(mport,
+				data == NULL ? pkg->prefix : (const char *)data) != MPORT_OK) {
+				goto SPECIAL_ERROR;
+			}
+			break;
 		case ASSET_INFO:
 			if (data != NULL) {
 				strlcpy(in, data, sizeof(in));
 			} else {
 				strlcpy(in, "/usr/local/share/info", sizeof(in));
 			}
-				char *abs_path = realpath(in, NULL);
-				if (abs_path == NULL)
-					goto SPECIAL_ERROR;
-				char *info_dir = dirname(abs_path);
-				if (info_dir != NULL && mport_file_exists("/usr/local/bin/indexinfo") &&
-				    mport_exec_indexinfo(mport, info_dir) != MPORT_OK) {
-					free(abs_path);
-					goto SPECIAL_ERROR;
-				}
+			char *abs_path = realpath(in, NULL);
+			if (abs_path == NULL)
+				goto SPECIAL_ERROR;
+			char *info_dir = dirname(abs_path);
+			if (info_dir != NULL && mport_file_exists("/usr/local/bin/indexinfo") &&
+			    mport_exec_indexinfo(mport, info_dir) != MPORT_OK) {
 				free(abs_path);
-				break;
-			case ASSET_KLD:
-				if (mport_exec_kldxref(mport, (const char *)data) != MPORT_OK) {
-					goto SPECIAL_ERROR;
-				}
+				goto SPECIAL_ERROR;
+			}
+			free(abs_path);
+			break;
+		case ASSET_KLD:
+			if (mport_exec_kldxref(mport, (const char *)data) != MPORT_OK) {
+				goto SPECIAL_ERROR;
+			}
 			/* attempt to remove the directory containing the kernel
 			 * module, if it's not /boot/modules */
 			if (strcmp("/boot/modules", data) != 0 &&
@@ -703,40 +748,37 @@ delete_pkg_infra(mportInstance *mport, mportPackageMeta *pack)
 {
 	char dir[FILENAME_MAX];
 	char file[FILENAME_MAX];
-	
+
 	/* delete mtree file */
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-	                pack->version,
-	                MPORT_MTREE_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_MTREE_FILE);
 
 	if (mport_file_exists(file) && unlink(file) != 0)
-		mport_call_msg_cb(
-		    mport, "Could not unlink %s: %s", file, strerror(errno));
+		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
 
 	/* delete pkg message file */
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-                    pack->version, MPORT_MESSAGE_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_MESSAGE_FILE);
 	if (mport_file_exists(file) && unlink(file) != 0)
-		mport_call_msg_cb(
-		    mport, "Could not unlink %s: %s", file, strerror(errno));
+		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
 
 	/* delete lua files */
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-		pack->version, MPORT_LUA_POST_INSTALL_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_LUA_POST_INSTALL_FILE);
 	if (mport_file_exists(file) && unlink(file) != 0)
 		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-		pack->version, MPORT_LUA_PRE_INSTALL_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_LUA_PRE_INSTALL_FILE);
 	if (mport_file_exists(file) && unlink(file) != 0)
 		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-		pack->version, MPORT_LUA_POST_DEINSTALL_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_LUA_POST_DEINSTALL_FILE);
 	if (mport_file_exists(file) && unlink(file) != 0)
 		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
-	(void) snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR, pack->name,
-		pack->version, MPORT_LUA_PRE_DEINSTALL_FILE);
+	(void)snprintf(file, FILENAME_MAX, "%s%s/%s-%s/%s", mport->root, MPORT_STUB_INFRA_DIR,
+	    pack->name, pack->version, MPORT_LUA_PRE_DEINSTALL_FILE);
 	if (mport_file_exists(file) && unlink(file) != 0)
-		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));	
+		mport_call_msg_cb(mport, "Could not unlink %s: %s", file, strerror(errno));
 
 	(void)snprintf(dir, FILENAME_MAX, "%s%s/%s-%s", mport->root, MPORT_INST_INFRA_DIR,
 	    pack->name, pack->version);

--- a/libmport/error.c
+++ b/libmport/error.c
@@ -38,25 +38,25 @@ static char err_msg[256];
 /* This goes with the error codes in mport.h */
 static char default_error_msg[] = "An error occurred.";
 
-
 /* mport_err_code()
  *
- * Return the current numeric error code. 
+ * Return the current numeric error code.
  */
 MPORT_PUBLIC_API int
-mport_err_code(void) {
-    return mport_err;
+mport_err_code(void)
+{
+	return mport_err;
 }
 
 /* mport_err_string()
  *
- * Return the current error string (if any).  Do not free this memory, it is static. 
+ * Return the current error string (if any).  Do not free this memory, it is static.
  */
 MPORT_PUBLIC_API const char *
-mport_err_string(void) {
-    return err_msg;
+mport_err_string(void)
+{
+	return err_msg;
 }
-
 
 /* In general, don't use these - use the macros in mport_private.h */
 
@@ -66,43 +66,44 @@ mport_err_string(void) {
  * be used if msg is NULL
  */
 int
-mport_set_err(int code, const char *msg) {
-    mport_err = code;
+mport_set_err(int code, const char *msg)
+{
+	mport_err = code;
 
-    if (code == MPORT_OK) {
-        bzero(err_msg, sizeof(err_msg));
-    } else {
-        if (msg != NULL) {
-            strlcpy(err_msg, msg, sizeof(err_msg));
-        } else {
-            strlcpy(err_msg, default_error_msg, sizeof(err_msg));
-        }
-    }
-    return code;
+	if (code == MPORT_OK) {
+		bzero(err_msg, sizeof(err_msg));
+	} else {
+		if (msg != NULL) {
+			strlcpy(err_msg, msg, sizeof(err_msg));
+		} else {
+			strlcpy(err_msg, default_error_msg, sizeof(err_msg));
+		}
+	}
+	return code;
 }
-
 
 /* mport_set_errx(code, fmt, arg1, arg2, ...)
  *
- * Like mport_set_error, but it has a printf() type formatting syntax.  
+ * Like mport_set_error, but it has a printf() type formatting syntax.
  * There is no way to access the default error messages with this function,
  * use mport_set_err() for that.
  */
 int
-mport_set_errx(int code, const char *fmt, ...) {
-    va_list args;
-    char *err;
-    int ret;
+mport_set_errx(int code, const char *fmt, ...)
+{
+	va_list args;
+	char *err;
+	int ret;
 
-    va_start(args, fmt);
-    if (vasprintf(&err, fmt, args) == -1) {
-        fprintf(stderr, "fatal error: mport_set_errx can't format the string.\n");
-        exit(255);
-    }
-    ret = mport_set_err(code, err);
-    free(err);
+	va_start(args, fmt);
+	if (vasprintf(&err, fmt, args) == -1) {
+		fprintf(stderr, "fatal error: mport_set_errx can't format the string.\n");
+		exit(255);
+	}
+	ret = mport_set_err(code, err);
+	free(err);
 
-    va_end(args);
+	va_end(args);
 
-    return ret;
+	return ret;
 }

--- a/libmport/import_export.c
+++ b/libmport/import_export.c
@@ -38,8 +38,8 @@
 #include <errno.h>
 #include <stddef.h>
 
-MPORT_PUBLIC_API int 
-mport_import(mportInstance *mport,  char  *path)
+MPORT_PUBLIC_API int
+mport_import(mportInstance *mport, char *path)
 {
 	FILE *file = NULL;
 	FILE *input;
@@ -48,7 +48,7 @@ mport_import(mportInstance *mport,  char  *path)
 
 	if (path == NULL)
 		console = true;
-	
+
 	if (!console && !mport_file_exists(path)) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "File exists at export path");
 	}
@@ -56,7 +56,8 @@ mport_import(mportInstance *mport,  char  *path)
 	if (!console) {
 		file = fopen(path, "r");
 		if (file == NULL)
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't open import file %s", path, strerror(errno));
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "Couldn't open import file %s", path, strerror(errno));
 	}
 
 	input = console ? stdin : file;
@@ -67,7 +68,7 @@ mport_import(mportInstance *mport,  char  *path)
 			continue;
 
 		mport_call_msg_cb(mport, "Installing %s", name);
-		mport_install(mport, name,  NULL, NULL, MPORT_EXPLICIT);
+		mport_install(mport, name, NULL, NULL, MPORT_EXPLICIT);
 	}
 
 	if (ferror(input)) {
@@ -79,22 +80,22 @@ mport_import(mportInstance *mport,  char  *path)
 	if (!console) {
 		fclose(file);
 	}
-	
+
 	return (MPORT_OK);
 }
 
-MPORT_PUBLIC_API int 
+MPORT_PUBLIC_API int
 mport_export(mportInstance *mport, char *path)
 {
 	mportPackageMeta **packs;
 	mportPackageMeta **packs_orig;
-	
+
 	FILE *file = NULL;
 	bool console = false;
 
 	if (path == NULL)
 		console = true;
-	
+
 	if (!console && mport_file_exists(path)) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "File exists at export path");
 	}
@@ -110,7 +111,8 @@ mport_export(mportInstance *mport, char *path)
 	if (!console) {
 		file = fopen(path, "w");
 		if (file == NULL)
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't open export file %s", path, strerror(errno));
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "Couldn't open export file %s", path, strerror(errno));
 	}
 
 	packs_orig = packs;
@@ -125,8 +127,8 @@ mport_export(mportInstance *mport, char *path)
 	if (!console) {
 		fclose(file);
 	}
-		
+
 	mport_pkgmeta_vec_free(packs_orig);
-		
+
 	return (MPORT_OK);
 }

--- a/libmport/index.c
+++ b/libmport/index.c
@@ -51,13 +51,14 @@ static int attach_index_db(sqlite3 *db);
 
 static void populate_row(sqlite3_stmt *stmt, mportIndexEntry *e);
 
-
 char *
-mport_index_file_path(void) {
+mport_index_file_path(void)
+{
 	char *envIndexFile = getenv("PKG_DB");
 
 	if (envIndexFile == NULL || strlen(envIndexFile) == 0) {
-		if (!mport_file_exists(MPORT_INDEX_FILE) && mport_file_exists(MPORT_INSTALL_MEDIA_INDEX_FILE)) {
+		if (!mport_file_exists(MPORT_INDEX_FILE) &&
+		    mport_file_exists(MPORT_INSTALL_MEDIA_INDEX_FILE)) {
 			/* copy install media index to local as a starting point. */
 			mport_copy_file(MPORT_INSTALL_MEDIA_INDEX_FILE, MPORT_INDEX_FILE);
 		}
@@ -71,7 +72,8 @@ mport_index_file_path(void) {
 	 */
 	char *dotDot = strstr(envIndexFile, "..");
 	if (dotDot != NULL) {
-		SET_ERROR(MPORT_ERR_WARN, "Relative path is not allowed in PKG_DB environment variable");
+		SET_ERROR(
+		    MPORT_ERR_WARN, "Relative path is not allowed in PKG_DB environment variable");
 		return MPORT_INDEX_FILE;
 	}
 
@@ -80,11 +82,11 @@ mport_index_file_path(void) {
 
 /*
  * Loads the index database.  The index contains a list of bundles that are
- * available for download, a list of aliases (apache is aliased to apache22 for 
+ * available for download, a list of aliases (apache is aliased to apache22 for
  * example), and a list of mirrors.
  *
  * This function will use the current local index if it is present and younger
- * than the max index age.  Otherwise, it will download the index.  If any 
+ * than the max index age.  Otherwise, it will download the index.  If any
  * index is present, the mirror list will be used; otherwise the bootstrap
  * url will be used.
  */
@@ -98,13 +100,14 @@ mport_index_load(mportInstance *mport)
 	if (autoupdate == NULL) {
 		autoupdate = mport_setting_get(mport, MPORT_SETTING_REPO_AUTOUPDATE_LEGACY);
 	}
-	if (autoupdate != NULL && (strcmp("FALSE", autoupdate) == 0 || strcmp("false", autoupdate) == 0 ||
-			strcmp("NO", autoupdate) == 0 || strcmp("no", autoupdate) == 0)) {
+	if (autoupdate != NULL &&
+	    (strcmp("FALSE", autoupdate) == 0 || strcmp("false", autoupdate) == 0 ||
+		strcmp("NO", autoupdate) == 0 || strcmp("no", autoupdate) == 0)) {
 		noIndex = true;
 	}
 	if (autoupdate != NULL)
 		free(autoupdate);
-	
+
 	if (mport_file_exists(indexFile)) {
 		if (attach_index_db(mport->db) != MPORT_OK) {
 			RETURN_CURRENT_ERROR;
@@ -152,7 +155,6 @@ attach_index_db(sqlite3 *db)
 	return (MPORT_OK);
 }
 
-
 /**
  * mport_index_load is typically preferred.  This function is only used to force
  * a download of the index manually by the user.
@@ -171,7 +173,8 @@ mport_index_get(mportInstance *mport)
 		}
 	} else {
 		if (mport_fetch_index(mport) != MPORT_OK) {
-			SET_ERROR(MPORT_ERR_WARN, "Could not fetch updated index; previous index used.");
+			SET_ERROR(
+			    MPORT_ERR_WARN, "Could not fetch updated index; previous index used.");
 			RETURN_CURRENT_ERROR;
 		}
 	}
@@ -210,21 +213,22 @@ mport_index_get(mportInstance *mport)
  *             with the system, 2 if matched on origin, 0 otherwise.
  */
 MPORT_PUBLIC_API int
-mport_index_check(mportInstance *mport, mportPackageMeta *pack) {
+mport_index_check(mportInstance *mport, mportPackageMeta *pack)
+{
 	mportIndexEntry **indexEntries = NULL, **indexEntries_orig = NULL;
 	int ret = 0;
 	bool used_origin = false;
 
-    if (mport == NULL) {
-        RETURN_ERROR(MPORT_ERR_FATAL, "mport not initialized");
-    }
+	if (mport == NULL) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "mport not initialized");
+	}
 
-    if (pack == NULL)
-        RETURN_ERROR(MPORT_ERR_FATAL, "pack not defined");
+	if (pack == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "pack not defined");
 
-    if (mport_index_lookup_pkgname(mport, pack->name, &indexEntries_orig) != MPORT_OK) {
-        SET_ERRORX(MPORT_ERR_WARN, "Error Looking up package name %s", pack->name);
-    }
+	if (mport_index_lookup_pkgname(mport, pack->name, &indexEntries_orig) != MPORT_OK) {
+		SET_ERRORX(MPORT_ERR_WARN, "Error Looking up package name %s", pack->name);
+	}
 
 	if (indexEntries_orig == NULL || *indexEntries_orig == NULL) {
 		// not found in the index.  Could be a version upgrade like py38->py39
@@ -232,34 +236,40 @@ mport_index_check(mportInstance *mport, mportPackageMeta *pack) {
 			mport_index_entry_free_vec(indexEntries_orig);
 			indexEntries_orig = NULL;
 		}
-		if (mport_index_lookup_pkgname(mport, pack->origin, &indexEntries_orig) != MPORT_OK) {
-			SET_ERRORX(MPORT_ERR_WARN, "Error Looking up package origin %s", pack->origin);
+		if (mport_index_lookup_pkgname(mport, pack->origin, &indexEntries_orig) !=
+		    MPORT_OK) {
+			SET_ERRORX(
+			    MPORT_ERR_WARN, "Error Looking up package origin %s", pack->origin);
 			return (0);
 		}
 		used_origin = true;
 	}
 
-    if (indexEntries_orig != NULL) {
-        indexEntries = indexEntries_orig;
-        while (*indexEntries != NULL) {
-            int osflag = mport_check_preconditions(mport, pack, MPORT_PRECHECK_OS);
-			// if the package was built for an older os, update it.  if the package version is less than the index version, update it.
-			// if the origin had to be matched, and the package name does not match the index, update it. (py38->py39)
-            if ((*indexEntries)->version != NULL && pack->version != NULL && (mport_version_cmp(pack->version, (*indexEntries)->version) < 0 ||
-                                                     (mport_version_cmp(pack->version, (*indexEntries)->version) == 0 && osflag == MPORT_OK) ||
-													 (used_origin && strcmp(pack->name, (*indexEntries)->pkgname) != 0))) {
-                ret = used_origin ? 2 : 1;
-                break;
-            }
-            indexEntries++;
-        }
-        mport_index_entry_free_vec(indexEntries_orig);
-        indexEntries_orig = NULL;
-    }
+	if (indexEntries_orig != NULL) {
+		indexEntries = indexEntries_orig;
+		while (*indexEntries != NULL) {
+			int osflag = mport_check_preconditions(mport, pack, MPORT_PRECHECK_OS);
+			// if the package was built for an older os, update it.  if the package
+			// version is less than the index version, update it. if the origin had to
+			// be matched, and the package name does not match the index, update it.
+			// (py38->py39)
+			if ((*indexEntries)->version != NULL && pack->version != NULL &&
+			    (mport_version_cmp(pack->version, (*indexEntries)->version) < 0 ||
+				(mport_version_cmp(pack->version, (*indexEntries)->version) == 0 &&
+				    osflag == MPORT_OK) ||
+				(used_origin &&
+				    strcmp(pack->name, (*indexEntries)->pkgname) != 0))) {
+				ret = used_origin ? 2 : 1;
+				break;
+			}
+			indexEntries++;
+		}
+		mport_index_entry_free_vec(indexEntries_orig);
+		indexEntries_orig = NULL;
+	}
 
-    return (ret);
+	return (ret);
 }
-
 
 /* return 1 if the index is younger than the max age, 0 otherwise */
 static int
@@ -302,7 +312,7 @@ index_update_last_checked(mportInstance *mport)
 	char *utime;
 	int ret;
 
-	if (asprintf(&utime, "%jd", (intmax_t) mport_get_time()) == -1)
+	if (asprintf(&utime, "%jd", (intmax_t)mport_get_time()) == -1)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
 	ret = mport_setting_set(mport, MPORT_SETTING_INDEX_LAST_CHECKED, utime);
 	free(utime);
@@ -312,7 +322,7 @@ index_update_last_checked(mportInstance *mport)
 
 /*
  * Fills the string vector with the list of the mirrors for the current
- * country.  
+ * country.
  */
 int
 mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size)
@@ -329,17 +339,18 @@ mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size
 	}
 
 	/* XXX the country is hard coded until a configuration system is created */
-	if (mport_db_count(mport->db, &len, "SELECT COUNT(*) FROM idx.mirrors WHERE country=%Q", mirror_region) != MPORT_OK) {
+	if (mport_db_count(mport->db, &len, "SELECT COUNT(*) FROM idx.mirrors WHERE country=%Q",
+		mirror_region) != MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
 	*list_size = len;
-	list = calloc((size_t) len + 1, sizeof(char *));
+	list = calloc((size_t)len + 1, sizeof(char *));
 	*list_p = list;
 	i = 0;
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT mirror FROM idx.mirrors WHERE country=%Q", mirror_region) !=
-	    MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt, "SELECT mirror FROM idx.mirrors WHERE country=%Q",
+		mirror_region) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -348,7 +359,7 @@ mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size
 		ret = sqlite3_step(stmt);
 
 		if (ret == SQLITE_ROW) {
-			list[i] = strdup((const char *) sqlite3_column_text(stmt, 0));
+			list[i] = strdup((const char *)sqlite3_column_text(stmt, 0));
 
 			if (list[i] == NULL) {
 				sqlite3_finalize(stmt);
@@ -373,11 +384,12 @@ mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size
 MPORT_PUBLIC_API int
 mport_index_print_mirror_list(mportInstance *mport)
 {
-	
+
 	int ret;
 	sqlite3_stmt *stmt;
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT country, mirror FROM idx.mirrors ORDER BY country") != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT country, mirror FROM idx.mirrors ORDER BY country") != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -387,7 +399,8 @@ mport_index_print_mirror_list(mportInstance *mport)
 		ret = sqlite3_step(stmt);
 
 		if (ret == SQLITE_ROW) {
-			mport_call_msg_cb(mport, "%s\t%s\n", sqlite3_column_text(stmt, 0), sqlite3_column_text(stmt, 1));
+			mport_call_msg_cb(mport, "%s\t%s\n", sqlite3_column_text(stmt, 0),
+			    sqlite3_column_text(stmt, 1));
 		} else if (ret == SQLITE_DONE) {
 			break;
 		} else {
@@ -403,7 +416,7 @@ mport_index_print_mirror_list(mportInstance *mport)
 MPORT_PUBLIC_API int
 mport_index_mirror_list(mportInstance *mport, mportMirrorEntry ***entry_vec)
 {
-	
+
 	sqlite3_stmt *stmt;
 	int count;
 	mportMirrorEntry **e = NULL;
@@ -416,22 +429,22 @@ mport_index_mirror_list(mportInstance *mport, mportMirrorEntry ***entry_vec)
 
 	MPORT_CHECK_FOR_INDEX(mport, "mport_index_mirror_list()")
 
-
 	if (mport_db_count(mport->db, &count, "SELECT count(*) FROM idx.mirrors") != MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
-	e = (mportMirrorEntry **) calloc((size_t) count + 1, sizeof(mportMirrorEntry *));
+	e = (mportMirrorEntry **)calloc((size_t)count + 1, sizeof(mportMirrorEntry *));
 	if (e == NULL) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not allocate memory for mirror entries");
 	}
 	*entry_vec = e;
 
-	if (count == 0) {	
+	if (count == 0) {
 		return ret;
 	}
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT country, mirror FROM idx.mirrors ORDER BY country") != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT country, mirror FROM idx.mirrors ORDER BY country") != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -440,13 +453,14 @@ mport_index_mirror_list(mportInstance *mport, mportMirrorEntry ***entry_vec)
 		ret = sqlite3_step(stmt);
 
 		if (ret == SQLITE_ROW) {
-			if ((e[i] = (mportMirrorEntry *) calloc(1, sizeof(mportMirrorEntry))) == NULL) {
+			if ((e[i] = (mportMirrorEntry *)calloc(1, sizeof(mportMirrorEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto DONE;
 			}
 
-			strlcpy(e[i]->country, (const char *) sqlite3_column_text(stmt, 0), 5);
-			strlcpy(e[i]->url, (const char *) sqlite3_column_text(stmt, 1), 256);
+			strlcpy(e[i]->country, (const char *)sqlite3_column_text(stmt, 0), 5);
+			strlcpy(e[i]->url, (const char *)sqlite3_column_text(stmt, 1), 256);
 			i++;
 		} else if (ret == SQLITE_DONE) {
 			break;
@@ -460,7 +474,6 @@ DONE:
 	sqlite3_finalize(stmt);
 	return ret;
 }
-
 
 /*
  * Looks up a pkgname from the index and fills a vector of index entries
@@ -490,13 +503,14 @@ mport_index_lookup_pkgname(mportInstance *mport, const char *pkgname, mportIndex
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (mport_db_count(mport->db, &count, "SELECT count(*) FROM idx.packages  WHERE pkg GLOB %Q", lookup) != MPORT_OK) {
+	if (mport_db_count(mport->db, &count,
+		"SELECT count(*) FROM idx.packages  WHERE pkg GLOB %Q", lookup) != MPORT_OK) {
 		free(lookup);
 		lookup = NULL;
 		RETURN_CURRENT_ERROR;
 	}
 
-	e = (mportIndexEntry **) calloc((size_t) count + 1, sizeof(mportIndexEntry *));
+	e = (mportIndexEntry **)calloc((size_t)count + 1, sizeof(mportIndexEntry *));
 	if (e == NULL) {
 		free(lookup);
 		lookup = NULL;
@@ -511,8 +525,8 @@ mport_index_lookup_pkgname(mportInstance *mport, const char *pkgname, mportIndex
 	}
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT pkg, version, comment, bundlefile, license, hash FROM idx.packages WHERE pkg GLOB %Q",
-	                     lookup) != MPORT_OK) {
+		"SELECT pkg, version, comment, bundlefile, license, hash FROM idx.packages WHERE pkg GLOB %Q",
+		lookup) != MPORT_OK) {
 		ret = mport_err_code();
 		goto DONE;
 	}
@@ -521,14 +535,16 @@ mport_index_lookup_pkgname(mportInstance *mport, const char *pkgname, mportIndex
 		step = sqlite3_step(stmt);
 
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportIndexEntry *) calloc(1, sizeof(mportIndexEntry))) == NULL) {
+			if ((e[i] = (mportIndexEntry *)calloc(1, sizeof(mportIndexEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto DONE;
 			}
 
 			populate_row(stmt, e[i]);
 
-			if (e[i]->pkgname == NULL || e[i]->version == NULL || e[i]->comment == NULL || e[i]->license == NULL ||
+			if (e[i]->pkgname == NULL || e[i]->version == NULL ||
+			    e[i]->comment == NULL || e[i]->license == NULL ||
 			    e[i]->bundlefile == NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto DONE;
@@ -553,8 +569,8 @@ DONE:
 }
 
 int
-mport_index_select_pkgname(mportInstance *mport, const char *pkgname, const char *msg, mportIndexEntry ***entry_vec,
-    mportIndexEntry **selected)
+mport_index_select_pkgname(mportInstance *mport, const char *pkgname, const char *msg,
+    mportIndexEntry ***entry_vec, mportIndexEntry **selected)
 {
 	mportIndexEntry **entries = NULL;
 	int choice = 0;
@@ -578,7 +594,8 @@ mport_index_select_pkgname(mportInstance *mport, const char *pkgname, const char
 		count++;
 
 	if (count > 1) {
-		choice = mport_call_select_cb(mport, msg == NULL ? "Multiple packages match your query." : msg, entries, 0);
+		choice = mport_call_select_cb(
+		    mport, msg == NULL ? "Multiple packages match your query." : msg, entries, 0);
 		if (choice < 0) {
 			mport_index_entry_free_vec(entries);
 			*entry_vec = NULL;
@@ -588,7 +605,8 @@ mport_index_select_pkgname(mportInstance *mport, const char *pkgname, const char
 		if (choice >= count) {
 			mport_index_entry_free_vec(entries);
 			*entry_vec = NULL;
-			SET_ERROR(MPORT_ERR_FATAL, "Package selection callback returned an invalid choice");
+			SET_ERROR(MPORT_ERR_FATAL,
+			    "Package selection callback returned an invalid choice");
 			RETURN_CURRENT_ERROR;
 		}
 	}
@@ -598,15 +616,15 @@ mport_index_select_pkgname(mportInstance *mport, const char *pkgname, const char
 	return MPORT_OK;
 }
 
-
 /*
  * Look up index entries containing the term. Supports unix style globs.
  * e.g. mport_index_search_term(mport, &indexEntry, 'gmake');
- * 
+ *
  * Simplified version of mport_index_search();
  */
 MPORT_PUBLIC_API int
-mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char *search_term) {
+mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char *search_term)
+{
 
 	sqlite3_stmt *stmt = NULL;
 	int ret = MPORT_OK;
@@ -614,7 +632,6 @@ mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char
 	int i = 0, step;
 	mportIndexEntry **e = NULL;
 	char *term = NULL;
-
 
 	if (mport == NULL) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "mport not initialized");
@@ -625,16 +642,17 @@ mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char
 
 	if (strstr(search_term, "*") != NULL)
 		term = strdup(search_term);
-	else 
-		if (asprintf(&term, "*%s*", search_term) == -1)
+	else if (asprintf(&term, "*%s*", search_term) == -1)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not allocate memory");
 
-	if (mport_db_count(mport->db, &len, "SELECT count(*) FROM idx.packages WHERE pkg glob %Q or comment glob %Q", term, term) != MPORT_OK) {
+	if (mport_db_count(mport->db, &len,
+		"SELECT count(*) FROM idx.packages WHERE pkg glob %Q or comment glob %Q", term,
+		term) != MPORT_OK) {
 		free(term);
 		RETURN_CURRENT_ERROR;
 	}
 
-	e = (mportIndexEntry **) calloc((size_t) len + 1, sizeof(mportIndexEntry *));
+	e = (mportIndexEntry **)calloc((size_t)len + 1, sizeof(mportIndexEntry *));
 	if (e == NULL) {
 		free(term);
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not allocate memory");
@@ -648,8 +666,8 @@ mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char
 	}
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT pkg, version, comment, bundlefile, license, hash, type FROM idx.packages WHERE pkg glob %Q or comment glob %Q", term, term) !=
-	    MPORT_OK) {
+		"SELECT pkg, version, comment, bundlefile, license, hash, type FROM idx.packages WHERE pkg glob %Q or comment glob %Q",
+		term, term) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		free(term);
 		term = NULL;
@@ -660,14 +678,16 @@ mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char
 		step = sqlite3_step(stmt);
 
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportIndexEntry *) calloc(1, sizeof(mportIndexEntry))) == NULL) {
+			if ((e[i] = (mportIndexEntry *)calloc(1, sizeof(mportIndexEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
 			}
 
 			populate_row(stmt, e[i]);
 
-			if (e[i]->pkgname == NULL || e[i]->version == NULL || e[i]->comment == NULL || e[i]->license == NULL ||
+			if (e[i]->pkgname == NULL || e[i]->version == NULL ||
+			    e[i]->comment == NULL || e[i]->license == NULL ||
 			    e[i]->bundlefile == NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
@@ -699,7 +719,8 @@ mport_index_search_term(mportInstance *mport, mportIndexEntry ***entry_vec, char
  *
  * mport_index_search(mport, &indexEntries, "pkg=%Q", name);
  *
- * indexEntries is set to an empty allocated list and MPORT_OK is returned if no packages where found.
+ * indexEntries is set to an empty allocated list and MPORT_OK is returned if no packages where
+ * found.
  */
 MPORT_PUBLIC_API int
 mport_index_search(mportInstance *mport, mportIndexEntry ***entry_vec, const char *fmt, ...)
@@ -726,11 +747,12 @@ mport_index_search(mportInstance *mport, mportIndexEntry ***entry_vec, const cha
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not build where clause");
 	}
 
-	if (mport_db_count(mport->db, &len, "SELECT count(*) FROM idx.packages  WHERE %s", where) != MPORT_OK) {
+	if (mport_db_count(mport->db, &len, "SELECT count(*) FROM idx.packages  WHERE %s", where) !=
+	    MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
-	e = (mportIndexEntry **) calloc((size_t) len + 1, sizeof(mportIndexEntry *));
+	e = (mportIndexEntry **)calloc((size_t)len + 1, sizeof(mportIndexEntry *));
 	if (e == NULL) {
 		sqlite3_free(where);
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not allocate memory");
@@ -743,8 +765,8 @@ mport_index_search(mportInstance *mport, mportIndexEntry ***entry_vec, const cha
 	}
 
 	if (mport_db_prepare(db, &stmt,
-	                     "SELECT pkg, version, comment, bundlefile, license, hash, type FROM idx.packages WHERE %s", where) !=
-	    MPORT_OK) {
+		"SELECT pkg, version, comment, bundlefile, license, hash, type FROM idx.packages WHERE %s",
+		where) != MPORT_OK) {
 		sqlite3_free(where);
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
@@ -754,14 +776,16 @@ mport_index_search(mportInstance *mport, mportIndexEntry ***entry_vec, const cha
 		step = sqlite3_step(stmt);
 
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportIndexEntry *) calloc(1, sizeof(mportIndexEntry))) == NULL) {
+			if ((e[i] = (mportIndexEntry *)calloc(1, sizeof(mportIndexEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
 			}
 
 			populate_row(stmt, e[i]);
 
-			if (e[i]->pkgname == NULL || e[i]->version == NULL || e[i]->comment == NULL || e[i]->license == NULL ||
+			if (e[i]->pkgname == NULL || e[i]->version == NULL ||
+			    e[i]->comment == NULL || e[i]->license == NULL ||
 			    e[i]->bundlefile == NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
@@ -783,7 +807,6 @@ mport_index_search(mportInstance *mport, mportIndexEntry ***entry_vec, const cha
 	return ret;
 }
 
-
 MPORT_PUBLIC_API int
 mport_index_list(mportInstance *mport, mportIndexEntry ***entry_vec)
 {
@@ -797,14 +820,15 @@ mport_index_list(mportInstance *mport, mportIndexEntry ***entry_vec)
 	if (mport_db_count(mport->db, &len, "SELECT count(*) FROM idx.packages") != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
-	e = (mportIndexEntry **) calloc((size_t) len + 1, sizeof(mportIndexEntry *));
+	e = (mportIndexEntry **)calloc((size_t)len + 1, sizeof(mportIndexEntry *));
 	*entry_vec = e;
 
 	if (len == 0) {
 		return MPORT_OK;
 	}
 
-	if (mport_db_prepare(db, &stmt, "SELECT pkg, version, comment, bundlefile, license, hash FROM idx.packages") !=
+	if (mport_db_prepare(db, &stmt,
+		"SELECT pkg, version, comment, bundlefile, license, hash FROM idx.packages") !=
 	    MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
@@ -814,14 +838,16 @@ mport_index_list(mportInstance *mport, mportIndexEntry ***entry_vec)
 		step = sqlite3_step(stmt);
 
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportIndexEntry *) calloc(1, sizeof(mportIndexEntry))) == NULL) {
+			if ((e[i] = (mportIndexEntry *)calloc(1, sizeof(mportIndexEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
 			}
 
 			populate_row(stmt, e[i]);
 
-			if (e[i]->pkgname == NULL || e[i]->version == NULL || e[i]->comment == NULL || e[i]->license == NULL ||
+			if (e[i]->pkgname == NULL || e[i]->version == NULL ||
+			    e[i]->comment == NULL || e[i]->license == NULL ||
 			    e[i]->bundlefile == NULL) {
 				ret = MPORT_ERR_FATAL;
 				break;
@@ -857,11 +883,12 @@ mport_moved_lookup(mportInstance *mport, const char *origin, mportIndexMovedEntr
 
 	MPORT_CHECK_FOR_INDEX(mport, "mport_moved_lookup()")
 
-	if (mport_db_count(mport->db, &count, "SELECT count(*) FROM idx.moved  WHERE port = %Q", origin) != MPORT_OK) {
+	if (mport_db_count(mport->db, &count, "SELECT count(*) FROM idx.moved  WHERE port = %Q",
+		origin) != MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
-	e = (mportIndexMovedEntry **) calloc((size_t) count + 1, sizeof(mportIndexMovedEntry *));
+	e = (mportIndexMovedEntry **)calloc((size_t)count + 1, sizeof(mportIndexMovedEntry *));
 	if (e == NULL) {
 		RETURN_ERROR(MPORT_ERR_FATAL, "Could not allocate memory for moved entries");
 	}
@@ -872,8 +899,8 @@ mport_moved_lookup(mportInstance *mport, const char *origin, mportIndexMovedEntr
 	}
 
 	if (mport_db_prepare(mport->db, &stmt,
-	                     "SELECT port, moved_to, why, date FROM idx.moved WHERE port = %Q",
-	                     origin) != MPORT_OK) {
+		"SELECT port, moved_to, why, date FROM idx.moved WHERE port = %Q",
+		origin) != MPORT_OK) {
 		ret = mport_err_code();
 		goto MOVED_DONE;
 	}
@@ -882,7 +909,8 @@ mport_moved_lookup(mportInstance *mport, const char *origin, mportIndexMovedEntr
 		step = sqlite3_step(stmt);
 
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportIndexMovedEntry *) calloc(1, sizeof(mportIndexMovedEntry))) == NULL) {
+			if ((e[i] = (mportIndexMovedEntry *)calloc(
+				 1, sizeof(mportIndexMovedEntry))) == NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto MOVED_DONE;
 			}
@@ -894,13 +922,15 @@ mport_moved_lookup(mportInstance *mport, const char *origin, mportIndexMovedEntr
 
 			// TODO: fix
 			char *orig_pkg = NULL;
-			if (lookup_alias_inverse(mport, origin, &orig_pkg) == MPORT_OK && orig_pkg != NULL) {
+			if (lookup_alias_inverse(mport, origin, &orig_pkg) == MPORT_OK &&
+			    orig_pkg != NULL) {
 				strlcpy(e[i]->pkgname, orig_pkg, 128); // original package name
 				free(orig_pkg);
 			}
 
 			char *moved_pkg = NULL;
-			if (e[i]->moved_to[0] != '\0' && lookup_alias_inverse(mport, e[i]->moved_to, &moved_pkg) != MPORT_OK) {
+			if (e[i]->moved_to[0] != '\0' &&
+			    lookup_alias_inverse(mport, e[i]->moved_to, &moved_pkg) != MPORT_OK) {
 				ret = mport_err_code();
 				goto MOVED_DONE;
 			} else if (moved_pkg != NULL) {
@@ -918,7 +948,7 @@ mport_moved_lookup(mportInstance *mport, const char *origin, mportIndexMovedEntr
 		}
 	}
 
-	MOVED_DONE:
+MOVED_DONE:
 	sqlite3_finalize(stmt);
 	return ret;
 }
@@ -948,7 +978,7 @@ populate_row(sqlite3_stmt *stmt, mportIndexEntry *e)
 	e->hash = (hash == NULL) ? NULL : strdup((const char *)hash);
 
 	if (sqlite3_column_type(stmt, 6) == SQLITE_INTEGER) {
-        e->type = sqlite3_column_int(stmt, 6);
+		e->type = sqlite3_column_int(stmt, 6);
 	}
 }
 
@@ -963,23 +993,24 @@ lookup_alias_inverse(mportInstance *mport, const char *query, char **result)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid parameters to lookup_alias_inverse");
 	}
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT pkg FROM idx.aliases WHERE pkg=%Q", query) != MPORT_OK)
+	if (mport_db_prepare(mport->db, &stmt, "SELECT pkg FROM idx.aliases WHERE pkg=%Q", query) !=
+	    MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	switch (sqlite3_step(stmt)) {
-		case SQLITE_ROW:
-			str = (const char *) sqlite3_column_text(stmt, 0);
-			if (str != NULL)
-				*result = strdup(str);
-			else
-				*result = NULL;
-			break;
-		case SQLITE_DONE:
-			*result = strdup(query);
-			break;
-		default:
-			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			break;
+	case SQLITE_ROW:
+		str = (const char *)sqlite3_column_text(stmt, 0);
+		if (str != NULL)
+			*result = strdup(str);
+		else
+			*result = NULL;
+		break;
+	case SQLITE_DONE:
+		*result = strdup(query);
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
 	}
 
 	sqlite3_finalize(stmt);
@@ -989,7 +1020,6 @@ lookup_alias_inverse(mportInstance *mport, const char *query, char **result)
 
 	return ret;
 }
-
 
 static int
 lookup_alias(mportInstance *mport, const char *query, char **result)
@@ -1002,24 +1032,26 @@ lookup_alias(mportInstance *mport, const char *query, char **result)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid parameters to lookup_alias");
 	}
 
-	// assumes that query is an alias|pkg maps to origin|pkgname e.g. www/py-qt5-webkit|py27-qt5-webkit
-	if (mport_db_prepare(mport->db, &stmt, "SELECT pkg FROM idx.aliases WHERE alias=%Q ORDER BY pkg desc", query) != MPORT_OK)
+	// assumes that query is an alias|pkg maps to origin|pkgname e.g.
+	// www/py-qt5-webkit|py27-qt5-webkit
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT pkg FROM idx.aliases WHERE alias=%Q ORDER BY pkg desc", query) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	switch (sqlite3_step(stmt)) {
-		case SQLITE_ROW:
-			str = (const char *) sqlite3_column_text(stmt, 0);
-			if (str != NULL)
-				*result = strdup(str);
-			else
-				*result = NULL;
-			break;
-		case SQLITE_DONE:
-			*result = strdup(query);
-			break;
-		default:
-			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			break;
+	case SQLITE_ROW:
+		str = (const char *)sqlite3_column_text(stmt, 0);
+		if (str != NULL)
+			*result = strdup(str);
+		else
+			*result = NULL;
+		break;
+	case SQLITE_DONE:
+		*result = strdup(query);
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
 	}
 
 	sqlite3_finalize(stmt);
@@ -1029,7 +1061,6 @@ lookup_alias(mportInstance *mport, const char *query, char **result)
 
 	return ret;
 }
-
 
 /* free a vector of mportIndexEntry structs */
 MPORT_PUBLIC_API void
@@ -1049,7 +1080,6 @@ mport_index_entry_free_vec(mportIndexEntry **e)
 	free(e_orig);
 	e_orig = NULL;
 }
-
 
 /* free a mportIndexEntry struct */
 MPORT_PUBLIC_API void

--- a/libmport/index_depends.c
+++ b/libmport/index_depends.c
@@ -36,16 +36,16 @@
 #include <stdlib.h>
 #include <errno.h>
 
-
 /*
- * Looks up dependencies list via pkgname and version from the index and fills with a vector of depends entries
- * with the result.
+ * Looks up dependencies list via pkgname and version from the index and fills with a vector of
+ * depends entries with the result.
  *
  * The calling code is responsible for freeing the memory allocated.  See
  * mport_index_depends_free_vec()
  */
 MPORT_PUBLIC_API int
-mport_index_depends_list(mportInstance *mport, const char *pkgname, const char *version, mportDependsEntry ***entry_vec)
+mport_index_depends_list(
+    mportInstance *mport, const char *pkgname, const char *version, mportDependsEntry ***entry_vec)
 {
 	int count, i = 0, step;
 	sqlite3_stmt *stmt = NULL;
@@ -53,51 +53,54 @@ mport_index_depends_list(mportInstance *mport, const char *pkgname, const char *
 	mportDependsEntry **e = NULL;
 
 	if (pkgname == NULL || version == NULL || entry_vec == NULL) {
-		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid argument(s) passed to mport_index_depends_list()");
+		RETURN_ERROR(
+		    MPORT_ERR_FATAL, "Invalid argument(s) passed to mport_index_depends_list()");
 	}
-  
+
 	MPORT_CHECK_FOR_INDEX(mport, "mport_index_depends_list()")
 
 	if (mport_db_prepare(mport->db, &stmt,
-	    "SELECT COUNT(*) FROM idx.depends WHERE pkg = %Q and version = %Q",
-	    pkgname, version) != MPORT_OK) {
+		"SELECT COUNT(*) FROM idx.depends WHERE pkg = %Q and version = %Q", pkgname,
+		version) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
- 
+
 	switch (sqlite3_step(stmt)) {
-		case SQLITE_ROW:
-			count = sqlite3_column_int(stmt, 0);
-			break;
-		case SQLITE_DONE:
-			ret = SET_ERROR(MPORT_ERR_FATAL,
-		    	"No rows returned from a 'SELECT COUNT(*)' query.");
-			goto DONE;
-		default:
-			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-			goto DONE;
+	case SQLITE_ROW:
+		count = sqlite3_column_int(stmt, 0);
+		break;
+	case SQLITE_DONE:
+		ret =
+		    SET_ERROR(MPORT_ERR_FATAL, "No rows returned from a 'SELECT COUNT(*)' query.");
+		goto DONE;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		goto DONE;
 	}
-  
+
 	sqlite3_finalize(stmt);
-  
+
 	e = (mportDependsEntry **)calloc(count + 1, sizeof(mportDependsEntry *));
 	*entry_vec = e;
-  
-	if (count == 0)  {
+
+	if (count == 0) {
 		return (MPORT_OK);
 	}
-  
+
 	if (mport_db_prepare(mport->db, &stmt,
-	    "SELECT pkg, version, d_pkg, d_version FROM idx.depends WHERE pkg= %Q and version=%Q", pkgname, version) != MPORT_OK) {
+		"SELECT pkg, version, d_pkg, d_version FROM idx.depends WHERE pkg= %Q and version=%Q",
+		pkgname, version) != MPORT_OK) {
 		ret = mport_err_code();
 		goto DONE;
 	}
-  
+
 	while (1) {
 		step = sqlite3_step(stmt);
-    
+
 		if (step == SQLITE_ROW) {
-			if ((e[i] = (mportDependsEntry *)calloc(1, sizeof(mportDependsEntry))) == NULL) {
+			if ((e[i] = (mportDependsEntry *)calloc(1, sizeof(mportDependsEntry))) ==
+			    NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto DONE;
 			}
@@ -109,13 +112,13 @@ mport_index_depends_list(mportInstance *mport, const char *pkgname, const char *
 
 			e[i]->pkgname = (pkgname == NULL) ? NULL : strdup((const char *)pkgname);
 			e[i]->version = (version == NULL) ? NULL : strdup((const char *)version);
-			e[i]->d_pkgname = (d_pkgname == NULL) ? NULL : strdup((const char *)d_pkgname);
-			e[i]->d_version = (d_version == NULL) ? NULL : strdup((const char *)d_version);
-      
-			if (e[i]->pkgname == NULL ||
-			    e[i]->version == NULL ||
-			    e[i]->d_pkgname == NULL ||
-			    e[i]->d_version == NULL) {
+			e[i]->d_pkgname =
+			    (d_pkgname == NULL) ? NULL : strdup((const char *)d_pkgname);
+			e[i]->d_version =
+			    (d_version == NULL) ? NULL : strdup((const char *)d_version);
+
+			if (e[i]->pkgname == NULL || e[i]->version == NULL ||
+			    e[i]->d_pkgname == NULL || e[i]->d_version == NULL) {
 				ret = MPORT_ERR_FATAL;
 				goto DONE;
 			}
@@ -125,17 +128,15 @@ mport_index_depends_list(mportInstance *mport, const char *pkgname, const char *
 			e[i] = NULL;
 			goto DONE;
 		} else {
-			ret = SET_ERROR(MPORT_ERR_FATAL,
-			    sqlite3_errmsg(mport->db));
+			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 			goto DONE;
 		}
 	}
-      
+
 DONE:
 	sqlite3_finalize(stmt);
-	return ret; 
+	return ret;
 }
-
 
 /* free a vector of mportDependsEntry structs */
 MPORT_PUBLIC_API void
@@ -146,7 +147,7 @@ mport_index_depends_free_vec(mportDependsEntry **depends)
 	if (depends == NULL) {
 		return;
 	}
-  
+
 	while (*depends != NULL) {
 		mport_index_depends_free(*depends);
 		depends++;
@@ -157,10 +158,9 @@ mport_index_depends_free_vec(mportDependsEntry **depends)
 	depends = NULL;
 }
 
-
 /* free a mportDependsEntry struct */
 MPORT_PUBLIC_API void
-mport_index_depends_free(mportDependsEntry *e) 
+mport_index_depends_free(mportDependsEntry *e)
 {
 	if (e == NULL) {
 		return;

--- a/libmport/info.c
+++ b/libmport/info.c
@@ -43,7 +43,8 @@
 #define CTIME_R_BUFLEN 26
 
 MPORT_PUBLIC_API char *
-mport_info(mportInstance *mport, const char *packageName) {
+mport_info(mportInstance *mport, const char *packageName)
+{
 	mportIndexEntry **indexEntries = NULL;
 	mportIndexEntry *indexEntry = NULL;
 	mportPackageMeta **packs = NULL;
@@ -72,8 +73,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 		return (NULL);
 	}
 
-	if (mport_index_select_pkgname(mport, packageName, "Multiple packages match your query.", &indexEntries, &indexEntry) !=
-	    MPORT_OK) {
+	if (mport_index_select_pkgname(mport, packageName, "Multiple packages match your query.",
+		&indexEntries, &indexEntry) != MPORT_OK) {
 		return (NULL);
 	}
 
@@ -94,7 +95,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 		return (NULL);
 	}
 
-	if (packs != NULL && mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK) {
+	if (packs != NULL &&
+	    mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK) {
 		SET_ERROR(MPORT_ERR_FATAL, "The moved lookup failed.");
 		return (NULL);
 	}
@@ -110,9 +112,16 @@ mport_info(mportInstance *mport, const char *packageName) {
 		options = strdup("");
 		desc = strdup("");
 
-		if (!status || !origin || !os_release || !cpe || !flavor || !deprecated || !options || !desc) {
-			free(status); free(origin); free(os_release); free(cpe);
-			free(flavor); free(deprecated); free(options); free(desc);
+		if (!status || !origin || !os_release || !cpe || !flavor || !deprecated ||
+		    !options || !desc) {
+			free(status);
+			free(origin);
+			free(os_release);
+			free(cpe);
+			free(flavor);
+			free(deprecated);
+			free(options);
+			free(desc);
 			mport_index_entry_free_vec(indexEntries);
 			free(movedEntries);
 			SET_ERROR(MPORT_ERR_FATAL, "Out of memory");
@@ -141,7 +150,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 		}
 		deprecated = (*packs)->deprecated;
 		if (deprecated == NULL || deprecated[0] == '\0') {
-			if (movedEntries != NULL && *movedEntries!= NULL && (*movedEntries)->date[0] != '\0') {
+			if (movedEntries != NULL && *movedEntries != NULL &&
+			    (*movedEntries)->date[0] != '\0') {
 				deprecated = strdup("yes");
 			} else {
 				deprecated = strdup("no");
@@ -153,7 +163,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 		}
 
 		expirationDate = (*packs)->expiration_date;
-		if (expirationDate == 0 && movedEntries != NULL && *movedEntries!= NULL && (*movedEntries)->date[0] != '\0') {
+		if (expirationDate == 0 && movedEntries != NULL && *movedEntries != NULL &&
+		    (*movedEntries)->date[0] != '\0') {
 			struct tm expDate;
 			strptime((*movedEntries)->date, "%Y-%m-%d", &expDate);
 			expirationDate = mktime(&expDate);
@@ -184,7 +195,8 @@ mport_info(mportInstance *mport, const char *packageName) {
 
 		if (indexEntry == NULL)
 			purl[0] = '\0';
-		else if (packs != NULL && indexEntry->pkgname != NULL && (*packs)->version != NULL) {
+		else if (packs != NULL && indexEntry->pkgname != NULL &&
+		    (*packs)->version != NULL) {
 			char *tmppurl = mport_purl_uri(*packs);
 			if (tmppurl != NULL) {
 				snprintf(purl, sizeof(purl), "%s", tmppurl);
@@ -193,27 +205,35 @@ mport_info(mportInstance *mport, const char *packageName) {
 				purl[0] = '\0';
 			}
 		} else
-			purl[0] = '\0';	
+			purl[0] = '\0';
 	}
 
 	char flatsize_str[8];
-	humanize_number(flatsize_str, sizeof(flatsize_str), flatsize, "B", HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
+	humanize_number(flatsize_str, sizeof(flatsize_str), flatsize, "B", HN_AUTOSCALE,
+	    HN_DECIMAL | HN_IEC_PREFIXES);
 
 	char *annotations_str = NULL;
 	if (packs != NULL) {
 		char **tags = NULL;
 		int tag_count = 0;
-		if (mport_annotation_list(mport, (*packs)->name, &tags, &tag_count) == MPORT_OK && tag_count > 0) {
+		if (mport_annotation_list(mport, (*packs)->name, &tags, &tag_count) == MPORT_OK &&
+		    tag_count > 0) {
 			size_t len = 0;
 			FILE *fp = open_memstream(&annotations_str, &len);
 			if (fp != NULL) {
 				for (int i = 0; i < tag_count; i++) {
 					char *val = NULL;
-					if (mport_annotation_get(mport, (*packs)->name, tags[i], &val) == MPORT_OK && val != NULL) {
+					if (mport_annotation_get(
+						mport, (*packs)->name, tags[i], &val) == MPORT_OK &&
+					    val != NULL) {
 						if (i == 0)
-							fprintf(fp, "Annotations     :\n                       %s:        %s\n", tags[i], val);
+							fprintf(fp,
+							    "Annotations     :\n                       %s:        %s\n",
+							    tags[i], val);
 						else
-							fprintf(fp, "                       %s:        %s\n", tags[i], val);
+							fprintf(fp,
+							    "                       %s:        %s\n",
+							    tags[i], val);
 						free(val);
 					}
 					free(tags[i]);
@@ -241,64 +261,48 @@ mport_info(mportInstance *mport, const char *packageName) {
 	if (insdate_str == NULL)
 		insdate_str = "\n";
 
-	if (packs !=NULL && indexEntry == NULL) {
+	if (packs != NULL && indexEntry == NULL) {
 		asprintf(&info_text,
-	         "%s-%s\n"
-	         "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
-	         "Flavor          : %s\nOS              : %s\n"
-	         "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
-	         "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
-	         (*packs)->name, (*packs)->version,
-	         (*packs)->name, status, "", "", origin,
-	         flavor, os_release,
-		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         expdate_str,
-	         insdate_str,
-	         "",
-	         annotations_str,
-	         options,
-		 type == MPORT_TYPE_APP ? "Application" : "System", 
-		 flatsize_str,
-		 desc);
+		    "%s-%s\n"
+		    "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
+		    "Flavor          : %s\nOS              : %s\n"
+		    "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
+		    "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
+		    (*packs)->name, (*packs)->version, (*packs)->name, status, "", "", origin,
+		    flavor, os_release, cpe, purl, locked ? "yes" : "no",
+		    automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no",
+		    deprecated, expdate_str, insdate_str, "", annotations_str, options,
+		    type == MPORT_TYPE_APP ? "Application" : "System", flatsize_str, desc);
 	} else if (packs != NULL) {
 		asprintf(&info_text,
-	         "%s-%s\n"
-	         "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
-	         "Flavor          : %s\nOS              : %s\n"
-	         "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
-	         "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
-	         (*packs)->name, (*packs)->version,
-	         (*packs)->name, status, indexEntry == NULL ? "" : indexEntry->version, indexEntry == NULL ? "" : indexEntry->license, origin,
-	         flavor, os_release,
-		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         expdate_str,
-	         insdate_str,
-	         indexEntry == NULL ? "" : indexEntry->comment,
-	         annotations_str,
-	         options,
-		 type == MPORT_TYPE_APP ? "Application" : "System",
-		 flatsize_str,
-		 desc);
+		    "%s-%s\n"
+		    "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
+		    "Flavor          : %s\nOS              : %s\n"
+		    "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
+		    "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
+		    (*packs)->name, (*packs)->version, (*packs)->name, status,
+		    indexEntry == NULL ? "" : indexEntry->version,
+		    indexEntry == NULL ? "" : indexEntry->license, origin, flavor, os_release, cpe,
+		    purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no",
+		    no_shlib_provided ? "yes" : "no", deprecated, expdate_str, insdate_str,
+		    indexEntry == NULL ? "" : indexEntry->comment, annotations_str, options,
+		    type == MPORT_TYPE_APP ? "Application" : "System", flatsize_str, desc);
 	} else {
 		/* Not installed locally; report index information only. */
 		asprintf(&info_text,
-	         "%s-%s\n"
-	         "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
-	         "Flavor          : %s\nOS              : %s\n"
-	         "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
-	         "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
-	         indexEntry->pkgname, indexEntry->version,
-	         indexEntry->pkgname, status, indexEntry->version, indexEntry->license == NULL ? "" : indexEntry->license, origin,
-	         flavor, os_release,
-		 cpe, purl, locked ? "yes" : "no", automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no", deprecated,
-	         "",  /* expiration date: not installed, always empty */
-	         "\n", /* install date: not installed, always empty */
-	         indexEntry->comment == NULL ? "" : indexEntry->comment,
-	         annotations_str,
-	         options,
-		 type == MPORT_TYPE_APP ? "Application" : "System",
-		 flatsize_str,
-		 desc);
+		    "%s-%s\n"
+		    "Name            : %s\nVersion         : %s\nLatest          : %s\nLicenses        : %s\nOrigin          : %s\n"
+		    "Flavor          : %s\nOS              : %s\n"
+		    "CPE             : %s\nPURL            : %s\nLocked          : %s\nPrime           : %s\nShared library  : %s\nDeprecated      : %s\nExpiration Date : %s\nInstall Date    : %s"
+		    "Comment         : %s\n%sOptions         : %s\nType            : %s\nFlat Size       : %s\nDescription     :\n%s\n",
+		    indexEntry->pkgname, indexEntry->version, indexEntry->pkgname, status,
+		    indexEntry->version, indexEntry->license == NULL ? "" : indexEntry->license,
+		    origin, flavor, os_release, cpe, purl, locked ? "yes" : "no",
+		    automatic == MPORT_EXPLICIT ? "yes" : "no", no_shlib_provided ? "yes" : "no",
+		    deprecated, "", /* expiration date: not installed, always empty */
+		    "\n", /* install date: not installed, always empty */
+		    indexEntry->comment == NULL ? "" : indexEntry->comment, annotations_str,
+		    options, type == MPORT_TYPE_APP ? "Application" : "System", flatsize_str, desc);
 	}
 
 	if (info_text == NULL) {

--- a/libmport/install.c
+++ b/libmport/install.c
@@ -36,10 +36,10 @@
  * @brief Installs a package and its dependencies.
  *
  * This function initiates the installation process for a specified package,
- * including handling its dependencies. 
- * 
- * Behavior change: 
- * In mport 2.7.1, mport_install_single does the old behavior of this function. 
+ * including handling its dependencies.
+ *
+ * Behavior change:
+ * In mport 2.7.1, mport_install_single does the old behavior of this function.
  * Now we handle dependency installation also.
  *
  * @param mport     Pointer to the mportInstance.
@@ -51,12 +51,13 @@
  * @return MPORT_OK on success, or an error code on failure.
  */
 MPORT_PUBLIC_API int
-mport_install(mportInstance *mport, const char *pkgname, const char *version, const char *prefix, mportAutomatic automatic)
+mport_install(mportInstance *mport, const char *pkgname, const char *version, const char *prefix,
+    mportAutomatic automatic)
 {
-  MPORT_CHECK_FOR_INDEX(mport, "mport_install()");
+	MPORT_CHECK_FOR_INDEX(mport, "mport_install()");
 
-  // todo: handle prefix
-  return mport_install_depends(mport, pkgname, version, automatic);
+	// todo: handle prefix
+	return mport_install_depends(mport, pkgname, version, automatic);
 }
 
 /**
@@ -71,128 +72,136 @@ mport_install(mportInstance *mport, const char *pkgname, const char *version, co
  * @param version   Version of the package to install. Can be NULL for latest version.
  * @param prefix    Installation prefix. Can be NULL for default location.
  * @param automatic Flag indicating if the installation is automatic or user-initiated.
- * 
+ *
  * @since 2.7.1
  *
  * @return MPORT_OK on success, or an error code on failure.
  */
 MPORT_PUBLIC_API int
-mport_install_single(mportInstance *mport, const char *pkgname, const char *version, const char *prefix, mportAutomatic automatic)
+mport_install_single(mportInstance *mport, const char *pkgname, const char *version,
+    const char *prefix, mportAutomatic automatic)
 {
-  mportIndexEntry **e = NULL;
-  char *filename = NULL;
-  int ret = MPORT_OK;
-  int e_loc = 0;
+	mportIndexEntry **e = NULL;
+	char *filename = NULL;
+	int ret = MPORT_OK;
+	int e_loc = 0;
 
-  MPORT_CHECK_FOR_INDEX(mport, "mport_install_single()");
+	MPORT_CHECK_FOR_INDEX(mport, "mport_install_single()");
 
-  if (mport_index_lookup_pkgname(mport, pkgname, &e) != MPORT_OK) {
-      RETURN_CURRENT_ERROR;
-  }
+	if (mport_index_lookup_pkgname(mport, pkgname, &e) != MPORT_OK) {
+		RETURN_CURRENT_ERROR;
+	}
 
-  /* we don't support installing more than one top-level package at a time.
-   * Consider a situation like this:
-   *
-   * mport_install_single(mport, "p5-Class-DBI*");
-   *
-   * Say this matches p5-Class-DBI and p5-Class-DBI-AbstractSearch
-   * and say the order from the index puts p5-Class-DBI-AbstractSearch 
-   * first.
-   * 
-   * p5-Class-DBI-AbstractSearch is installed, and its dependencies installed.
-   * However, p5-Class-DBI is a dependency of p5-Class-DBI-AbstractSearch, so
-   * when it comes time to install p5-Class-DBI, we can't - because it is
-   * already installed.
-   *
-   * If a user facing application wants this functionality, it would be
-   * easy to piece together with mport_index_lookup_pkgname(), a
-   * check for already installed packages, and mport_install_single().
-   */
+	/* we don't support installing more than one top-level package at a time.
+	 * Consider a situation like this:
+	 *
+	 * mport_install_single(mport, "p5-Class-DBI*");
+	 *
+	 * Say this matches p5-Class-DBI and p5-Class-DBI-AbstractSearch
+	 * and say the order from the index puts p5-Class-DBI-AbstractSearch
+	 * first.
+	 *
+	 * p5-Class-DBI-AbstractSearch is installed, and its dependencies installed.
+	 * However, p5-Class-DBI is a dependency of p5-Class-DBI-AbstractSearch, so
+	 * when it comes time to install p5-Class-DBI, we can't - because it is
+	 * already installed.
+	 *
+	 * If a user facing application wants this functionality, it would be
+	 * easy to piece together with mport_index_lookup_pkgname(), a
+	 * check for already installed packages, and mport_install_single().
+	 */
 
-  if (e[1] != NULL) {
-    if (version != NULL) {
-        while (e[e_loc] != NULL) {
-          if (strcmp(e[e_loc]->version, version) == 0) {
-            break;
-          }
-          e_loc++;
-        }
-        if (e[e_loc] == NULL) {
-          mport_index_entry_free_vec(e);
-          e = NULL;
-          RETURN_ERRORX(MPORT_ERR_FATAL, "Could not resolve '%s-%s'.", pkgname, version);
-        }
-    } else {
-      mport_index_entry_free_vec(e);
-      RETURN_ERRORX(MPORT_ERR_FATAL, "Could not resolve '%s' to a single package.", pkgname);
-    }
-  }
+	if (e[1] != NULL) {
+		if (version != NULL) {
+			while (e[e_loc] != NULL) {
+				if (strcmp(e[e_loc]->version, version) == 0) {
+					break;
+				}
+				e_loc++;
+			}
+			if (e[e_loc] == NULL) {
+				mport_index_entry_free_vec(e);
+				e = NULL;
+				RETURN_ERRORX(MPORT_ERR_FATAL, "Could not resolve '%s-%s'.",
+				    pkgname, version);
+			}
+		} else {
+			mport_index_entry_free_vec(e);
+			RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "Could not resolve '%s' to a single package.", pkgname);
+		}
+	}
 
-  if (asprintf(&filename, "%s/%s", MPORT_LOCAL_PKG_PATH, e[e_loc]->bundlefile) == -1) {
-    mport_index_entry_free_vec(e);
-    e = NULL;
-    RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-  }
+	if (asprintf(&filename, "%s/%s", MPORT_LOCAL_PKG_PATH, e[e_loc]->bundlefile) == -1) {
+		mport_index_entry_free_vec(e);
+		e = NULL;
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	}
 
-  if (!mport_file_exists(filename)) {
-    free(filename);
+	if (!mport_file_exists(filename)) {
+		free(filename);
 
-    /* fallback to install media location default */
-    if (asprintf(&filename, "%s/%s", MPORT_INSTALL_MEDIA_DIR, e[e_loc]->bundlefile) == -1) {
-      mport_index_entry_free_vec(e);
-      e = NULL;
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-    }
+		/* fallback to install media location default */
+		if (asprintf(&filename, "%s/%s", MPORT_INSTALL_MEDIA_DIR, e[e_loc]->bundlefile) ==
+		    -1) {
+			mport_index_entry_free_vec(e);
+			e = NULL;
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+		}
 
-    if (!mport_file_exists(filename)) {
-      free(filename);
-      filename = NULL;
+		if (!mport_file_exists(filename)) {
+			free(filename);
+			filename = NULL;
 
-      /* neither location works. Download from the internet. */
-        if (mport_fetch_bundle(mport, MPORT_FETCH_STAGING_DIR, e[e_loc]->bundlefile) != MPORT_OK) {
-            free(filename);
-            filename = NULL;
-            mport_index_entry_free_vec(e);
-            e = NULL;
-            RETURN_CURRENT_ERROR;
-        }
-      if (asprintf(&filename, "%s/%s", MPORT_FETCH_STAGING_DIR, e[e_loc]->bundlefile) == -1) {
-        mport_index_entry_free_vec(e);
-        e = NULL;
-        RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-      }
-    }
-  }
+			/* neither location works. Download from the internet. */
+			if (mport_fetch_bundle(
+				mport, MPORT_FETCH_STAGING_DIR, e[e_loc]->bundlefile) != MPORT_OK) {
+				free(filename);
+				filename = NULL;
+				mport_index_entry_free_vec(e);
+				e = NULL;
+				RETURN_CURRENT_ERROR;
+			}
+			if (asprintf(&filename, "%s/%s", MPORT_FETCH_STAGING_DIR,
+				e[e_loc]->bundlefile) == -1) {
+				mport_index_entry_free_vec(e);
+				e = NULL;
+				RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+			}
+		}
+	}
 
-  if (mport_verify_hash(filename, e[e_loc]->hash) == 0) {
-	  mport_index_entry_free_vec(e);
+	if (mport_verify_hash(filename, e[e_loc]->hash) == 0) {
+		mport_index_entry_free_vec(e);
 
-	  if (unlink(filename) == 0) {
-		  free(filename);
-		  filename = NULL;
-		  RETURN_ERROR(
-		      MPORT_ERR_FATAL, "Package failed hash verification and was removed.\n");
-	  } else {
-		  free(filename);
-		  filename = NULL;
-		  RETURN_ERROR(MPORT_ERR_FATAL,
-		      "Package failed hash verification, but could not be removed.\n");
-	  }
-  }
+		if (unlink(filename) == 0) {
+			free(filename);
+			filename = NULL;
+			RETURN_ERROR(
+			    MPORT_ERR_FATAL, "Package failed hash verification and was removed.\n");
+		} else {
+			free(filename);
+			filename = NULL;
+			RETURN_ERROR(MPORT_ERR_FATAL,
+			    "Package failed hash verification, but could not be removed.\n");
+		}
+	}
 
-  ret = mport_install_primative(mport, filename, prefix, automatic);
+	ret = mport_install_primative(mport, filename, prefix, automatic);
 
-  free(filename);
-  filename = NULL;
-  mport_index_entry_free_vec(e);
-  e = NULL;
+	free(filename);
+	filename = NULL;
+	mport_index_entry_free_vec(e);
+	e = NULL;
 
-  return ret;
+	return ret;
 }
 
 /* recursive function */
 int
-mport_install_depends(mportInstance *mport, const char *packageName, const char *version, mportAutomatic automatic) {
+mport_install_depends(
+    mportInstance *mport, const char *packageName, const char *version, mportAutomatic automatic)
+{
 	mportPackageMeta **packs = NULL;
 	mportDependsEntry **depends = NULL;
 	mportDependsEntry **depends_orig = NULL;
@@ -203,7 +212,7 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 
 	mport_index_depends_list(mport, packageName, version, &depends_orig);
 	depends = depends_orig;
- 
+
 	if (mport_pkgmeta_search_master(mport, &packs, "pkg=%Q", packageName) != MPORT_OK) {
 		mport_call_msg_cb(mport, "%s", mport_err_string());
 		return mport_err_code();
@@ -211,19 +220,21 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 
 	if (packs == NULL && depends == NULL) {
 		/* Package is not installed and there are no dependencies */
-		if (mport_install_single(mport, packageName, version, NULL, automatic) != MPORT_OK) {
+		if (mport_install_single(mport, packageName, version, NULL, automatic) !=
+		    MPORT_OK) {
 			mport_call_msg_cb(mport, "%s", mport_err_string());
 			return mport_err_code();
 		}
 	} else if (packs == NULL) {
 		/* Package is not installed */
 		for (mportDependsEntry **dep = depends; dep && *dep != NULL; dep++) {
-			if (mport_install_depends(mport, (*dep)->d_pkgname, (*dep)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
+			if (mport_install_depends(mport, (*dep)->d_pkgname, (*dep)->d_version,
+				MPORT_AUTOMATIC) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
 				mport_index_depends_free_vec(depends_orig);
 				depends_orig = NULL;
 				if (mport->ignoreMissing) {
-				    continue;
+					continue;
 				}
 				return mport_err_code();
 			}
@@ -246,7 +257,8 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 		depends_orig = NULL;
 		depends = NULL;
 
-		if (mport_check_preconditions(mport, packs[0], MPORT_PRECHECK_UPGRADEABLE) == MPORT_OK) {
+		if (mport_check_preconditions(mport, packs[0], MPORT_PRECHECK_UPGRADEABLE) ==
+		    MPORT_OK) {
 			if (mport_update(mport, packageName) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
 				mport_pkgmeta_vec_free(packs);
@@ -258,14 +270,16 @@ mport_install_depends(mportInstance *mport, const char *packageName, const char 
 			/* force reinstall of already-installed package, regardless of version */
 			mport_pkgmeta_vec_free(packs);
 			packs = NULL;
-			if (mport_install_single(mport, packageName, version, NULL, automatic) != MPORT_OK) {
+			if (mport_install_single(mport, packageName, version, NULL, automatic) !=
+			    MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
 				return mport_err_code();
 			}
 		} else {
 			if (getenv("MPORT_GUI") == NULL) {
 				mport_call_msg_cb(mport,
-			    	"The most recent version of %s is already installed.", packageName);
+				    "The most recent version of %s is already installed.",
+				    packageName);
 			}
 			mport_pkgmeta_vec_free(packs);
 		}

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -35,15 +35,15 @@
 #include <sys/statvfs.h>
 #include <libutil.h>
 
-static char ** get_dependencies(mportInstance *mport, mportPackageMeta *pack);
+static char **get_dependencies(mportInstance *mport, mportPackageMeta *pack);
 static char *find_file_with_prefix(const char *dir, const char *prefix);
 
-#define GOTO_CLEANUP_ON_MPORT_ERR(expr) \
-	do { \
-		if ((expr) != MPORT_OK) { \
+#define GOTO_CLEANUP_ON_MPORT_ERR(expr)         \
+	do {                                    \
+		if ((expr) != MPORT_OK) {       \
 			ret = mport_err_code(); \
-			goto cleanup; \
-		} \
+			goto cleanup;           \
+		}                               \
 	} while (0)
 
 static char **
@@ -86,7 +86,7 @@ get_dependencies(mportInstance *mport, mportPackageMeta *pkg)
 		return NULL;
 	}
 
-    int i = 0;
+	int i = 0;
 	while (1) {
 		const char *depend_pkg, *depend_version;
 
@@ -101,7 +101,8 @@ get_dependencies(mportInstance *mport, mportPackageMeta *pkg)
 					return NULL;
 				}
 			} else {
-				if (asprintf(&dependencies[i], "%s-%s", depend_pkg, depend_version) == -1) {
+				if (asprintf(&dependencies[i], "%s-%s", depend_pkg,
+					depend_version) == -1) {
 					sqlite3_finalize(stmt);
 					return NULL;
 				}
@@ -118,40 +119,42 @@ get_dependencies(mportInstance *mport, mportPackageMeta *pkg)
 		}
 
 		if (i == count)
-			break;	
+			break;
 	}
 
 	return dependencies;
 }
 
 char *
-find_file_with_prefix(const char *dir, const char *prefix) 
+find_file_with_prefix(const char *dir, const char *prefix)
 {
-    DIR *d;
-    struct dirent *dir_entry;
-    char *found_file = NULL;
-    size_t prefix_len = strlen(prefix);
+	DIR *d;
+	struct dirent *dir_entry;
+	char *found_file = NULL;
+	size_t prefix_len = strlen(prefix);
 
-    d = opendir(dir);
-    if (d) {
-        while ((dir_entry = readdir(d)) != NULL) {
-            if (strncmp(dir_entry->d_name, prefix, prefix_len) == 0) {
-                // Found a file with the correct prefix
-                found_file = malloc(strlen(dir) + strlen(dir_entry->d_name) + 2); // +2 for '/' and null terminator
-                if (found_file) {
-                    sprintf(found_file, "%s/%s", dir, dir_entry->d_name);
-                }
-                break;
-            }
-        }
-        closedir(d);
-    }
+	d = opendir(dir);
+	if (d) {
+		while ((dir_entry = readdir(d)) != NULL) {
+			if (strncmp(dir_entry->d_name, prefix, prefix_len) == 0) {
+				// Found a file with the correct prefix
+				found_file = malloc(strlen(dir) + strlen(dir_entry->d_name) +
+				    2); // +2 for '/' and null terminator
+				if (found_file) {
+					sprintf(found_file, "%s/%s", dir, dir_entry->d_name);
+				}
+				break;
+			}
+		}
+		closedir(d);
+	}
 
-    return found_file;
+	return found_file;
 }
 
 MPORT_PUBLIC_API int
-mport_install_primative(mportInstance *mport, const char *filename, const char *prefix, mportAutomatic automatic)
+mport_install_primative(
+    mportInstance *mport, const char *filename, const char *prefix, mportAutomatic automatic)
 {
 	mportBundleRead *bundle = NULL;
 	mportPackageMeta **already_installed = NULL;
@@ -166,11 +169,11 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 	if (mport == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "mport not initialized");
 
-		/* There are two scenarios here.  
-		   1. We are installing online with an index and have already fetched dependencies. 
-		   2. We are installing from a local package file. Check if the dependencies are availaible in the
-		   same directory that are missing.
-		*/
+	/* There are two scenarios here.
+	   1. We are installing online with an index and have already fetched dependencies.
+	   2. We are installing from a local package file. Check if the dependencies are availaible
+	   in the same directory that are missing.
+	*/
 	if (mport->offline) {
 		// temporarily open pkg file to get metadata.
 		if ((bundle = mport_bundle_read_new()) == NULL)
@@ -181,27 +184,32 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 		GOTO_CLEANUP_ON_MPORT_ERR(mport_pkgmeta_read_stub(mport, &pkgs));
 
 		if (!mport_is_age_verified(mport, pkgs[0])) {
-			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkgs[0]->name, pkgs[0]->version);
+			mport_call_msg_cb(mport,
+			    "Unable to install %s-%s: package is age restricted and user does not meet the requirements.",
+			    pkgs[0]->name, pkgs[0]->version);
 			ret = MPORT_ERR_FATAL;
 			goto cleanup;
 		}
 
-		/* if we previously installed it and want to force, allow it.  
-		   In this case, automatic flag from previous install not honored 
+		/* if we previously installed it and want to force, allow it.
+		   In this case, automatic flag from previous install not honored
 		*/
-		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_INSTALLED) != MPORT_OK) {
+		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_INSTALLED) !=
+		    MPORT_OK) {
 			if (mport->force) {
 				mport_delete_primative(mport, pkgs[0], 1);
 			} else {
-				mport_call_msg_cb(mport, "%s-%s: already installed.", pkgs[0]->name, pkgs[0]->version);
+				mport_call_msg_cb(mport, "%s-%s: already installed.", pkgs[0]->name,
+				    pkgs[0]->version);
 				ret = MPORT_OK;
 				goto cleanup;
 			}
 		}
 
-		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_CONFLICTS) != MPORT_OK) {
-			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkgs[0]->name, pkgs[0]->version,
-			                  mport_err_string());
+		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_CONFLICTS) !=
+		    MPORT_OK) {
+			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkgs[0]->name,
+			    pkgs[0]->version, mport_err_string());
 			ret = MPORT_ERR_FATAL;
 			goto cleanup;
 		}
@@ -221,8 +229,8 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 
 		deps = dependencies;
 		dir = mport_directory(filename);
-		while (deps!= NULL && *deps != NULL) {
-			char *dep_filename = NULL; 
+		while (deps != NULL && *deps != NULL) {
+			char *dep_filename = NULL;
 			if (asprintf(&dep_filename, "%s/%s.mport", dir, *deps) == -1) {
 				deps++;
 				continue;
@@ -232,14 +240,17 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 				free(dep_filename);
 				dep_filename = find_file_with_prefix(dir, *deps);
 				if (dep_filename == NULL) {
-	    			mport_call_msg_cb(mport, "Dependency %s not found in %s", *deps, dir);
-	    			deps++;
-		   			continue;
+					mport_call_msg_cb(
+					    mport, "Dependency %s not found in %s", *deps, dir);
+					deps++;
+					continue;
 				}
 			}
 
-			if (mport_install_primative(mport, dep_filename, prefix, MPORT_AUTOMATIC)!= MPORT_OK) {
-				mport_call_msg_cb(mport, "Unable to install %s: %s", *deps, mport_err_string());
+			if (mport_install_primative(mport, dep_filename, prefix, MPORT_AUTOMATIC) !=
+			    MPORT_OK) {
+				mport_call_msg_cb(
+				    mport, "Unable to install %s: %s", *deps, mport_err_string());
 				if (!mport->ignoreMissing) {
 					free(dep_filename);
 					ret = MPORT_ERR_FATAL;
@@ -252,7 +263,8 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 	}
 
 	if ((bundle = mport_bundle_read_new()) == NULL) {
-		ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
+		ret = mport_set_errx(
+		    MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
 		goto cleanup;
 	}
 
@@ -262,20 +274,24 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 
 	for (i = 0; *(pkgs + i) != NULL; i++) {
 		pkg = pkgs[i];
-        pkg->automatic = automatic;
+		pkg->automatic = automatic;
 		pkg->install_date = mport_get_time();
 		pkg->action = MPORT_ACTION_INSTALL;
 
 		if (!mport_is_age_verified(mport, pkg)) {
-			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkg->name, pkg->version);
+			mport_call_msg_cb(mport,
+			    "Unable to install %s-%s: package is age restricted and user does not meet the requirements.",
+			    pkg->name, pkg->version);
 			ret = MPORT_ERR_FATAL;
 			break; /* do not keep going if we have an age verification failure! */
 		}
 
-		if (mport_pkgmeta_search_master(mport, &already_installed, "pkg=%Q", pkg->name) == MPORT_OK) {
+		if (mport_pkgmeta_search_master(mport, &already_installed, "pkg=%Q", pkg->name) ==
+		    MPORT_OK) {
 			if (already_installed != NULL && already_installed[0] != NULL) {
 				if (mport->force) {
-					pkg->automatic = already_installed[0]->automatic; // honor old flag
+					pkg->automatic =
+					    already_installed[0]->automatic; // honor old flag
 				}
 				mport_pkgmeta_vec_free(already_installed);
 				already_installed = NULL;
@@ -286,42 +302,49 @@ mport_install_primative(mportInstance *mport, const char *filename, const char *
 			/* override the default prefix with the given prefix */
 			free(pkg->prefix);
 			if ((pkg->prefix = strdup(prefix)) == NULL) { /* all hope is lost! bail */
-				ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s", __FILE__, __LINE__, "Out of memory.");
+				ret = mport_set_errx(MPORT_ERR_FATAL, "Error at %s:(%d): %s",
+				    __FILE__, __LINE__, "Out of memory.");
 				goto cleanup;
 			}
 		}
 
 		if (pkg->flatsize > 0) {
 			struct statvfs sfs;
-			const char *check_path = (mport->root != NULL && mport->root[0] != '\0') ? mport->root : pkg->prefix;
+			const char *check_path = (mport->root != NULL && mport->root[0] != '\0') ?
+			    mport->root :
+			    pkg->prefix;
 			if (statvfs(check_path, &sfs) == 0) {
 				int64_t avail_bytes;
 				if (sfs.f_frsize != 0 &&
-				    (uintmax_t)sfs.f_bavail > (uintmax_t)INT64_MAX / (uintmax_t)sfs.f_frsize) {
+				    (uintmax_t)sfs.f_bavail >
+					(uintmax_t)INT64_MAX / (uintmax_t)sfs.f_frsize) {
 					avail_bytes = INT64_MAX;
 				} else {
-					avail_bytes = (int64_t)((uintmax_t)sfs.f_bavail * (uintmax_t)sfs.f_frsize);
+					avail_bytes = (int64_t)((uintmax_t)sfs.f_bavail *
+					    (uintmax_t)sfs.f_frsize);
 				}
 				if (pkg->flatsize > avail_bytes) {
 					char avail_str[32], need_str[32];
-					humanize_number(avail_str, sizeof(avail_str), avail_bytes, "B",
-					    HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
-					humanize_number(need_str, sizeof(need_str), pkg->flatsize, "B",
-					    HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
+					humanize_number(avail_str, sizeof(avail_str), avail_bytes,
+					    "B", HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
+					humanize_number(need_str, sizeof(need_str), pkg->flatsize,
+					    "B", HN_AUTOSCALE, HN_DECIMAL | HN_IEC_PREFIXES);
 					mport_call_msg_cb(mport,
 					    "Warning: %s-%s requires %s but only %s is available on %s.",
-					    pkg->name, pkg->version, need_str, avail_str, check_path);
+					    pkg->name, pkg->version, need_str, avail_str,
+					    check_path);
 				}
 			}
 		}
 
-		long precheck_flags = MPORT_PRECHECK_INSTALLED | MPORT_PRECHECK_DEPENDS | MPORT_PRECHECK_CONFLICTS;
+		long precheck_flags =
+		    MPORT_PRECHECK_INSTALLED | MPORT_PRECHECK_DEPENDS | MPORT_PRECHECK_CONFLICTS;
 		if (!mport->force)
 			precheck_flags |= MPORT_PRECHECK_FILE_CONFLICTS;
-		if ((mport_check_preconditions(mport, pkg, precheck_flags) != MPORT_OK)
-                   || (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
-			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkg->name, pkg->version,
-			                  mport_err_string());
+		if ((mport_check_preconditions(mport, pkg, precheck_flags) != MPORT_OK) ||
+		    (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
+			mport_call_msg_cb(mport, "Unable to install %s-%s: %s", pkg->name,
+			    pkg->version, mport_err_string());
 			ret = MPORT_ERR_FATAL;
 			break; /* do not keep going if we have a package failure! */
 		}

--- a/libmport/instance.c
+++ b/libmport/instance.c
@@ -37,7 +37,6 @@
 #include "mport.h"
 #include "mport_private.h"
 
-
 /**
  * @brief Allocates memory for a new mportInstance structure.
  *
@@ -48,16 +47,19 @@
  *         Returns NULL if memory allocation fails.
  */
 MPORT_PUBLIC_API mportInstance *
-mport_instance_new(void) {
+mport_instance_new(void)
+{
 
-    return (mportInstance *) calloc(1, sizeof(mportInstance));
+	return (mportInstance *)calloc(1, sizeof(mportInstance));
 }
 
 /**
  * Set up the master database, and related instance infrastructure.
  */
 MPORT_PUBLIC_API int
-mport_instance_init(mportInstance *mport, const char *root, const char *outputPath, bool noIndex, mportVerbosity verbosity) {
+mport_instance_init(mportInstance *mport, const char *root, const char *outputPath, bool noIndex,
+    mportVerbosity verbosity)
+{
 
 	char dir[FILENAME_MAX];
 	mport->flags = 0;
@@ -66,20 +68,20 @@ mport_instance_init(mportInstance *mport, const char *root, const char *outputPa
 	mport->verbosity = verbosity;
 	mport->offline = false;
 	mport->force = false;
-    mport->ignoreMissing = false;
+	mport->ignoreMissing = false;
 
 	if (root != NULL) {
 		mport->root = strdup(root);
 		if (mport->root == NULL)
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
-    	if ((mport->rootfd = open(mport->root, O_DIRECTORY|O_RDONLY|O_CLOEXEC)) < 0) {
+		if ((mport->rootfd = open(mport->root, O_DIRECTORY | O_RDONLY | O_CLOEXEC)) < 0) {
 			RETURN_ERROR(MPORT_ERR_FATAL, "unable to open root directory");
-    	}
+		}
 	} else {
 		mport->root = strdup("");
 		if (mport->root == NULL)
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
-		if ((mport->rootfd = open("/", O_DIRECTORY|O_RDONLY|O_CLOEXEC)) < 0) {
+		if ((mport->rootfd = open("/", O_DIRECTORY | O_RDONLY | O_CLOEXEC)) < 0) {
 			RETURN_ERROR(MPORT_ERR_FATAL, "unable to open root directory");
 		}
 	}
@@ -94,32 +96,30 @@ mport_instance_init(mportInstance *mport, const char *root, const char *outputPa
 			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
 	}
 
-	(void) snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_INST_DIR);
+	(void)snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_INST_DIR);
 
 	if (mport_mkdir(dir) != MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
-	(void) snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_INST_INFRA_DIR);
+	(void)snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_INST_INFRA_DIR);
 
 	if (mport_mkdir(dir) != MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
 	/* dir is a file here, just trying to save memory */
-	(void) snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_MASTER_DB_FILE);
+	(void)snprintf(dir, FILENAME_MAX, "%s/%s", mport->root, MPORT_MASTER_DB_FILE);
 	if (sqlite3_open(dir, &(mport->db)) != 0) {
 		sqlite3_close(mport->db);
 		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 	}
 
-	if (sqlite3_create_function(mport->db, "mport_version_cmp", 2, SQLITE_ANY, NULL, &mport_version_cmp_sqlite,
-								NULL,
-								NULL) != SQLITE_OK) {
+	if (sqlite3_create_function(mport->db, "mport_version_cmp", 2, SQLITE_ANY, NULL,
+		&mport_version_cmp_sqlite, NULL, NULL) != SQLITE_OK) {
 		sqlite3_close(mport->db);
 		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 	}
-
 
 	/* set the default UI callbacks */
 	mport->msg_cb = &mport_default_msg_cb;
@@ -141,7 +141,6 @@ mport_instance_init(mportInstance *mport, const char *root, const char *outputPa
 	return mport_upgrade_master_schema(mport->db, db_version);
 }
 
-
 /**
  * @brief Retrieves the version of the mport database schema.
  *
@@ -154,18 +153,19 @@ mport_instance_init(mportInstance *mport, const char *root, const char *outputPa
  *         or -1 if an error occurred or the version could not be retrieved.
  */
 int
-mport_get_database_version(sqlite3 *db) {
-    int databaseVersion = -1; /* ERROR condition */
+mport_get_database_version(sqlite3 *db)
+{
+	int databaseVersion = -1; /* ERROR condition */
 
-    sqlite3_stmt *stmt_version;
-        if (sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &stmt_version, NULL) == SQLITE_OK) {
-            while (sqlite3_step(stmt_version) == SQLITE_ROW) {
-                databaseVersion = sqlite3_column_int(stmt_version, 0);
-            }
-        }
-        sqlite3_finalize(stmt_version);
+	sqlite3_stmt *stmt_version;
+	if (sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &stmt_version, NULL) == SQLITE_OK) {
+		while (sqlite3_step(stmt_version) == SQLITE_ROW) {
+			databaseVersion = sqlite3_column_int(stmt_version, 0);
+		}
+	}
+	sqlite3_finalize(stmt_version);
 
-    return databaseVersion;
+	return databaseVersion;
 }
 
 /**
@@ -181,19 +181,20 @@ mport_get_database_version(sqlite3 *db) {
  *         or an error code if the operation fails.
  */
 int
-mport_set_database_version(sqlite3 *db) {
-    char *sql;
+mport_set_database_version(sqlite3 *db)
+{
+	char *sql;
 
-    asprintf(&sql, "PRAGMA user_version=%d", MPORT_MASTER_VERSION);
+	asprintf(&sql, "PRAGMA user_version=%d", MPORT_MASTER_VERSION);
 
-    if (mport_db_do(db, sql) != MPORT_OK) {
-        free(sql);
-        RETURN_CURRENT_ERROR;
-    }
+	if (mport_db_do(db, sql) != MPORT_OK) {
+		free(sql);
+		RETURN_CURRENT_ERROR;
+	}
 
-    free(sql);
+	free(sql);
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 /* Setters for the variable UI callbacks. */
@@ -211,8 +212,9 @@ mport_set_database_version(sqlite3 *db) {
  * @return This function does not return a value.
  */
 MPORT_PUBLIC_API void
-mport_set_msg_cb(mportInstance *mport, mport_msg_cb cb) {
-    mport->msg_cb = cb;
+mport_set_msg_cb(mportInstance *mport, mport_msg_cb cb)
+{
+	mport->msg_cb = cb;
 }
 
 /**
@@ -229,8 +231,9 @@ mport_set_msg_cb(mportInstance *mport, mport_msg_cb cb) {
  * @return This function does not return a value.
  */
 MPORT_PUBLIC_API void
-mport_set_progress_init_cb(mportInstance *mport, mport_progress_init_cb cb) {
-    mport->progress_init_cb = cb;
+mport_set_progress_init_cb(mportInstance *mport, mport_progress_init_cb cb)
+{
+	mport->progress_init_cb = cb;
 }
 
 /**
@@ -247,8 +250,9 @@ mport_set_progress_init_cb(mportInstance *mport, mport_progress_init_cb cb) {
  * @return This function does not return a value.
  */
 MPORT_PUBLIC_API void
-mport_set_progress_step_cb(mportInstance *mport, mport_progress_step_cb cb) {
-    mport->progress_step_cb = cb;
+mport_set_progress_step_cb(mportInstance *mport, mport_progress_step_cb cb)
+{
+	mport->progress_step_cb = cb;
 }
 
 /**
@@ -265,8 +269,9 @@ mport_set_progress_step_cb(mportInstance *mport, mport_progress_step_cb cb) {
  * @return This function does not return a value.
  */
 MPORT_PUBLIC_API void
-mport_set_progress_free_cb(mportInstance *mport, mport_progress_free_cb cb) {
-    mport->progress_free_cb = cb;
+mport_set_progress_free_cb(mportInstance *mport, mport_progress_free_cb cb)
+{
+	mport->progress_free_cb = cb;
 }
 
 /**
@@ -283,17 +288,18 @@ mport_set_progress_free_cb(mportInstance *mport, mport_progress_free_cb cb) {
  * @return This function does not return a value.
  */
 MPORT_PUBLIC_API void
-mport_set_confirm_cb(mportInstance *mport, mport_confirm_cb cb) {
-    mport->confirm_cb = cb;
+mport_set_confirm_cb(mportInstance *mport, mport_confirm_cb cb)
+{
+	mport->confirm_cb = cb;
 }
 
 MPORT_PUBLIC_API void
-mport_set_select_cb(mportInstance *mport, mport_select_cb cb) {
-    mport->select_cb = cb;
+mport_set_select_cb(mportInstance *mport, mport_select_cb cb)
+{
+	mport->select_cb = cb;
 }
 
 /* callers for the callbacks (only for msg at the moment) */
-
 
 /**
  * @brief Calls the message callback function with a formatted message.
@@ -308,23 +314,24 @@ mport_set_select_cb(mportInstance *mport, mport_select_cb cb) {
  * @return MPORT_OK on success, MPORT_ERR_WARN if message formatting fails.
  */
 MPORT_PUBLIC_API int
-mport_call_msg_cb(mportInstance *mport, const char *fmt, ...) {
-    va_list args;
+mport_call_msg_cb(mportInstance *mport, const char *fmt, ...)
+{
+	va_list args;
 
-    char *msg;
-    va_start(args, fmt);
-    (void) vasprintf(&msg, fmt, args);
-    va_end(args);
+	char *msg;
+	va_start(args, fmt);
+	(void)vasprintf(&msg, fmt, args);
+	va_end(args);
 
-    if (msg == NULL)
-        RETURN_ERROR(MPORT_ERR_WARN, "Unable to format message");
+	if (msg == NULL)
+		RETURN_ERROR(MPORT_ERR_WARN, "Unable to format message");
 
-    (mport->msg_cb)(msg);
+	(mport->msg_cb)(msg);
 
-    free(msg);
-    msg = NULL;
+	free(msg);
+	msg = NULL;
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 /**
@@ -344,25 +351,27 @@ mport_call_msg_cb(mportInstance *mport, const char *fmt, ...) {
  *         false if the user declines or the callback reports an error.
  */
 MPORT_PUBLIC_API bool
-mport_call_confirm_cb(mportInstance *mport, const char *msg, const char *yes, const char *no, int def) {
-    if (getenv("ASSUME_ALWAYS_YES") != NULL) {
-        return (true);
-    }
+mport_call_confirm_cb(
+    mportInstance *mport, const char *msg, const char *yes, const char *no, int def)
+{
+	if (getenv("ASSUME_ALWAYS_YES") != NULL) {
+		return (true);
+	}
 
-    return (mport->confirm_cb)(msg, yes, no, def) == MPORT_OK ? true : false;
+	return (mport->confirm_cb)(msg, yes, no, def) == MPORT_OK ? true : false;
 }
 
 MPORT_PUBLIC_API int
-mport_call_select_cb(mportInstance *mport, const char *msg, mportIndexEntry **choices, int def) {
-    if (mport == NULL || mport->select_cb == NULL)
-        RETURN_ERROR(MPORT_ERR_FATAL, "No package selection callback configured");
+mport_call_select_cb(mportInstance *mport, const char *msg, mportIndexEntry **choices, int def)
+{
+	if (mport == NULL || mport->select_cb == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "No package selection callback configured");
 
-    if (choices == NULL || *choices == NULL)
-        RETURN_ERROR(MPORT_ERR_FATAL, "No package choices were provided");
+	if (choices == NULL || *choices == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "No package choices were provided");
 
-    return (mport->select_cb)(msg, choices, def);
+	return (mport->select_cb)(msg, choices, def);
 }
-
 
 /**
  * @brief Initializes and calls the progress callback with a formatted title.
@@ -377,24 +386,24 @@ mport_call_select_cb(mportInstance *mport, const char *msg, mportIndexEntry **ch
  * @return MPORT_OK on success, MPORT_ERR_WARN if title formatting fails.
  */
 MPORT_PUBLIC_API int
-mport_call_progress_init_cb(mportInstance *mport, const char *fmt, ...) {
-    va_list args;
-    char *title = NULL;
+mport_call_progress_init_cb(mportInstance *mport, const char *fmt, ...)
+{
+	va_list args;
+	char *title = NULL;
 
-    va_start(args, fmt);
-    (void) vasprintf(&title, fmt, args);
+	va_start(args, fmt);
+	(void)vasprintf(&title, fmt, args);
 
-    if (title == NULL)
-        RETURN_ERROR(MPORT_ERR_WARN, "Unable to format progress title");
+	if (title == NULL)
+		RETURN_ERROR(MPORT_ERR_WARN, "Unable to format progress title");
 
-    (mport->progress_init_cb)(title);
+	(mport->progress_init_cb)(title);
 
-    free(title);
-    title = NULL;
+	free(title);
+	title = NULL;
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
-
 
 /**
  * @brief Frees resources associated with a mportInstance.
@@ -402,23 +411,26 @@ mport_call_progress_init_cb(mportInstance *mport, const char *fmt, ...) {
  * This function closes the SQLite database connection, closes the root file descriptor,
  * frees allocated memory for root and outputPath, and finally frees the mportInstance itself.
  *
- * @param mport Pointer to the mportInstance to be freed. The pointer becomes invalid after this call.
+ * @param mport Pointer to the mportInstance to be freed. The pointer becomes invalid after this
+ * call.
  *
- * @return MPORT_OK on successful freeing of resources, or MPORT_ERR_FATAL if there's an error closing the database.
+ * @return MPORT_OK on successful freeing of resources, or MPORT_ERR_FATAL if there's an error
+ * closing the database.
  */
 MPORT_PUBLIC_API int
-mport_instance_free(mportInstance *mport) {
-    if (sqlite3_close(mport->db) != SQLITE_OK) {
-        RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-    }
+mport_instance_free(mportInstance *mport)
+{
+	if (sqlite3_close(mport->db) != SQLITE_OK) {
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+	}
 
-    close(mport->rootfd);
-    free(mport->root);
-    mport->root = NULL;
+	close(mport->rootfd);
+	free(mport->root);
+	mport->root = NULL;
 
-    free(mport->outputPath);
-    mport->outputPath = NULL;
-    free(mport);
+	free(mport->outputPath);
+	mport->outputPath = NULL;
+	free(mport);
 
-    return MPORT_OK;
+	return MPORT_OK;
 }

--- a/libmport/list.c
+++ b/libmport/list.c
@@ -37,7 +37,7 @@
 #include <unistd.h>
 
 MPORT_PUBLIC_API int
-mport_list_print(mportInstance *mport, mportListPrint *print) 
+mport_list_print(mportInstance *mport, mportListPrint *print)
 {
 
 	mportPackageMeta **packs = NULL;
@@ -64,34 +64,44 @@ mport_list_print(mportInstance *mport, mportListPrint *print)
 
 	while (*packs != NULL) {
 		if (print->update) {
-			if (mport_index_lookup_pkgname(mport, (*packs)->name, &indexEntries) != MPORT_OK) {
-				RETURN_ERRORX(MPORT_ERR_FATAL, "Error looking up package name %s: %d %s", (*packs)->name, mport_err_code(), mport_err_string());
+			if (mport_index_lookup_pkgname(mport, (*packs)->name, &indexEntries) !=
+			    MPORT_OK) {
+				RETURN_ERRORX(MPORT_ERR_FATAL,
+				    "Error looking up package name %s: %d %s", (*packs)->name,
+				    mport_err_code(), mport_err_string());
 			}
 
 			if (indexEntries == NULL || *indexEntries == NULL) {
-				if (mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK) {
-					mport_call_msg_cb(mport,"%-30s %9s     is not part of the package repository.", (*packs)->name, (*packs)->version);
+				if (mport_moved_lookup(mport, (*packs)->origin, &movedEntries) !=
+				    MPORT_OK) {
+					mport_call_msg_cb(mport,
+					    "%-30s %9s     is not part of the package repository.",
+					    (*packs)->name, (*packs)->version);
 					packs++;
 					continue;
 				}
 
 				if (movedEntries != NULL && *movedEntries != NULL) {
-					if ((*movedEntries)->moved_to[0]!= '\0') {
-						mport_call_msg_cb(mport,"%-30s %9s     was moved to %s", (*packs)->name, (*packs)->version, (*movedEntries)->moved_to);
+					if ((*movedEntries)->moved_to[0] != '\0') {
+						mport_call_msg_cb(mport,
+						    "%-30s %9s     was moved to %s", (*packs)->name,
+						    (*packs)->version, (*movedEntries)->moved_to);
 						free(movedEntries);
 						movedEntries = NULL;
 						packs++;
 						continue;
 					}
-	
-					if ((*movedEntries)->date[0]!= '\0') {
-						mport_call_msg_cb(mport,"%-30s %9s     expired on %s", (*packs)->name, (*packs)->version, (*movedEntries)->date);
+
+					if ((*movedEntries)->date[0] != '\0') {
+						mport_call_msg_cb(mport,
+						    "%-30s %9s     expired on %s", (*packs)->name,
+						    (*packs)->version, (*movedEntries)->date);
 						free(movedEntries);
 						movedEntries = NULL;
 						packs++;
 						continue;
 					}
-	
+
 					free(movedEntries);
 					movedEntries = NULL;
 				}
@@ -111,21 +121,30 @@ mport_list_print(mportInstance *mport, mportListPrint *print)
 					continue;
 				}
 			}
-	
-			iestart = indexEntries;		
+
+			iestart = indexEntries;
 			while (indexEntries != NULL && *indexEntries != NULL) {
-				if (((*indexEntries)->version != NULL && mport_version_cmp((*packs)->version, (*indexEntries)->version) < 0) 
-					|| ((*packs)->version != NULL && mport_version_cmp((*packs)->os_release, os_release) < 0)) {
+				if (((*indexEntries)->version != NULL &&
+					mport_version_cmp(
+					    (*packs)->version, (*indexEntries)->version) < 0) ||
+				    ((*packs)->version != NULL &&
+					mport_version_cmp((*packs)->os_release, os_release) < 0)) {
 
 					if (mport->verbosity == MPORT_VVERBOSE) {
-						mport_call_msg_cb(mport,"%-30s %9s (%s)  <  %-9s %-30s", (*packs)->name, (*packs)->version, (*packs)->os_release, (*indexEntries)->version, (*indexEntries)->pkgname);
+						mport_call_msg_cb(mport,
+						    "%-30s %9s (%s)  <  %-9s %-30s", (*packs)->name,
+						    (*packs)->version, (*packs)->os_release,
+						    (*indexEntries)->version,
+						    (*indexEntries)->pkgname);
 					} else {
-						mport_call_msg_cb(mport,"%-30s %9s  <  %-9s", (*packs)->name, (*packs)->version, (*indexEntries)->version);
+						mport_call_msg_cb(mport, "%-30s %9s  <  %-9s",
+						    (*packs)->name, (*packs)->version,
+						    (*indexEntries)->version);
 					}
 				}
 				indexEntries++;
 			}
-				
+
 			mport_index_entry_free_vec(iestart);
 			iestart = NULL;
 			indexEntries = NULL;
@@ -134,22 +153,24 @@ mport_list_print(mportInstance *mport, mportListPrint *print)
 		} else if (mport->verbosity == MPORT_VVERBOSE || print->verbose) {
 			comment = mport_str_remove((*packs)->comment, '\\');
 			snprintf(name_version, 30, "%s-%s", (*packs)->name, (*packs)->version);
-			
-			mport_call_msg_cb(mport,"%-30s\t%6s\t%s", name_version, (*packs)->os_release, comment);
+
+			mport_call_msg_cb(
+			    mport, "%-30s\t%6s\t%s", name_version, (*packs)->os_release, comment);
 			free(comment);
 			comment = NULL;
 		} else if (print->prime && (*packs)->automatic == 0) {
-			mport_call_msg_cb(mport,"%s", (*packs)->name);
+			mport_call_msg_cb(mport, "%s", (*packs)->name);
 		} else if (mport->verbosity == MPORT_VQUIET && !print->origin) {
-			mport_call_msg_cb(mport,"%s", (*packs)->name);
+			mport_call_msg_cb(mport, "%s", (*packs)->name);
 		} else if (mport->verbosity == MPORT_VQUIET && print->origin) {
-			mport_call_msg_cb(mport,"%s", (*packs)->origin);
+			mport_call_msg_cb(mport, "%s", (*packs)->origin);
 		} else if (print->origin) {
-			mport_call_msg_cb(mport,"Information for %s-%s:\n\nOrigin:\n%s\n",
-						  (*packs)->name, (*packs)->version, (*packs)->origin);
+			mport_call_msg_cb(mport, "Information for %s-%s:\n\nOrigin:\n%s\n",
+			    (*packs)->name, (*packs)->version, (*packs)->origin);
 		} else if (print->locks) {
 			if ((*packs)->locked == 1)
-				mport_call_msg_cb(mport,"%s-%s", (*packs)->name, (*packs)->version);
+				mport_call_msg_cb(
+				    mport, "%s-%s", (*packs)->name, (*packs)->version);
 
 		} else {
 			mport_call_msg_cb(mport, "%s-%s", (*packs)->name, (*packs)->version);

--- a/libmport/lock.c
+++ b/libmport/lock.c
@@ -43,7 +43,8 @@ mport_lock_lock(mportInstance *mport, mportPackageMeta *pkg)
 		return (MPORT_OK);
 	}
 
-	if (mport_db_do(mport->db, "update packages set locked=1 where pkg=%Q", pkg->name) != MPORT_OK) {
+	if (mport_db_do(mport->db, "update packages set locked=1 where pkg=%Q", pkg->name) !=
+	    MPORT_OK) {
 		RETURN_CURRENT_ERROR;
 	}
 
@@ -54,7 +55,8 @@ MPORT_PUBLIC_API int
 mport_lock_unlock(mportInstance *mport, mportPackageMeta *pkg)
 {
 	if (mport_lock_islocked(pkg) == MPORT_LOCKED) {
-		if (mport_db_do(mport->db, "update packages set locked=0 where pkg=%Q", pkg->name) != MPORT_OK) {
+		if (mport_db_do(mport->db, "update packages set locked=0 where pkg=%Q",
+			pkg->name) != MPORT_OK) {
 			RETURN_CURRENT_ERROR;
 		}
 	}

--- a/libmport/lua.c
+++ b/libmport/lua.c
@@ -44,68 +44,69 @@
 
 #include "mport_lua.h"
 
-
 #ifndef DEFFILEMODE
-#define DEFFILEMODE (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)
+#define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 #endif
 
 extern char **environ;
 
-int set_attrsat(int fd, const char *path, mode_t perm, uid_t uid, gid_t gid, const struct timespec *ats, const struct timespec *mts);
+int set_attrsat(int fd, const char *path, mode_t perm, uid_t uid, gid_t gid,
+    const struct timespec *ats, const struct timespec *mts);
 int checkflags(const char *mode, int *optr);
 
 lua_CFunction
 stack_dump(lua_State *L)
 {
-    int i;
-    int top = lua_gettop(L);
-    FILE *stream;
-    char *stackstr;
-    size_t size;
+	int i;
+	int top = lua_gettop(L);
+	FILE *stream;
+	char *stackstr;
+	size_t size;
 
-    stream = open_memstream(&stackstr, &size);
-    if (stream == NULL) {
-        perror("open_memstream");
-        return 0;
-    }
+	stream = open_memstream(&stackstr, &size);
+	if (stream == NULL) {
+		perror("open_memstream");
+		return 0;
+	}
 
-    fputs("\nLua Stack\n---------\n"
-          "\tType   Data\n\t-----------\n", stream);
+	fputs("\nLua Stack\n---------\n"
+	      "\tType   Data\n\t-----------\n",
+	    stream);
 
-    for (i = 1; i <= top; i++) {  /* repeat for each level */
-        int t = lua_type(L, i);
-        fprintf(stream, "%i", i);
-        switch (t) {
-        case LUA_TSTRING:  /* strings */
-            fprintf(stream, "\tString: `%s'\n", lua_tostring(L, i));
-            break;
-        case LUA_TBOOLEAN:  /* booleans */
-            fprintf(stream, "\tBoolean: %s", lua_toboolean(L, i) ? "\ttrue\n" : "\tfalse\n");
-            break;
-        case LUA_TNUMBER:  /* numbers */
-            fprintf(stream, "\tNumber: %g\n", lua_tonumber(L, i));
-            break;
-        default:  /* other values */
-            fprintf(stream, "\tOther: %s\n", lua_typename(L, t));
-            break;
-        }
-    }
+	for (i = 1; i <= top; i++) { /* repeat for each level */
+		int t = lua_type(L, i);
+		fprintf(stream, "%i", i);
+		switch (t) {
+		case LUA_TSTRING: /* strings */
+			fprintf(stream, "\tString: `%s'\n", lua_tostring(L, i));
+			break;
+		case LUA_TBOOLEAN: /* booleans */
+			fprintf(stream, "\tBoolean: %s",
+			    lua_toboolean(L, i) ? "\ttrue\n" : "\tfalse\n");
+			break;
+		case LUA_TNUMBER: /* numbers */
+			fprintf(stream, "\tNumber: %g\n", lua_tonumber(L, i));
+			break;
+		default: /* other values */
+			fprintf(stream, "\tOther: %s\n", lua_typename(L, t));
+			break;
+		}
+	}
 
-    fclose(stream);
-    // TODO: better error handling here.
-    fprintf(stderr, "%s\n", stackstr);
-    free(stackstr);
+	fclose(stream);
+	// TODO: better error handling here.
+	fprintf(stderr, "%s\n", stackstr);
+	free(stackstr);
 
-    return (0);
+	return (0);
 }
 
 int
 lua_print_msg(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 1, n > 1 ? 2 : n,
-	    "pkg.print_msg takes exactly one argument");
-	const char* str = luaL_checkstring(L, 1);
+	luaL_argcheck(L, n == 1, n > 1 ? 2 : n, "pkg.print_msg takes exactly one argument");
+	const char *str = luaL_checkstring(L, 1);
 	lua_getglobal(L, "msgfd");
 	int fd = lua_tointeger(L, -1);
 
@@ -114,18 +115,18 @@ lua_print_msg(lua_State *L)
 	return (0);
 }
 
-
-static const char**
-luaL_checkarraystrings(lua_State *L, int arg) {
+static const char **
+luaL_checkarraystrings(lua_State *L, int arg)
+{
 	const char **ret;
 	lua_Integer n, i;
 	int t;
 	int abs_arg = lua_absindex(L, arg);
 	luaL_checktype(L, abs_arg, LUA_TTABLE);
 	n = lua_rawlen(L, abs_arg);
-	ret = lua_newuserdata(L, (n+1)*sizeof(char*));
-	for (i=0; i<n; i++) {
-		t = lua_rawgeti(L, abs_arg, i+1);
+	ret = lua_newuserdata(L, (n + 1) * sizeof(char *));
+	for (i = 0; i < n; i++) {
+		t = lua_rawgeti(L, abs_arg, i + 1);
 		if (t == LUA_TNIL)
 			break;
 		luaL_argcheck(L, t == LUA_TSTRING, arg, "expected array of strings");
@@ -141,12 +142,11 @@ lua_exec(lua_State *L)
 {
 	int r, pstat;
 	posix_spawn_file_actions_t action;
-	int stdin_pipe[2] = {-1, -1};
+	int stdin_pipe[2] = { -1, -1 };
 	pid_t pid;
 	const char **argv;
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 1, n > 1 ? 2 : n,
-	    "pkg.exec takes exactly one argument");
+	luaL_argcheck(L, n == 1, n > 1 ? 2 : n, "pkg.exec takes exactly one argument");
 
 #ifdef HAVE_CAPSICUM
 	unsigned int capmode;
@@ -162,8 +162,7 @@ lua_exec(lua_State *L)
 	posix_spawn_file_actions_addclose(&action, stdin_pipe[1]);
 
 	argv = luaL_checkarraystrings(L, 1);
-	if (0 != (r = posix_spawnp(&pid, argv[0], &action, NULL,
-		(char*const*)argv, environ))) {
+	if (0 != (r = posix_spawnp(&pid, argv[0], &action, NULL, (char *const *)argv, environ))) {
 		lua_pushnil(L);
 		lua_pushstring(L, strerror(r));
 		lua_pushinteger(L, r);
@@ -199,16 +198,15 @@ int
 lua_pkg_copy(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 2, n > 2 ? 3 : n,
-	    "pkg.copy takes exactly two arguments");
-	const char* src = luaL_checkstring(L, 1);
-	const char* dst = luaL_checkstring(L, 2);
+	luaL_argcheck(L, n == 2, n > 2 ? 3 : n, "pkg.copy takes exactly two arguments");
+	const char *src = luaL_checkstring(L, 1);
+	const char *dst = luaL_checkstring(L, 2);
 	struct stat s1;
 	int fd1, fd2;
 	struct timespec ts[2];
 
 #ifdef HAVE_CHFLAGSAT
-        bool install_as_user = (getenv("INSTALL_AS_USER") != NULL);
+	bool install_as_user = (getenv("INSTALL_AS_USER") != NULL);
 #endif
 
 	lua_getglobal(L, "rootfd");
@@ -258,16 +256,15 @@ lua_pkg_copy(lua_State *L)
 #endif
 #endif
 
-	if (set_attrsat(rootfd, RELATIVE_PATH(dst), s1.st_mode, s1.st_uid,
-	  s1.st_gid, &ts[0], &ts[1]) != MPORT_OK) {
+	if (set_attrsat(rootfd, RELATIVE_PATH(dst), s1.st_mode, s1.st_uid, s1.st_gid, &ts[0],
+		&ts[1]) != MPORT_OK) {
 		lua_pushinteger(L, -1);
 		return (1);
 	}
 
 #ifdef HAVE_CHFLAGSAT
 	if (!install_as_user && s1.st_flags != 0) {
-		if (chflagsat(rootfd, RELATIVE_PATH(dst),
-		    s1.st_flags, AT_SYMLINK_NOFOLLOW) == -1) {
+		if (chflagsat(rootfd, RELATIVE_PATH(dst), s1.st_flags, AT_SYMLINK_NOFOLLOW) == -1) {
 			pkg_fatal_errno("Fail to chflags %s", dst);
 			lua_pushinteger(L, -1);
 			return (1);
@@ -281,10 +278,9 @@ int
 lua_pkg_filecmp(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 2, n > 2 ? 3 : n,
-	    "pkg.filecmp takes exactly two arguments");
-	const char* file1 = luaL_checkstring(L, 1);
-	const char* file2 = luaL_checkstring(L, 2);
+	luaL_argcheck(L, n == 2, n > 2 ? 3 : n, "pkg.filecmp takes exactly two arguments");
+	const char *file1 = luaL_checkstring(L, 1);
+	const char *file2 = luaL_checkstring(L, 2);
 	char *buf1, *buf2;
 	struct stat s1, s2;
 	int fd1, fd2;
@@ -342,8 +338,7 @@ int
 lua_pkg_symlink(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 2, n > 2 ? 3 : n,
-	    "pkg.symlink takes exactly two arguments");
+	luaL_argcheck(L, n == 2, n > 2 ? 3 : n, "pkg.symlink takes exactly two arguments");
 	const char *from = luaL_checkstring(L, 1);
 	const char *to = luaL_checkstring(L, 2);
 	lua_getglobal(L, "rootfd");
@@ -357,8 +352,7 @@ int
 lua_prefix_path(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 1, n > 1 ? 2 : n,
-	    "pkg.prefix_path takes exactly one argument");
+	luaL_argcheck(L, n == 1, n > 1 ? 2 : n, "pkg.prefix_path takes exactly one argument");
 	const char *str = luaL_checkstring(L, 1);
 	lua_getglobal(L, "package");
 	mportPackageMeta *p = lua_touserdata(L, -1);
@@ -382,8 +376,7 @@ int
 lua_stat(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 1, n > 1 ? 2 : n,
-	    "pkg.stat takes exactly one argument");
+	luaL_argcheck(L, n == 1, n > 1 ? 2 : n, "pkg.stat takes exactly one argument");
 	const char *path = RELATIVE_PATH(luaL_checkstring(L, 1));
 	lua_getglobal(L, "rootfd");
 	int rootfd = lua_tointeger(L, -1);
@@ -437,7 +430,6 @@ lua_args_table(lua_State *L, char **argv, int argc)
 	lua_setglobal(L, "arg");
 }
 
-
 /*
  * this is a copy of lua code to be able to override open
  * merge of newprefile and newfile
@@ -452,7 +444,8 @@ my_iofclose(lua_State *L)
 }
 
 static luaL_Stream *
-newfile(lua_State *L) {
+newfile(lua_State *L)
+{
 	luaL_Stream *p = (luaL_Stream *)lua_newuserdata(L, sizeof(luaL_Stream));
 	p->f = NULL;
 	p->closef = &my_iofclose;
@@ -479,7 +472,8 @@ lua_io_open(lua_State *L)
 }
 
 static int
-lua_os_remove(lua_State *L) {
+lua_os_remove(lua_State *L)
+{
 	const char *filename = RELATIVE_PATH(luaL_checkstring(L, 1));
 	lua_getglobal(L, "rootfd");
 	int rootfd = lua_tointeger(L, -1);
@@ -541,8 +535,7 @@ int
 lua_readdir(lua_State *L)
 {
 	int n = lua_gettop(L);
-	luaL_argcheck(L, n == 1, n > 1 ? 2 : n,
-	    "pkg.readdir takes exactly one argument");
+	luaL_argcheck(L, n == 1, n > 1 ? 2 : n, "pkg.readdir takes exactly one argument");
 	const char *path = luaL_checkstring(L, 1);
 	int fd = -1;
 
@@ -550,7 +543,7 @@ lua_readdir(lua_State *L)
 		lua_getglobal(L, "rootfd");
 		int rootfd = lua_tointeger(L, -1);
 		if (strlen(path) > 1) {
-			fd = openat(rootfd, path +1, O_DIRECTORY);
+			fd = openat(rootfd, path + 1, O_DIRECTORY);
 		} else {
 			fd = dup(rootfd);
 		}
@@ -578,28 +571,26 @@ lua_readdir(lua_State *L)
 }
 
 int
-set_attrsat(int fd, const char *path, mode_t perm, uid_t uid, gid_t gid,
-    const struct timespec *ats, const struct timespec *mts)
+set_attrsat(int fd, const char *path, mode_t perm, uid_t uid, gid_t gid, const struct timespec *ats,
+    const struct timespec *mts)
 {
 	struct stat st;
 	struct timespec times[2];
 
 	times[0] = *ats;
 	times[1] = *mts;
-	if (utimensat(fd, RELATIVE_PATH(path), times,
-	    AT_SYMLINK_NOFOLLOW) == -1 && errno != EOPNOTSUPP){
+	if (utimensat(fd, RELATIVE_PATH(path), times, AT_SYMLINK_NOFOLLOW) == -1 &&
+	    errno != EOPNOTSUPP) {
 		fprintf(stderr, "Fail to set time on %s", path);
 	}
 
 	if (getenv("INSTALL_AS_USER") == NULL) {
-		if (fchownat(fd, RELATIVE_PATH(path), uid, gid,
-				AT_SYMLINK_NOFOLLOW) == -1) {
+		if (fchownat(fd, RELATIVE_PATH(path), uid, gid, AT_SYMLINK_NOFOLLOW) == -1) {
 			if (errno == ENOTSUP) {
 				if (fchownat(fd, RELATIVE_PATH(path), uid, gid, 0) == -1) {
 					fprintf(stderr, "Fail to chown(fallback) %s", path);
 				}
-			}
-			else {
+			} else {
 				fprintf(stderr, "Fail to chown %s", path);
 			}
 		}
@@ -627,8 +618,7 @@ set_attrsat(int fd, const char *path, mode_t perm, uid_t uid, gid_t gid,
 					fprintf(stderr, "Fail to chmod(fallback) %s", path);
 				}
 			}
-		}
-		else {
+		} else {
 			fprintf(stderr, "Fail to chmod %s", path);
 		}
 	}
@@ -649,25 +639,25 @@ checkflags(const char *mode, int *optr)
 
 	switch (*mode++) {
 
-	case 'r':	/* open for reading */
+	case 'r': /* open for reading */
 		ret = 1;
 		m = O_RDONLY;
 		o = 0;
 		break;
 
-	case 'w':	/* open for writing */
+	case 'w': /* open for writing */
 		ret = 1;
 		m = O_WRONLY;
 		o = O_CREAT | O_TRUNC;
 		break;
 
-	case 'a':	/* open for appending */
+	case 'a': /* open for appending */
 		ret = 1;
 		m = O_WRONLY;
 		o = O_CREAT | O_APPEND;
 		break;
 
-	default:	/* illegal mode */
+	default: /* illegal mode */
 		errno = EINVAL;
 		return (0);
 	}
@@ -705,4 +695,3 @@ checkflags(const char *mode, int *optr)
 	*optr = m | o;
 	return (ret);
 }
-

--- a/libmport/lua_scripts.c
+++ b/libmport/lua_scripts.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Lucas Holt
  * Copyright (c) 2019 Baptiste Daroussin <bapt@FreeBSD.org>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -14,7 +14,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -56,11 +56,12 @@ get_socketpair(int *pipe)
 }
 
 int
-mport_script_run_child(mportInstance *mport, int pid, int *pstat, int inputfd, const char *script_name) 
+mport_script_run_child(
+    mportInstance *mport, int pid, int *pstat, int inputfd, const char *script_name)
 {
 	struct pollfd pfd;
 	bool wait_for_child;
-	char msgbuf[16384+1];
+	char msgbuf[16384 + 1];
 
 	memset(&pfd, 0, sizeof(pfd));
 	pfd.events = POLLIN | POLLERR | POLLHUP;
@@ -75,7 +76,8 @@ mport_script_run_child(mportInstance *mport, int pid, int *pstat, int inputfd, c
 		pid_t p = 0;
 		while (wait_for_child && (p = waitpid(pid, pstat, WNOHANG)) == -1) {
 			if (errno != EINTR) {
-                RETURN_ERRORX(MPORT_ERR_FATAL, "waitpid() failed: %s", strerror(errno));
+				RETURN_ERRORX(
+				    MPORT_ERR_FATAL, "waitpid() failed: %s", strerror(errno));
 			}
 		}
 		if (p > 0) {
@@ -89,7 +91,8 @@ mport_script_run_child(mportInstance *mport, int pid, int *pstat, int inputfd, c
 			int pres;
 			while ((pres = poll(&pfd, 1, wait_for_child ? 1000 : 0)) == -1) {
 				if (errno != EINTR) {
-                    RETURN_ERRORX(MPORT_ERR_FATAL, "poll() failed: %s", strerror(errno));
+					RETURN_ERRORX(
+					    MPORT_ERR_FATAL, "poll() failed: %s", strerror(errno));
 				}
 			}
 			if (pres > 0 && pfd.revents & POLLIN) {
@@ -99,13 +102,14 @@ mport_script_run_child(mportInstance *mport, int pid, int *pstat, int inputfd, c
 						break;
 					}
 					if (errno != EINTR) {
-                        RETURN_ERRORX(MPORT_ERR_FATAL, "read() failed: %s", strerror(errno));
+						RETURN_ERRORX(MPORT_ERR_FATAL, "read() failed: %s",
+						    strerror(errno));
 					}
 				}
 				if (readsize > 0) {
 					msgbuf[readsize] = '\0';
-                    
-                    mport_call_msg_cb(mport, msgbuf);
+
+					mport_call_msg_cb(mport, msgbuf);
 				}
 			}
 		} while (readsize > 0);
@@ -115,7 +119,7 @@ mport_script_run_child(mportInstance *mport, int pid, int *pstat, int inputfd, c
 		if (WEXITSTATUS(*pstat) == 3)
 			exit(0);
 
-        RETURN_ERRORX(MPORT_ERR_FATAL, "%s script failed", script_name);
+		RETURN_ERRORX(MPORT_ERR_FATAL, "%s script failed", script_name);
 	}
 	return (MPORT_OK);
 }
@@ -135,9 +139,10 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 	if (tll_length(pkg->lua_scripts[type]) == 0)
 		return (MPORT_OK);
 
-	tll_foreach(pkg->lua_scripts[type], s) {
+	tll_foreach(pkg->lua_scripts[type], s)
+	{
 		if (get_socketpair(cur_pipe) == -1) {
-            SET_ERROR(MPORT_ERR_FATAL, "socket pair failed");
+			SET_ERROR(MPORT_ERR_FATAL, "socket pair failed");
 			goto cleanup;
 		}
 		pid_t pid = fork();
@@ -155,8 +160,8 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 			};
 			close(cur_pipe[0]);
 			lua_State *L = luaL_newstate();
-			luaL_openlibs( L );
-			lua_atpanic(L, (lua_CFunction)stack_dump );
+			luaL_openlibs(L);
+			lua_atpanic(L, (lua_CFunction)stack_dump);
 			lua_pushinteger(L, cur_pipe[1]);
 			lua_setglobal(L, "msgfd");
 			lua_pushlightuserdata(L, pkg);
@@ -169,7 +174,7 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 			lua_setglobal(L, "pkg_name");
 			lua_pushstring(L, mport->root);
 			lua_setglobal(L, "pkg_rootdir");
-			lua_pushboolean(L, (pkg->action == MPORT_ACTION_UPGRADE? 1 : 0));
+			lua_pushboolean(L, (pkg->action == MPORT_ACTION_UPGRADE ? 1 : 0));
 			lua_setglobal(L, "pkg_upgrade");
 			luaL_newlib(L, pkg_lib);
 			lua_setglobal(L, "pkg");
@@ -197,7 +202,8 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 						if (args_base != NULL) {
 							walk = args_base;
 							while (walk != NULL) {
-								args[argc++] = mport_tokenize(&walk);
+								args[argc++] =
+								    mport_tokenize(&walk);
 							}
 							lua_args_table(L, args, argc);
 							free(args_base);
@@ -208,9 +214,11 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 				}
 			}
 
-			//pkg_debug(3, "Scripts: executing lua\n--- BEGIN ---\n%s\nScripts: --- END ---", s->item);
+			// pkg_debug(3, "Scripts: executing lua\n--- BEGIN ---\n%s\nScripts: --- END
+			// ---", s->item);
 			if (luaL_dostring(L, s->item)) {
-                SET_ERRORX(MPORT_ERR_FATAL, "Failed to execute lua script: %s", lua_tostring(L, -1));
+				SET_ERRORX(MPORT_ERR_FATAL, "Failed to execute lua script: %s",
+				    lua_tostring(L, -1));
 				lua_close(L);
 				_exit(1);
 			}
@@ -223,7 +231,7 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 			lua_close(L);
 			_exit(0);
 		} else if (pid < 0) {
-            SET_ERROR(MPORT_ERR_FATAL, "Cannot fork lua script");
+			SET_ERROR(MPORT_ERR_FATAL, "Cannot fork lua script");
 			ret = MPORT_ERR_FATAL;
 			goto cleanup;
 		}
@@ -232,7 +240,6 @@ mport_lua_script_run(mportInstance *mport, mportPackageMeta *pkg, mport_lua_scri
 
 		ret = mport_script_run_child(mport, pid, &pstat, cur_pipe[0], "lua");
 	}
-
 
 cleanup:
 
@@ -245,22 +252,23 @@ mport_lua_script_to_ucl(stringlist_t *scripts)
 	ucl_object_t *array;
 
 	array = ucl_object_typed_new(UCL_ARRAY);
-	tll_foreach(*scripts, s)
-		ucl_array_append(array, ucl_object_fromstring_common(s->item,
-		    strlen(s->item), UCL_STRING_RAW|UCL_STRING_TRIM));
+	tll_foreach(*scripts, s) ucl_array_append(array,
+	    ucl_object_fromstring_common(
+		s->item, strlen(s->item), UCL_STRING_RAW | UCL_STRING_TRIM));
 
 	return (array);
 }
 
 int
-mport_lua_script_from_ucl(mportInstance *mport, mportPackageMeta *pkg, const ucl_object_t *obj, mport_lua_script type)
+mport_lua_script_from_ucl(
+    mportInstance *mport, mportPackageMeta *pkg, const ucl_object_t *obj, mport_lua_script type)
 {
 	const ucl_object_t *cur;
 	ucl_object_iter_t it = NULL;
 
 	while ((cur = ucl_iterate_object(obj, &it, true))) {
 		if (ucl_object_type(cur) != UCL_STRING) {
-            RETURN_ERROR(MPORT_ERR_FATAL, "lua scripts should be strings.\n");
+			RETURN_ERROR(MPORT_ERR_FATAL, "lua scripts should be strings.\n");
 		}
 		char *script = strdup(ucl_object_tostring(cur));
 		if (script == NULL) {
@@ -276,14 +284,17 @@ mport_lua_script_load(mportInstance *mport, mportPackageMeta *pkg)
 {
 	mport_lua_script_read_file(mport, pkg, MPORT_LUA_PRE_INSTALL, MPORT_LUA_PRE_INSTALL_FILE);
 	mport_lua_script_read_file(mport, pkg, MPORT_LUA_POST_INSTALL, MPORT_LUA_POST_INSTALL_FILE);
-	mport_lua_script_read_file(mport, pkg, MPORT_LUA_PRE_DEINSTALL, MPORT_LUA_PRE_DEINSTALL_FILE);
-	mport_lua_script_read_file(mport, pkg, MPORT_LUA_POST_DEINSTALL, MPORT_LUA_POST_DEINSTALL_FILE);
+	mport_lua_script_read_file(
+	    mport, pkg, MPORT_LUA_PRE_DEINSTALL, MPORT_LUA_PRE_DEINSTALL_FILE);
+	mport_lua_script_read_file(
+	    mport, pkg, MPORT_LUA_POST_DEINSTALL, MPORT_LUA_POST_DEINSTALL_FILE);
 
 	return (MPORT_OK);
 }
 
 int
-mport_lua_script_read_file(mportInstance *mport, mportPackageMeta *pkg, mport_lua_script type, char *luafile)
+mport_lua_script_read_file(
+    mportInstance *mport, mportPackageMeta *pkg, mport_lua_script type, char *luafile)
 {
 	char filename[FILENAME_MAX];
 	char *buf = NULL;
@@ -322,7 +333,7 @@ mport_lua_script_read_file(mportInstance *mport, mportPackageMeta *pkg, mport_lu
 
 		if (ucl_parser_add_chunk(parser, (const unsigned char *)buf, st.st_size)) {
 			obj = ucl_parser_get_object(parser);
-		    int ret = mport_lua_script_from_ucl(mport, pkg, obj, type);
+			int ret = mport_lua_script_from_ucl(mport, pkg, obj, type);
 			ucl_parser_free(parser);
 			free(buf);
 

--- a/libmport/merge_primative.c
+++ b/libmport/merge_primative.c
@@ -40,20 +40,21 @@
 /* build a hashtable with pkgname keys, values are a struct with fields for
  * filename, and boolean is_in_db */
 struct table_entry {
-  char *file;
-  short is_in_db;
-  char *name;
-  struct table_entry *next;
+	char *file;
+	short is_in_db;
+	char *name;
+	struct table_entry *next;
 };
 
 #define TABLE_SIZE 128
 
-static int build_stub_db(mportInstance *, sqlite3 **, const char *, const char *, const char **, struct table_entry **);
+static int build_stub_db(
+    mportInstance *, sqlite3 **, const char *, const char *, const char **, struct table_entry **);
 static int archive_metafiles(mportBundleWrite *, sqlite3 *, struct table_entry **);
 static int archive_package_files(mportBundleWrite *, sqlite3 *, struct table_entry **);
 static int extract_stub_db(const char *, const char *);
 
-static struct table_entry * find_in_table(struct table_entry **, const char *);
+static struct table_entry *find_in_table(struct table_entry **, const char *);
 static int insert_into_table(struct table_entry **, const char *, const char *);
 static uint32_t SuperFastHash(const char *);
 
@@ -66,7 +67,7 @@ static uint32_t SuperFastHash(const char *);
  * a new bundle file containing all the packages un the different input bundle files,
  * named `outfile`.  Care is taken to not have duplicates, to ensure that the exterior
  * dependencies are correct, and that the packages are in an optimal order for installation.
- */ 
+ */
 MPORT_PUBLIC_API int
 mport_merge_primative(mportInstance *mport, const char **filenames, const char *outfile)
 {
@@ -83,543 +84,559 @@ mport_merge_primative(mportInstance *mport, const char **filenames, const char *
 
 	strlcpy(dirtmpl, tmpdir, sizeof(dirtmpl));
 	strlcat(dirtmpl, "/mport.XXXXXXXX", sizeof(dirtmpl));
-  
-  if ((table = (struct table_entry **)calloc(TABLE_SIZE, sizeof(struct table_entry *))) == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate hash table.");
-  
-  DIAG("mport_merge_primative(%p, %s)", filenames, outfile)
-  
-  if ((tmpdir = mkdtemp(dirtmpl)) == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't make temp directory.");
-  if (asprintf(&dbfile, "%s/%s", tmpdir, "merged.db") == -1)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't build merge database name.");
-  
-  DIAG("Building stub")
 
-  /* this function merges the stub databases into one db. */      
-  if (build_stub_db(mport, &db, tmpdir, dbfile, filenames, table) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
-  
-  DIAG("Stub complete: %s", dbfile)
-    
-  /* set up the bundle, and add our new stub database to it. */
-  if ((bundle = mport_bundle_write_new()) == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't alloca bundle struct.");
-  if (mport_bundle_write_init(bundle, outfile) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
-   
-  DIAG("Adding %s", dbfile)
-    
-  if (mport_bundle_write_add_file(bundle, dbfile, MPORT_STUB_DB_FILE) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
-  
-  DIAG("Adding metafiles")
-  /* add all the meta files in the correct order */
-  if (archive_metafiles(bundle, db, table) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
+	if ((table = (struct table_entry **)calloc(TABLE_SIZE, sizeof(struct table_entry *))) ==
+	    NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate hash table.");
 
-  DIAG("Adding realfiles")
-  /* add all the other files */     
-  if (archive_package_files(bundle, db, table) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
+	DIAG("mport_merge_primative(%p, %s)", filenames, outfile)
 
-  DIAG("Realfiles complete")
-  
-  if (mport_bundle_write_finish(bundle) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
- 
-  /* attempt removal of tmpdir, ignore errors. */
-  mport_rmtree(tmpdir);
- 
- return MPORT_OK;
+	if ((tmpdir = mkdtemp(dirtmpl)) == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't make temp directory.");
+	if (asprintf(&dbfile, "%s/%s", tmpdir, "merged.db") == -1)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't build merge database name.");
+
+	DIAG("Building stub")
+
+	/* this function merges the stub databases into one db. */
+	if (build_stub_db(mport, &db, tmpdir, dbfile, filenames, table) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	DIAG("Stub complete: %s", dbfile)
+
+	/* set up the bundle, and add our new stub database to it. */
+	if ((bundle = mport_bundle_write_new()) == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't alloca bundle struct.");
+	if (mport_bundle_write_init(bundle, outfile) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	DIAG("Adding %s", dbfile)
+
+	if (mport_bundle_write_add_file(bundle, dbfile, MPORT_STUB_DB_FILE) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	DIAG("Adding metafiles")
+	/* add all the meta files in the correct order */
+	if (archive_metafiles(bundle, db, table) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	DIAG("Adding realfiles")
+	/* add all the other files */
+	if (archive_package_files(bundle, db, table) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	DIAG("Realfiles complete")
+
+	if (mport_bundle_write_finish(bundle) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	/* attempt removal of tmpdir, ignore errors. */
+	mport_rmtree(tmpdir);
+
+	return MPORT_OK;
 }
-
 
 /* This function goes through each file, and builds up the merged database as
  * filename `dbfile`.  It also builds up the hashtable of package -> filename pairs.
  * When this function is done, db points to a readonly sqlite object representing
  * the merged db.
  */
-static int build_stub_db(mportInstance *mport, sqlite3 **db,  const char *tmpdir,  const char *dbfile,  const char **filenames, struct table_entry **table)
+static int
+build_stub_db(mportInstance *mport, sqlite3 **db, const char *tmpdir, const char *dbfile,
+    const char **filenames, struct table_entry **table)
 {
-  char *tmpdbfile;
-  const char *name;
-  const char *file = NULL;
-  int made_table = 0, ret;
-  sqlite3_stmt *stmt;
-  
-  if (asprintf(&tmpdbfile, "%s/%s", tmpdir, "pkg.db") == -1)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't make stub db tempfile.");
-  
-  if (sqlite3_open(dbfile, db) != SQLITE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-  
-  if (mport_generate_stub_schema(mport, *db) != MPORT_OK)
-    RETURN_CURRENT_ERROR;
-    
-  for (file = *filenames; file != NULL; file = *(++filenames)) {
-    DIAG("Visiting %s", file)
-    if (extract_stub_db(file, tmpdbfile) != MPORT_OK)
-      RETURN_CURRENT_ERROR;
+	char *tmpdbfile;
+	const char *name;
+	const char *file = NULL;
+	int made_table = 0, ret;
+	sqlite3_stmt *stmt;
 
-    if (mport_db_do(*db, "ATTACH %Q AS subbundle", tmpdbfile) != MPORT_OK)
-      RETURN_CURRENT_ERROR;
-    
-    if (mport_db_do(*db, "BEGIN TRANSACTION") != MPORT_OK)
-      RETURN_CURRENT_ERROR;
-      
-    if (made_table == 0) { 
-      made_table++;
-      if (mport_db_do(*db, "CREATE TABLE unsorted AS SELECT * FROM subbundle.packages") != MPORT_OK)
-        RETURN_CURRENT_ERROR;
-    } else {
-      if (mport_db_do(*db, "INSERT INTO unsorted SELECT * FROM subbundle.packages") != MPORT_OK)
-        RETURN_CURRENT_ERROR;
-    }
-    
-    if (mport_db_do(*db, "INSERT INTO assets SELECT * FROM subbundle.assets") != MPORT_OK) 
-      RETURN_CURRENT_ERROR;
-    if (mport_db_do(*db, "INSERT INTO conflicts SELECT * FROM subbundle.conflicts") != MPORT_OK) 
-      RETURN_CURRENT_ERROR;
-    if (mport_db_do(*db, "INSERT INTO depends SELECT * FROM subbundle.depends") != MPORT_OK) 
-      RETURN_CURRENT_ERROR;
+	if (asprintf(&tmpdbfile, "%s/%s", tmpdir, "pkg.db") == -1)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't make stub db tempfile.");
 
-    /* build our hashtable (pkgname => metadata) up */      
-    if (mport_db_prepare(*db, &stmt, "SELECT pkg FROM subbundle.packages") != MPORT_OK) {
-      sqlite3_finalize(stmt);
-      RETURN_CURRENT_ERROR;
-    }
-    
-    while (1) {
-      ret = sqlite3_step(stmt);
-      
-      if (ret == SQLITE_ROW) {
-        name = sqlite3_column_text(stmt, 0);
-        if (insert_into_table(table, name, file) != MPORT_OK) {
-          sqlite3_finalize(stmt);
-          RETURN_CURRENT_ERROR;
-        }
-      } else if (ret == SQLITE_DONE) {
-        break;
-      } else {
-        SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-        sqlite3_finalize(stmt);
-        RETURN_CURRENT_ERROR;
-      }
-    }
-        
-    sqlite3_finalize(stmt);
-    
-    if (mport_db_do(*db, "COMMIT TRANSACTION") != MPORT_OK)
-      RETURN_CURRENT_ERROR;  
-    if (mport_db_do(*db, "DETACH subbundle") != MPORT_OK)
-      RETURN_CURRENT_ERROR;    
-  }
+	if (sqlite3_open(dbfile, db) != SQLITE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
 
-  /* just have to sort the packages (going from unsorted to packages), no big deal... ;) */
-  while (1) {
-    if (mport_db_do(*db, "INSERT INTO packages SELECT * FROM unsorted WHERE NOT EXISTS (SELECT 1 FROM packages WHERE packages.pkg=unsorted.pkg) AND (NOT EXISTS (SELECT 1 FROM depends WHERE depends.pkg=unsorted.pkg) OR NOT EXISTS (SELECT 1 FROM depends LEFT JOIN packages ON depends.depend_pkgname=packages.pkg WHERE depends.pkg=unsorted.pkg AND EXISTS (SELECT 1 FROM unsorted AS us2 WHERE us2.pkg=depend_pkgname) AND packages.pkg ISNULL))") != MPORT_OK)
-      RETURN_CURRENT_ERROR;
-    if (sqlite3_changes(*db) == 0) /* if there is nothing left to insert, we're done */
-      break;
-  }
-      
-  /* Check that unsorted and packages have the same number of rows. */     
-  if (mport_db_prepare(*db, &stmt, "SELECT COUNT(DISTINCT pkg) FROM packages")) {
-    sqlite3_finalize(stmt);
-    RETURN_CURRENT_ERROR;  
-  }
-  if (sqlite3_step(stmt) != SQLITE_ROW) {
-    SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-    sqlite3_finalize(stmt);
-    RETURN_CURRENT_ERROR;
-  }
-  
-  int pkgs = sqlite3_column_int(stmt, 0);
-  sqlite3_finalize(stmt);
-  
-  if (mport_db_prepare(*db, &stmt, "SELECT COUNT(DISTINCT pkg) FROM unsorted")) {
-    sqlite3_finalize(stmt);
-    RETURN_CURRENT_ERROR;
-  }
-    
-  if (sqlite3_step(stmt) != SQLITE_ROW) {
-    SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-    sqlite3_finalize(stmt);
-    RETURN_CURRENT_ERROR;
-  }
-  
-  int unsort = sqlite3_column_int(stmt, 0);
-  sqlite3_finalize(stmt);
-  
-  if (pkgs != unsort) 
-    RETURN_ERRORX(MPORT_ERR_FATAL, "Sorted (%i) and unsorted (%i) counts do no match.", pkgs, unsort);
-    
-      
-  /* Close the stub database handle, and reopen as read only to ensure that we don't
-   * try to change it after this point 
-   */    
-  if (sqlite3_close(*db) != SQLITE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-  if (sqlite3_open_v2(dbfile, db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
-  
-  return MPORT_OK;
+	if (mport_generate_stub_schema(mport, *db) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	for (file = *filenames; file != NULL; file = *(++filenames)) {
+		DIAG("Visiting %s", file)
+		if (extract_stub_db(file, tmpdbfile) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+
+		if (mport_db_do(*db, "ATTACH %Q AS subbundle", tmpdbfile) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+
+		if (mport_db_do(*db, "BEGIN TRANSACTION") != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+
+		if (made_table == 0) {
+			made_table++;
+			if (mport_db_do(
+				*db, "CREATE TABLE unsorted AS SELECT * FROM subbundle.packages") !=
+			    MPORT_OK)
+				RETURN_CURRENT_ERROR;
+		} else {
+			if (mport_db_do(
+				*db, "INSERT INTO unsorted SELECT * FROM subbundle.packages") !=
+			    MPORT_OK)
+				RETURN_CURRENT_ERROR;
+		}
+
+		if (mport_db_do(*db, "INSERT INTO assets SELECT * FROM subbundle.assets") !=
+		    MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		if (mport_db_do(*db, "INSERT INTO conflicts SELECT * FROM subbundle.conflicts") !=
+		    MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		if (mport_db_do(*db, "INSERT INTO depends SELECT * FROM subbundle.depends") !=
+		    MPORT_OK)
+			RETURN_CURRENT_ERROR;
+
+		/* build our hashtable (pkgname => metadata) up */
+		if (mport_db_prepare(*db, &stmt, "SELECT pkg FROM subbundle.packages") !=
+		    MPORT_OK) {
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		while (1) {
+			ret = sqlite3_step(stmt);
+
+			if (ret == SQLITE_ROW) {
+				name = sqlite3_column_text(stmt, 0);
+				if (insert_into_table(table, name, file) != MPORT_OK) {
+					sqlite3_finalize(stmt);
+					RETURN_CURRENT_ERROR;
+				}
+			} else if (ret == SQLITE_DONE) {
+				break;
+			} else {
+				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
+				sqlite3_finalize(stmt);
+				RETURN_CURRENT_ERROR;
+			}
+		}
+
+		sqlite3_finalize(stmt);
+
+		if (mport_db_do(*db, "COMMIT TRANSACTION") != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		if (mport_db_do(*db, "DETACH subbundle") != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+	}
+
+	/* just have to sort the packages (going from unsorted to packages), no big deal... ;) */
+	while (1) {
+		if (mport_db_do(*db,
+			"INSERT INTO packages SELECT * FROM unsorted WHERE NOT EXISTS (SELECT 1 FROM packages WHERE packages.pkg=unsorted.pkg) AND (NOT EXISTS (SELECT 1 FROM depends WHERE depends.pkg=unsorted.pkg) OR NOT EXISTS (SELECT 1 FROM depends LEFT JOIN packages ON depends.depend_pkgname=packages.pkg WHERE depends.pkg=unsorted.pkg AND EXISTS (SELECT 1 FROM unsorted AS us2 WHERE us2.pkg=depend_pkgname) AND packages.pkg ISNULL))") !=
+		    MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		if (sqlite3_changes(*db) == 0) /* if there is nothing left to insert, we're done */
+			break;
+	}
+
+	/* Check that unsorted and packages have the same number of rows. */
+	if (mport_db_prepare(*db, &stmt, "SELECT COUNT(DISTINCT pkg) FROM packages")) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+	if (sqlite3_step(stmt) != SQLITE_ROW) {
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	int pkgs = sqlite3_column_int(stmt, 0);
+	sqlite3_finalize(stmt);
+
+	if (mport_db_prepare(*db, &stmt, "SELECT COUNT(DISTINCT pkg) FROM unsorted")) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	if (sqlite3_step(stmt) != SQLITE_ROW) {
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
+
+	int unsort = sqlite3_column_int(stmt, 0);
+	sqlite3_finalize(stmt);
+
+	if (pkgs != unsort)
+		RETURN_ERRORX(MPORT_ERR_FATAL, "Sorted (%i) and unsorted (%i) counts do no match.",
+		    pkgs, unsort);
+
+	/* Close the stub database handle, and reopen as read only to ensure that we don't
+	 * try to change it after this point
+	 */
+	if (sqlite3_close(*db) != SQLITE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
+	if (sqlite3_open_v2(dbfile, db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(*db));
+
+	return MPORT_OK;
 }
 
-
-static int archive_metafiles(mportBundleWrite *bundle, sqlite3 *db, struct table_entry **table) 
+static int
+archive_metafiles(mportBundleWrite *bundle, sqlite3 *db, struct table_entry **table)
 {
-  sqlite3_stmt *stmt;
-  int ret, sret;
-  char *filename;
-  const char *pkgname;
-  struct table_entry *match = NULL;
-  mportBundleRead *inbundle= NULL;
-  struct archive_entry *entry;
-  
-  ret = MPORT_OK;
-        
-  if (mport_db_prepare(db, &stmt, "SELECT pkg FROM packages") != MPORT_OK) {
-	  sqlite3_finalize(stmt);
-	  RETURN_CURRENT_ERROR;
-  }
-    
-  while (1) {
-    sret = sqlite3_step(stmt);
-    
-    if (sret == SQLITE_DONE) {
-      goto DONE;
-    } else if (sret != SQLITE_ROW) {
-      ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
-      goto DONE;
-    } 
-    
-    /* at this point, ret must be SQLITE_ROW */
-    pkgname  = sqlite3_column_text(stmt, 0);
-    match = find_in_table(table, pkgname);
-    
-    if (match == NULL) {
-      ret = SET_ERRORX(MPORT_ERR_FATAL, "Couldn't find package '%s' in filename table.", pkgname);
-      goto DONE;
-    }
-    
-    filename = match->file;
-    
-    if ((inbundle = mport_bundle_read_new()) == NULL) {
-      SET_ERROR(MPORT_ERR_FATAL, "Couldn't allocate bundle");
-      goto DONE;
-    }
+	sqlite3_stmt *stmt;
+	int ret, sret;
+	char *filename;
+	const char *pkgname;
+	struct table_entry *match = NULL;
+	mportBundleRead *inbundle = NULL;
+	struct archive_entry *entry;
 
-    
-    if (mport_bundle_read_init(inbundle, filename) != MPORT_OK) {
-      ret = mport_bundle_read_finish(NULL, inbundle);
-      goto DONE;
-    }
+	ret = MPORT_OK;
 
-    
-    /* skip the sub db */
-    if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
-      ret = mport_bundle_read_finish(NULL, inbundle);
-      goto DONE;
-    }
-    if (archive_read_data_skip(inbundle->archive) != ARCHIVE_OK) {
-      ret = mport_bundle_read_finish(NULL, inbundle);
-      ret = SET_ERRORX(MPORT_ERR_FATAL, "Unable to read %s: %s", filename, archive_error_string(inbundle->archive));
-      goto DONE;
-    }
-    
-    
-    while (1) {
-      if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
-        ret = mport_bundle_read_finish(NULL, inbundle);
-        goto DONE;
-      } 
-      
-      if (*(archive_entry_pathname(entry)) != '+')
-        break;
-      
-      DIAG("Adding %s", archive_entry_pathname(entry))
-      
-      if ((ret = mport_bundle_write_add_entry(bundle, inbundle, entry)) != MPORT_OK) {
-        DIAG("bundle add entry failed")
-        ret = mport_bundle_read_finish(NULL, inbundle);
-        goto DONE;
-      }
-    }
+	if (mport_db_prepare(db, &stmt, "SELECT pkg FROM packages") != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
 
-    ret = mport_bundle_read_finish(NULL, inbundle);    
-  }
-  
-  DONE:
-    sqlite3_finalize(stmt);
-    return ret;
+	while (1) {
+		sret = sqlite3_step(stmt);
+
+		if (sret == SQLITE_DONE) {
+			goto DONE;
+		} else if (sret != SQLITE_ROW) {
+			ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
+			goto DONE;
+		}
+
+		/* at this point, ret must be SQLITE_ROW */
+		pkgname = sqlite3_column_text(stmt, 0);
+		match = find_in_table(table, pkgname);
+
+		if (match == NULL) {
+			ret = SET_ERRORX(MPORT_ERR_FATAL,
+			    "Couldn't find package '%s' in filename table.", pkgname);
+			goto DONE;
+		}
+
+		filename = match->file;
+
+		if ((inbundle = mport_bundle_read_new()) == NULL) {
+			SET_ERROR(MPORT_ERR_FATAL, "Couldn't allocate bundle");
+			goto DONE;
+		}
+
+		if (mport_bundle_read_init(inbundle, filename) != MPORT_OK) {
+			ret = mport_bundle_read_finish(NULL, inbundle);
+			goto DONE;
+		}
+
+		/* skip the sub db */
+		if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
+			ret = mport_bundle_read_finish(NULL, inbundle);
+			goto DONE;
+		}
+		if (archive_read_data_skip(inbundle->archive) != ARCHIVE_OK) {
+			ret = mport_bundle_read_finish(NULL, inbundle);
+			ret = SET_ERRORX(MPORT_ERR_FATAL, "Unable to read %s: %s", filename,
+			    archive_error_string(inbundle->archive));
+			goto DONE;
+		}
+
+		while (1) {
+			if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
+				ret = mport_bundle_read_finish(NULL, inbundle);
+				goto DONE;
+			}
+
+			if (*(archive_entry_pathname(entry)) != '+')
+				break;
+
+			DIAG("Adding %s", archive_entry_pathname(entry))
+
+			if ((ret = mport_bundle_write_add_entry(bundle, inbundle, entry)) !=
+			    MPORT_OK) {
+				DIAG("bundle add entry failed")
+				ret = mport_bundle_read_finish(NULL, inbundle);
+				goto DONE;
+			}
+		}
+
+		ret = mport_bundle_read_finish(NULL, inbundle);
+	}
+
+DONE:
+	sqlite3_finalize(stmt);
+	return ret;
 }
 
-
-
-static int archive_package_files(mportBundleWrite *bundle, sqlite3 *db, struct table_entry **table)
+static int
+archive_package_files(mportBundleWrite *bundle, sqlite3 *db, struct table_entry **table)
 {
-  sqlite3_stmt *stmt, *files;
-  int ret;
-  struct table_entry *cur;
-  const char *pkgname;
-  const char *file;
-  mportBundleRead *inbundle;
-  struct archive_entry *entry;
-  
-  if (mport_db_prepare(db, &stmt, "SELECT pkg FROM packages") != MPORT_OK) {
-	  sqlite3_finalize(stmt);
-	  RETURN_CURRENT_ERROR;
-  }
-  
-  while (1) {
-    ret = sqlite3_step(stmt);
-    
-    if (ret == SQLITE_DONE)
-      break;
-    
-    if (ret != SQLITE_ROW) {
-      SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
-      sqlite3_finalize(stmt);
-      RETURN_CURRENT_ERROR;
-    }
-    
-    pkgname = sqlite3_column_text(stmt, 0);
-    cur     = find_in_table(table, pkgname);
-    
-    if (cur == NULL) {
-      sqlite3_finalize(stmt);
-      RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't find package '%s' in bundle hash table", pkgname);
-    }
-    
-    file = cur->file;
-        
-    if ((inbundle = mport_bundle_read_new()) == NULL)
-      RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-        
-    
-    if (mport_bundle_read_init(inbundle, file) != MPORT_OK) {
-      mport_bundle_read_finish(NULL, inbundle);
-      RETURN_CURRENT_ERROR;
-    }
-    
-    if (mport_bundle_read_skip_metafiles(inbundle) != MPORT_OK) {
-      mport_bundle_read_finish(NULL, inbundle);
-      sqlite3_finalize(stmt);
-      RETURN_CURRENT_ERROR;
-    }
+	sqlite3_stmt *stmt, *files;
+	int ret;
+	struct table_entry *cur;
+	const char *pkgname;
+	const char *file;
+	mportBundleRead *inbundle;
+	struct archive_entry *entry;
 
-    if (mport_db_prepare(db, &files, "SELECT data FROM assets WHERE pkg=%Q AND (type=%i or type=%i or type=%i)", pkgname, ASSET_FILE, ASSET_SAMPLE, ASSET_SAMPLE_OWNER_MODE) != MPORT_OK) {
-      mport_bundle_read_finish(NULL, inbundle);
-      sqlite3_finalize(stmt);
-      RETURN_CURRENT_ERROR;
-    }
-    
-    while (1) {
-      int fret = sqlite3_step(files);
+	if (mport_db_prepare(db, &stmt, "SELECT pkg FROM packages") != MPORT_OK) {
+		sqlite3_finalize(stmt);
+		RETURN_CURRENT_ERROR;
+	}
 
-      if (fret == SQLITE_DONE) {
-        sqlite3_finalize(files);
-        break;
-      } else if (fret != SQLITE_ROW) {
-        SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
-        sqlite3_finalize(stmt);
-        sqlite3_finalize(files);
-        mport_bundle_read_finish(NULL, inbundle);
-        RETURN_CURRENT_ERROR;
-      }
-      
-      file = sqlite3_column_text(files, 0);
-      
-      if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
-        mport_bundle_read_finish(NULL, inbundle);
-        sqlite3_finalize(stmt);
-        sqlite3_finalize(files);
-        RETURN_CURRENT_ERROR;
-      } 
-      
-      if (strcmp(file, archive_entry_pathname(entry)) != 0) {
-        SET_ERRORX(MPORT_ERR_FATAL, "Plist to archive mismatch in package %s: found '%s', expected '%s'", pkgname, archive_entry_pathname(entry), file);
-        mport_bundle_read_finish(NULL, inbundle);
-        sqlite3_finalize(stmt);
-        sqlite3_finalize(files);
-        RETURN_CURRENT_ERROR;
-      }
+	while (1) {
+		ret = sqlite3_step(stmt);
 
-      DIAG("Adding realfile: %s", archive_entry_pathname(entry));
-  
-      if (mport_bundle_write_add_entry(bundle, inbundle, entry) != MPORT_OK) {
-        mport_bundle_read_finish(NULL, inbundle);
-        sqlite3_finalize(stmt);
-        sqlite3_finalize(files);
-        RETURN_CURRENT_ERROR;
-      } 
-    }
-  
-    /* we're done with this package, onto the next one */
-    sqlite3_finalize(files);
-    mport_bundle_read_finish(NULL, inbundle);
-  } 
-  
-  sqlite3_finalize(stmt);
-  
-  return MPORT_OK;   
+		if (ret == SQLITE_DONE)
+			break;
+
+		if (ret != SQLITE_ROW) {
+			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		pkgname = sqlite3_column_text(stmt, 0);
+		cur = find_in_table(table, pkgname);
+
+		if (cur == NULL) {
+			sqlite3_finalize(stmt);
+			RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "Couldn't find package '%s' in bundle hash table", pkgname);
+		}
+
+		file = cur->file;
+
+		if ((inbundle = mport_bundle_read_new()) == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+
+		if (mport_bundle_read_init(inbundle, file) != MPORT_OK) {
+			mport_bundle_read_finish(NULL, inbundle);
+			RETURN_CURRENT_ERROR;
+		}
+
+		if (mport_bundle_read_skip_metafiles(inbundle) != MPORT_OK) {
+			mport_bundle_read_finish(NULL, inbundle);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		if (mport_db_prepare(db, &files,
+			"SELECT data FROM assets WHERE pkg=%Q AND (type=%i or type=%i or type=%i)",
+			pkgname, ASSET_FILE, ASSET_SAMPLE, ASSET_SAMPLE_OWNER_MODE) != MPORT_OK) {
+			mport_bundle_read_finish(NULL, inbundle);
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+
+		while (1) {
+			int fret = sqlite3_step(files);
+
+			if (fret == SQLITE_DONE) {
+				sqlite3_finalize(files);
+				break;
+			} else if (fret != SQLITE_ROW) {
+				SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(db));
+				sqlite3_finalize(stmt);
+				sqlite3_finalize(files);
+				mport_bundle_read_finish(NULL, inbundle);
+				RETURN_CURRENT_ERROR;
+			}
+
+			file = sqlite3_column_text(files, 0);
+
+			if (mport_bundle_read_next_entry(inbundle, &entry) != MPORT_OK) {
+				mport_bundle_read_finish(NULL, inbundle);
+				sqlite3_finalize(stmt);
+				sqlite3_finalize(files);
+				RETURN_CURRENT_ERROR;
+			}
+
+			if (strcmp(file, archive_entry_pathname(entry)) != 0) {
+				SET_ERRORX(MPORT_ERR_FATAL,
+				    "Plist to archive mismatch in package %s: found '%s', expected '%s'",
+				    pkgname, archive_entry_pathname(entry), file);
+				mport_bundle_read_finish(NULL, inbundle);
+				sqlite3_finalize(stmt);
+				sqlite3_finalize(files);
+				RETURN_CURRENT_ERROR;
+			}
+
+			DIAG("Adding realfile: %s", archive_entry_pathname(entry));
+
+			if (mport_bundle_write_add_entry(bundle, inbundle, entry) != MPORT_OK) {
+				mport_bundle_read_finish(NULL, inbundle);
+				sqlite3_finalize(stmt);
+				sqlite3_finalize(files);
+				RETURN_CURRENT_ERROR;
+			}
+		}
+
+		/* we're done with this package, onto the next one */
+		sqlite3_finalize(files);
+		mport_bundle_read_finish(NULL, inbundle);
+	}
+
+	sqlite3_finalize(stmt);
+
+	return MPORT_OK;
 }
-
-
 
 /* get the stub database file out of filename and place it at destfile */
-static int extract_stub_db(const char *filename, const char *destfile)
+static int
+extract_stub_db(const char *filename, const char *destfile)
 {
-  struct archive *a = archive_read_new();
-  struct archive_entry *entry;
-  
-  if (a == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate read archive struct");
+	struct archive *a = archive_read_new();
+	struct archive_entry *entry;
 
-  if (archive_read_support_format_tar(a) != ARCHIVE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
-  if (archive_read_support_filter_xz(a))
-    RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
-    
-  if (archive_read_open_filename(a, filename, 10240) != ARCHIVE_OK) {
-    SET_ERRORX(MPORT_ERR_FATAL, "Could not open %s: %s", filename, archive_error_string(a));
-    archive_read_free(a);
-    RETURN_CURRENT_ERROR;
-  }
-  
-  if (archive_read_next_header(a, &entry) != ARCHIVE_OK) {
-    SET_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
-    archive_read_free(a);
-    RETURN_CURRENT_ERROR;
-  }
-  
-  if (strcmp(archive_entry_pathname(entry), MPORT_STUB_DB_FILE) != 0) {
-    archive_read_free(a);
-    RETURN_ERROR(MPORT_ERR_FATAL, "Invalid bundle file: stub database is not the first file");
-  }
-    
-  archive_entry_set_pathname(entry, destfile);
-  
-  if (archive_read_extract(a, entry, 0) != ARCHIVE_OK) {
-    SET_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
-    archive_read_free(a);
-    RETURN_CURRENT_ERROR;
-  }
-  
-  if (archive_read_free(a) != ARCHIVE_OK)
-    RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
-    
-  return MPORT_OK;
+	if (a == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate read archive struct");
+
+	if (archive_read_support_format_tar(a) != ARCHIVE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
+	if (archive_read_support_filter_xz(a))
+		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
+
+	if (archive_read_open_filename(a, filename, 10240) != ARCHIVE_OK) {
+		SET_ERRORX(
+		    MPORT_ERR_FATAL, "Could not open %s: %s", filename, archive_error_string(a));
+		archive_read_free(a);
+		RETURN_CURRENT_ERROR;
+	}
+
+	if (archive_read_next_header(a, &entry) != ARCHIVE_OK) {
+		SET_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
+		archive_read_free(a);
+		RETURN_CURRENT_ERROR;
+	}
+
+	if (strcmp(archive_entry_pathname(entry), MPORT_STUB_DB_FILE) != 0) {
+		archive_read_free(a);
+		RETURN_ERROR(
+		    MPORT_ERR_FATAL, "Invalid bundle file: stub database is not the first file");
+	}
+
+	archive_entry_set_pathname(entry, destfile);
+
+	if (archive_read_extract(a, entry, 0) != ARCHIVE_OK) {
+		SET_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
+		archive_read_free(a);
+		RETURN_CURRENT_ERROR;
+	}
+
+	if (archive_read_free(a) != ARCHIVE_OK)
+		RETURN_ERROR(MPORT_ERR_FATAL, archive_error_string(a));
+
+	return MPORT_OK;
 }
-
 
 /* insert into a name => file pair into the given hash table. */
-static int insert_into_table(struct table_entry **table, const char *name, const char *file)
+static int
+insert_into_table(struct table_entry **table, const char *name, const char *file)
 {
-  struct table_entry *node, *cur;
-  int hash = SuperFastHash(name) % TABLE_SIZE;
-  
-  if ((node = (struct table_entry *)calloc(1, sizeof(struct table_entry))) == NULL)
-    RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate table entry");
+	struct table_entry *node, *cur;
+	int hash = SuperFastHash(name) % TABLE_SIZE;
 
-  node->name     = strdup(name);
-  node->file     = strdup(file);
-  node->is_in_db = 0;
-  node->next     = NULL;
-   
-  if (table[hash] == NULL) {     
-    table[hash] = node;   
-  } else {
-    cur = table[hash];
-    while (cur->next != NULL) 
-      cur = cur->next;
-  
-    cur->next = node;
-  }
-  
-  return MPORT_OK;
+	if ((node = (struct table_entry *)calloc(1, sizeof(struct table_entry))) == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't allocate table entry");
+
+	node->name = strdup(name);
+	node->file = strdup(file);
+	node->is_in_db = 0;
+	node->next = NULL;
+
+	if (table[hash] == NULL) {
+		table[hash] = node;
+	} else {
+		cur = table[hash];
+		while (cur->next != NULL)
+			cur = cur->next;
+
+		cur->next = node;
+	}
+
+	return MPORT_OK;
 }
 
-
-static struct table_entry * find_in_table(struct table_entry **table, const char *name)
+static struct table_entry *
+find_in_table(struct table_entry **table, const char *name)
 {
-  int hash = SuperFastHash(name) % TABLE_SIZE;
-  struct table_entry *e = NULL;
-  
-  e = table[hash];  
-  while (e != NULL) {
-    if (strcmp(e->name, name) == 0)
-      return e;
-      
-    e = e->next;
-  }
-  
-  return e;
+	int hash = SuperFastHash(name) % TABLE_SIZE;
+	struct table_entry *e = NULL;
+
+	e = table[hash];
+	while (e != NULL) {
+		if (strcmp(e->name, name) == 0)
+			return e;
+
+		e = e->next;
+	}
+
+	return e;
 }
-      
-      
-    
-      
+
 /* Paul Hsieh's fast hash function, from http://www.azillionmonkeys.com/qed/hash.html */
 /* This function has been modified to only work with C strings */
 #undef get16bits
-#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) \
-  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
-#define get16bits(d) (*((const uint16_t *) (d)))
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) || defined(_MSC_VER) || \
+    defined(__BORLANDC__) || defined(__TURBOC__)
+#define get16bits(d) (*((const uint16_t *)(d)))
 #endif
 
-#if !defined (get16bits)
-#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)\
-                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#if !defined(get16bits)
+#define get16bits(d) \
+	((((uint32_t)(((const uint8_t *)(d))[1])) << 8) + (uint32_t)(((const uint8_t *)(d))[0]))
 #endif
 
-static uint32_t SuperFastHash(const char * data) 
+static uint32_t
+SuperFastHash(const char *data)
 {
-    int len = strlen(data);
-    uint32_t hash = len, tmp;
-    int rem;
+	int len = strlen(data);
+	uint32_t hash = len, tmp;
+	int rem;
 
-    if (len <= 0 || data == NULL) return 0;
+	if (len <= 0 || data == NULL)
+		return 0;
 
-    rem = len & 3;
-    len >>= 2;
+	rem = len & 3;
+	len >>= 2;
 
-    /* Main loop */
-    for (;len > 0; len--) {
-        hash  += get16bits (data);
-        tmp    = (get16bits (data+2) << 11) ^ hash;
-        hash   = (hash << 16) ^ tmp;
-        data  += 2*sizeof (uint16_t);
-        hash  += hash >> 11;
-    }
+	/* Main loop */
+	for (; len > 0; len--) {
+		hash += get16bits(data);
+		tmp = (get16bits(data + 2) << 11) ^ hash;
+		hash = (hash << 16) ^ tmp;
+		data += 2 * sizeof(uint16_t);
+		hash += hash >> 11;
+	}
 
-    /* Handle end cases */
-    switch (rem) {
-        case 3: hash += get16bits (data);
-                hash ^= hash << 16;
-                hash ^= data[sizeof (uint16_t)] << 18;
-                hash += hash >> 11;
-                break;
-        case 2: hash += get16bits (data);
-                hash ^= hash << 11;
-                hash += hash >> 17;
-                break;
-        case 1: hash += *data;
-                hash ^= hash << 10;
-                hash += hash >> 1;
-    }
+	/* Handle end cases */
+	switch (rem) {
+	case 3:
+		hash += get16bits(data);
+		hash ^= hash << 16;
+		hash ^= data[sizeof(uint16_t)] << 18;
+		hash += hash >> 11;
+		break;
+	case 2:
+		hash += get16bits(data);
+		hash ^= hash << 11;
+		hash += hash >> 17;
+		break;
+	case 1:
+		hash += *data;
+		hash ^= hash << 10;
+		hash += hash >> 1;
+	}
 
-    /* Force "avalanching" of final 127 bits */
-    hash ^= hash << 3;
-    hash += hash >> 5;
-    hash ^= hash << 4;
-    hash += hash >> 17;
-    hash ^= hash << 25;
-    hash += hash >> 6;
+	/* Force "avalanching" of final 127 bits */
+	hash ^= hash << 3;
+	hash += hash >> 5;
+	hash ^= hash << 4;
+	hash += hash >> 17;
+	hash ^= hash << 25;
+	hash += hash >> 6;
 
-    return hash;
+	return hash;
 }
-
-

--- a/libmport/message.c
+++ b/libmport/message.c
@@ -76,20 +76,19 @@ mport_pkg_message_display(mportInstance *mport, mportPackageMeta *pkg)
 	}
 
 	/* Limit message display based on version if provided. */
-	if (packageMessage.minimum_version != NULL && 
-		mport_version_cmp(packageMessage.minimum_version, pkg->version) == 1) {
-			free(packageMessage.str);
-			packageMessage.str = NULL;
-			return MPORT_OK;
+	if (packageMessage.minimum_version != NULL &&
+	    mport_version_cmp(packageMessage.minimum_version, pkg->version) == 1) {
+		free(packageMessage.str);
+		packageMessage.str = NULL;
+		return MPORT_OK;
 	}
 
-	if (packageMessage.maximum_version != NULL && 
-		mport_version_cmp(packageMessage.maximum_version, pkg->version) == -1) {
-			free(packageMessage.str);
-			packageMessage.str = NULL;
-			return MPORT_OK;
+	if (packageMessage.maximum_version != NULL &&
+	    mport_version_cmp(packageMessage.maximum_version, pkg->version) == -1) {
+		free(packageMessage.str);
+		packageMessage.str = NULL;
+		return MPORT_OK;
 	}
-
 
 	if (packageMessage.type == expectedType || packageMessage.type == PKG_MESSAGE_ALWAYS) {
 		if (packageMessage.str != NULL && packageMessage.str[0] != '\0')
@@ -103,7 +102,8 @@ mport_pkg_message_display(mportInstance *mport, mportPackageMeta *pkg)
 }
 
 int
-mport_pkg_message_load(mportInstance *mport, mportPackageMeta *pkg, mportPackageMessage *packageMessage)
+mport_pkg_message_load(
+    mportInstance *mport, mportPackageMeta *pkg, mportPackageMessage *packageMessage)
 {
 	char filename[FILENAME_MAX];
 	char *buf = NULL;
@@ -113,7 +113,8 @@ mport_pkg_message_load(mportInstance *mport, mportPackageMeta *pkg, mportPackage
 	ucl_object_t *obj = NULL;
 
 	if (mport == NULL || pkg == NULL || packageMessage == NULL) {
-		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid argument(s) passed to mport_pkg_message_load()");
+		RETURN_ERROR(
+		    MPORT_ERR_FATAL, "Invalid argument(s) passed to mport_pkg_message_load()");
 	}
 
 	/* Assumes copy_metafile has run on install already */

--- a/libmport/mkdir.c
+++ b/libmport/mkdir.c
@@ -45,7 +45,6 @@
 #include "mport.h"
 #include "mport_private.h"
 
-
 /*
  * Create directory (like mkdir -p) based on mkdir.c source.
  * WARNING: unlike most mport_ functions this does not use MPORT_ERR_FATAL, etc.
@@ -64,9 +63,9 @@ mport_mkdirp(char *path, mode_t omode)
 	p = path;
 	oumask = 0;
 	retval = 1;
-	if (p[0] == '/')		/* Skip leading '/'. */
+	if (p[0] == '/') /* Skip leading '/'. */
 		++p;
-	for (first = 1, last = 0; !last ; ++p) {
+	for (first = 1, last = 0; !last; ++p) {
 		if (p[0] == '\0')
 			last = 1;
 		else if (p[0] != '/')
@@ -118,7 +117,7 @@ mport_mkdirp(char *path, mode_t omode)
 			}
 		}
 		if (!last)
-		    *p = '/';
+			*p = '/';
 	}
 	if (!first && !last)
 		(void)umask(oumask);

--- a/libmport/ping.c
+++ b/libmport/ping.c
@@ -79,7 +79,7 @@ getCurrentTime(void)
 
 /**
  * @brief Ping a host to determine the round trip time
- * 
+ *
  * @param hostname IP address or hostname to ping
  * @return long milliseconds
  */
@@ -121,7 +121,8 @@ ping(char *hostname)
 		return -1;
 	}
 
-	for (int i = 0; i < MAX_RETRIES; i++) rtts[i] = -1;
+	for (int i = 0; i < MAX_RETRIES; i++)
+		rtts[i] = -1;
 
 	for (; try < MAX_RETRIES; try++) {
 		memset(&icmphdr, 0, sizeof(icmphdr));
@@ -147,8 +148,8 @@ ping(char *hostname)
 		for (;;) {
 			addr_len = sizeof(from_addr);
 			n = recvfrom(sockfd, recv_packet, sizeof(recv_packet), 0,
-				(struct sockaddr *)&from_addr, &addr_len);
-			
+			    (struct sockaddr *)&from_addr, &addr_len);
+
 			if (n < 0) {
 				if (errno == EINTR)
 					continue;
@@ -159,14 +160,13 @@ ping(char *hostname)
 
 			struct ip *ip_hdr = (struct ip *)recv_packet;
 			int ip_hdr_len = ip_hdr->ip_hl << 2;
-			
+
 			if (n < ip_hdr_len + (ssize_t)sizeof(struct icmp))
 				continue;
 
 			struct icmp *icmp_reply = (struct icmp *)(recv_packet + ip_hdr_len);
 
-			if (icmp_reply->icmp_type == ICMP_ECHOREPLY && 
-			    icmp_reply->icmp_id == pid && 
+			if (icmp_reply->icmp_type == ICMP_ECHOREPLY && icmp_reply->icmp_id == pid &&
 			    icmp_reply->icmp_seq == try) {
 				long end_time = getCurrentTime();
 				rtt = end_time - start_time;
@@ -174,7 +174,7 @@ ping(char *hostname)
 				break;
 			}
 		}
-		
+
 		if (try < MAX_RETRIES - 1)
 			usleep(100000); // 100ms between retries
 	}

--- a/libmport/pkgmeta.c
+++ b/libmport/pkgmeta.c
@@ -280,7 +280,8 @@ mport_pkgmeta_count(mportInstance *mport, enum count_type type, char *where)
 	else if (type == WHERE)
 		sql = "SELECT count(*) FROM packages WHERE %s";
 
-	if (mport == NULL) return len;
+	if (mport == NULL)
+		return len;
 
 	if (type == WHERE && where != NULL) {
 		if (mport_db_prepare(mport->db, &stmt, sql, where) != MPORT_OK) {
@@ -505,7 +506,8 @@ mport_pkgmeta_logevent(mportInstance *mport, mportPackageMeta *pkg, const char *
  *
  */
 static int
-enrich_vec(mportPackageMeta ***vec, int len, sqlite3 *db) {
+enrich_vec(mportPackageMeta ***vec, int len, sqlite3 *db)
+{
 	sqlite3_stmt *stmt;
 
 	for (int i = 0; i < len; i++) {
@@ -513,9 +515,11 @@ enrich_vec(mportPackageMeta ***vec, int len, sqlite3 *db) {
 		if (pkg == NULL)
 			continue;
 
-		if (mport_db_prepare(db, &stmt, "SELECT conflict_pkg FROM conflicts WHERE pkg=%Q", pkg->name) == MPORT_OK) {
+		if (mport_db_prepare(db, &stmt, "SELECT conflict_pkg FROM conflicts WHERE pkg=%Q",
+			pkg->name) == MPORT_OK) {
 			if (sqlite3_step(stmt) == SQLITE_ROW) {
-				tll_push_back(pkg->conflicts, strdup((const char *)sqlite3_column_text(stmt, 0)));
+				tll_push_back(pkg->conflicts,
+				    strdup((const char *)sqlite3_column_text(stmt, 0)));
 			}
 			sqlite3_finalize(stmt);
 		}

--- a/libmport/plist.c
+++ b/libmport/plist.c
@@ -35,70 +35,71 @@
 #include "mport_private.h"
 
 #define CMND_MAGIC_COOKIE '@'
-#define STRING_EQ(r, l) (strcmp((r),(l)) == 0)
+#define STRING_EQ(r, l) (strcmp((r), (l)) == 0)
 
 static mportAssetListEntryType parse_command(const char *);
 static int parse_file_owner_mode(mportAssetListEntry *, char *);
 
 struct command_map {
-    const char *name;
-    mportAssetListEntryType type;
+	const char *name;
+	mportAssetListEntryType type;
 };
 
 static const struct command_map command_map_table[] = {
-    { "comment",             ASSET_COMMENT },
-    { "preexec",             ASSET_PREEXEC },
-    { "preunexec",           ASSET_PREUNEXEC },
-    { "postexec",            ASSET_POSTEXEC },
-    { "postunexec",          ASSET_POSTUNEXEC },
-    { "exec",                ASSET_EXEC },
-    { "unexec",              ASSET_UNEXEC },
-    { "dir",                 ASSET_DIR },
-    { "dirrm",               ASSET_DIRRM },
-    { "dirrmtry",            ASSET_DIRRMTRY },
-    { "cwd",                 ASSET_CWD },
-    { "cd",                  ASSET_CWD },
-    { "srcdir",              ASSET_SRC },
-    { "mode",                ASSET_CHMOD },
-    { "owner",               ASSET_CHOWN },
-    { "group",               ASSET_CHGRP },
-    { "noinst",              ASSET_NOINST },
-    { "ignore",              ASSET_IGNORE },
-    { "ignore_inst",         ASSET_IGNORE_INST },
-    { "info",                ASSET_INFO },
-    { "name",                ASSET_NAME },
-    { "display",             ASSET_DISPLAY },
-    { "pkgdep",              ASSET_PKGDEP },
-    { "conflicts",           ASSET_CONFLICTS },
-    { "mtree",               ASSET_MTREE },
-    { "option",              ASSET_OPTION },
-    { "sample",              ASSET_SAMPLE },
-    { "shell",               ASSET_SHELL },
-    { "ldconfig-linux",      ASSET_LDCONFIG_LINUX },
-    { "ldconfig",            ASSET_LDCONFIG },
-    { "rmempty",             ASSET_RMEMPTY },
-    { "glib-schemas",        ASSET_GLIB_SCHEMAS },
-    { "kld",                 ASSET_KLD },
-    { "desktop-file-utils",  ASSET_DESKTOP_FILE_UTILS },
-    { "touch",               ASSET_TOUCH },
+	{ "comment", ASSET_COMMENT },
+	{ "preexec", ASSET_PREEXEC },
+	{ "preunexec", ASSET_PREUNEXEC },
+	{ "postexec", ASSET_POSTEXEC },
+	{ "postunexec", ASSET_POSTUNEXEC },
+	{ "exec", ASSET_EXEC },
+	{ "unexec", ASSET_UNEXEC },
+	{ "dir", ASSET_DIR },
+	{ "dirrm", ASSET_DIRRM },
+	{ "dirrmtry", ASSET_DIRRMTRY },
+	{ "cwd", ASSET_CWD },
+	{ "cd", ASSET_CWD },
+	{ "srcdir", ASSET_SRC },
+	{ "mode", ASSET_CHMOD },
+	{ "owner", ASSET_CHOWN },
+	{ "group", ASSET_CHGRP },
+	{ "noinst", ASSET_NOINST },
+	{ "ignore", ASSET_IGNORE },
+	{ "ignore_inst", ASSET_IGNORE_INST },
+	{ "info", ASSET_INFO },
+	{ "name", ASSET_NAME },
+	{ "display", ASSET_DISPLAY },
+	{ "pkgdep", ASSET_PKGDEP },
+	{ "conflicts", ASSET_CONFLICTS },
+	{ "mtree", ASSET_MTREE },
+	{ "option", ASSET_OPTION },
+	{ "sample", ASSET_SAMPLE },
+	{ "shell", ASSET_SHELL },
+	{ "ldconfig-linux", ASSET_LDCONFIG_LINUX },
+	{ "ldconfig", ASSET_LDCONFIG },
+	{ "rmempty", ASSET_RMEMPTY },
+	{ "glib-schemas", ASSET_GLIB_SCHEMAS },
+	{ "kld", ASSET_KLD },
+	{ "desktop-file-utils", ASSET_DESKTOP_FILE_UTILS },
+	{ "touch", ASSET_TOUCH },
 };
 
 /* Do everything needed to set up a new plist.  Always use this to create a plist,
  * don't go off and do it yourself.
  */
 MPORT_PUBLIC_API mportAssetList *
-mport_assetlist_new(void) {
+mport_assetlist_new(void)
+{
 
-    mportAssetList *list = (mportAssetList *) calloc(1, sizeof(mportAssetList));
-    assert(list != NULL);
-    STAILQ_INIT(list);
-    return list;
+	mportAssetList *list = (mportAssetList *)calloc(1, sizeof(mportAssetList));
+	assert(list != NULL);
+	STAILQ_INIT(list);
+	return list;
 }
-
 
 /* free all the entries in the list, and then the list itself. */
 MPORT_PUBLIC_API void
-mport_assetlist_free(mportAssetList *list) {
+mport_assetlist_free(mportAssetList *list)
+{
 	mportAssetListEntry *n = NULL;
 	mportAssetList *list_orig;
 	list_orig = list;
@@ -116,152 +117,156 @@ mport_assetlist_free(mportAssetList *list) {
 
 		STAILQ_REMOVE_HEAD(list, next);
 		free(n);
-        n = NULL;
+		n = NULL;
 	}
 
 	free(list_orig);
-    list_orig = NULL;
+	list_orig = NULL;
 	list = NULL;
 }
 
-
 /**
- * Parses the contents of the given plistfile pointer.  
- * Returns MPORT_OK on success, 
+ * Parses the contents of the given plistfile pointer.
+ * Returns MPORT_OK on success,
  * an error code on failure.
  */
 MPORT_PUBLIC_API int
-mport_parse_plistfile(FILE *fp, mportAssetList *list) {
-    size_t linecap = 0;
-    char *line = NULL;
-    ssize_t read = 0;
-    int ret = MPORT_OK;
-    assert(fp != NULL);
+mport_parse_plistfile(FILE *fp, mportAssetList *list)
+{
+	size_t linecap = 0;
+	char *line = NULL;
+	ssize_t read = 0;
+	int ret = MPORT_OK;
+	assert(fp != NULL);
 
-    while ((read = getline(&line, &linecap, fp)) != -1) {
-        if (read > 0 && line[read - 1] == '\n') {
-            line[--read] = '\0';
-        }
+	while ((read = getline(&line, &linecap, fp)) != -1) {
+		if (read > 0 && line[read - 1] == '\n') {
+			line[--read] = '\0';
+		}
 
-        char *parse_line = line;
+		char *parse_line = line;
 
-        /* Skip blank/whitespace lines early to avoid allocation */
-        while (*parse_line != '\0' && isspace((unsigned char)*parse_line)) {
-            parse_line++;
-        }
-        if (*parse_line == '\0')
-            continue;
+		/* Skip blank/whitespace lines early to avoid allocation */
+		while (*parse_line != '\0' && isspace((unsigned char)*parse_line)) {
+			parse_line++;
+		}
+		if (*parse_line == '\0')
+			continue;
 
-        mportAssetListEntry *entry = (mportAssetListEntry *) calloc(1, sizeof(mportAssetListEntry));
-        if (entry == NULL) {
-            SET_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-            ret = MPORT_ERR_FATAL;
-            goto cleanup;
-        }
+		mportAssetListEntry *entry =
+		    (mportAssetListEntry *)calloc(1, sizeof(mportAssetListEntry));
+		if (entry == NULL) {
+			SET_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+			ret = MPORT_ERR_FATAL;
+			goto cleanup;
+		}
 
-        /* reset parse_line because leading whitespace might be significant for non-directives */
-        parse_line = line;
+		/* reset parse_line because leading whitespace might be significant for
+		 * non-directives */
+		parse_line = line;
 
-        if (*parse_line == CMND_MAGIC_COOKIE) {
-            parse_line++;
-            /* directive lines skip leading spaces after @ */
-            while (*parse_line != '\0' && isspace((unsigned char)*parse_line)) {
-                parse_line++;
-            }
+		if (*parse_line == CMND_MAGIC_COOKIE) {
+			parse_line++;
+			/* directive lines skip leading spaces after @ */
+			while (*parse_line != '\0' && isspace((unsigned char)*parse_line)) {
+				parse_line++;
+			}
 
-            char *cmnd = strsep(&parse_line, " \t");
-            if (cmnd == NULL || *cmnd == '\0') {
-                free(entry);
-                SET_ERROR(MPORT_ERR_FATAL, "Malformed plist file.");
-                ret = MPORT_ERR_FATAL;
-                goto cleanup;
-            }
+			char *cmnd = strsep(&parse_line, " \t");
+			if (cmnd == NULL || *cmnd == '\0') {
+				free(entry);
+				SET_ERROR(MPORT_ERR_FATAL, "Malformed plist file.");
+				ret = MPORT_ERR_FATAL;
+				goto cleanup;
+			}
 
-            entry->checksum[0] = '\0'; /* checksum is only used by bundle read install */
-            entry->type = parse_command(cmnd);
-            if (entry->type == ASSET_FILE_OWNER_MODE) {
-                if (parse_file_owner_mode(entry, cmnd) != MPORT_OK) {
-                    free(entry);
-                    ret = MPORT_ERR_FATAL;
-                    goto cleanup;
-                }
-            } else if (entry->type == ASSET_DIR_OWNER_MODE) {
-                if (parse_file_owner_mode(entry, &cmnd[3]) != MPORT_OK) {
-                    free(entry);
-                    ret = MPORT_ERR_FATAL;
-                    goto cleanup;
-                }
-            } else if (entry->type == ASSET_SAMPLE_OWNER_MODE) {
-                if (parse_file_owner_mode(entry, &cmnd[6]) != MPORT_OK) {
-                    free(entry);
-                    ret = MPORT_ERR_FATAL;
-                    goto cleanup;
-                }
-            }
+			entry->checksum[0] =
+			    '\0'; /* checksum is only used by bundle read install */
+			entry->type = parse_command(cmnd);
+			if (entry->type == ASSET_FILE_OWNER_MODE) {
+				if (parse_file_owner_mode(entry, cmnd) != MPORT_OK) {
+					free(entry);
+					ret = MPORT_ERR_FATAL;
+					goto cleanup;
+				}
+			} else if (entry->type == ASSET_DIR_OWNER_MODE) {
+				if (parse_file_owner_mode(entry, &cmnd[3]) != MPORT_OK) {
+					free(entry);
+					ret = MPORT_ERR_FATAL;
+					goto cleanup;
+				}
+			} else if (entry->type == ASSET_SAMPLE_OWNER_MODE) {
+				if (parse_file_owner_mode(entry, &cmnd[6]) != MPORT_OK) {
+					free(entry);
+					ret = MPORT_ERR_FATAL;
+					goto cleanup;
+				}
+			}
 
-            /* Skip leading whitespace for directive data */
-            while (parse_line != NULL && *parse_line != '\0' && isspace((unsigned char)*parse_line)) {
-                parse_line++;
-            }
-        } else {
-            /* command is backed by a file */
-            entry->type = ASSET_FILE;
-        }
+			/* Skip leading whitespace for directive data */
+			while (parse_line != NULL && *parse_line != '\0' &&
+			    isspace((unsigned char)*parse_line)) {
+				parse_line++;
+			}
+		} else {
+			/* command is backed by a file */
+			entry->type = ASSET_FILE;
+		}
 
-        if (parse_line == NULL || *parse_line == '\0') {
-            /* line was just a directive, no data */
-            entry->data = NULL;
-        } else {
-            if (entry->type == ASSET_COMMENT) {
-                if (!strncmp(parse_line, "ORIGIN:", 7)) {
-                    parse_line += 7;
-                    entry->type = ASSET_ORIGIN;
-                } else if (!strncmp(parse_line, "DEPORIGIN:", 10)) {
-                    parse_line += 10;
-                    entry->type = ASSET_DEPORIGIN;
-                }
-            }
+		if (parse_line == NULL || *parse_line == '\0') {
+			/* line was just a directive, no data */
+			entry->data = NULL;
+		} else {
+			if (entry->type == ASSET_COMMENT) {
+				if (!strncmp(parse_line, "ORIGIN:", 7)) {
+					parse_line += 7;
+					entry->type = ASSET_ORIGIN;
+				} else if (!strncmp(parse_line, "DEPORIGIN:", 10)) {
+					parse_line += 10;
+					entry->type = ASSET_DEPORIGIN;
+				}
+			}
 
-            size_t buflen = strlen(parse_line);
-            char *pos = parse_line + buflen - 1;
-            while (pos >= parse_line && isspace((unsigned char)*pos)) {
-                *pos = '\0';
-                pos--;
-            }
+			size_t buflen = strlen(parse_line);
+			char *pos = parse_line + buflen - 1;
+			while (pos >= parse_line && isspace((unsigned char)*pos)) {
+				*pos = '\0';
+				pos--;
+			}
 
-            entry->data = strdup(parse_line);
-            if (entry->data == NULL) {
-                free(entry);
-                SET_ERROR(MPORT_ERR_FATAL, "Out of memory.");
-                ret = MPORT_ERR_FATAL;
-                goto cleanup;
-            }
-        }
+			entry->data = strdup(parse_line);
+			if (entry->data == NULL) {
+				free(entry);
+				SET_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+				ret = MPORT_ERR_FATAL;
+				goto cleanup;
+			}
+		}
 
-        STAILQ_INSERT_TAIL(list, entry, next);
-    }
+		STAILQ_INSERT_TAIL(list, entry, next);
+	}
 
 cleanup:
-    free(line);
-    return ret;
+	free(line);
+	return ret;
 }
-
 
 /**
  * Parse the file owner, group and mode.
  */
-static int 
-parse_file_owner_mode(mportAssetListEntry *entry, char *cmnd) {
+static int
+parse_file_owner_mode(mportAssetListEntry *entry, char *cmnd)
+{
 	char *op = cmnd;
-	char *permissions[3] = {NULL, NULL, NULL};
+	char *permissions[3] = { NULL, NULL, NULL };
 	char *tok = NULL;
 	int i = 0;
 
-    if (entry == NULL || cmnd == NULL) {
-        RETURN_ERROR(MPORT_ERR_FATAL, "Entry or command is NULL");
-    }
+	if (entry == NULL || cmnd == NULL) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "Entry or command is NULL");
+	}
 
-	while((tok = strsep(&op, "(,)")) != NULL && i < 3) {
+	while ((tok = strsep(&op, "(,)")) != NULL && i < 3) {
 		if (*tok == '\0')
 			continue;
 		permissions[i++] = tok;
@@ -280,28 +285,24 @@ parse_file_owner_mode(mportAssetListEntry *entry, char *cmnd) {
 	return MPORT_OK;
 }
 
-
-
 static mportAssetListEntryType
-parse_command(const char *s) {
-    if (s == NULL || *s == '\0')
-        return ASSET_INVALID;
+parse_command(const char *s)
+{
+	if (s == NULL || *s == '\0')
+		return ASSET_INVALID;
 
-    /* special/Prefix cases first */
-    if (s[0] == '(')
-        return ASSET_FILE_OWNER_MODE;
-    if (strncmp(s, "dir(", 4) == 0)
-        return ASSET_DIR_OWNER_MODE;
-    if (strncmp(s, "sample(", 7) == 0)
-        return ASSET_SAMPLE_OWNER_MODE;
+	/* special/Prefix cases first */
+	if (s[0] == '(')
+		return ASSET_FILE_OWNER_MODE;
+	if (strncmp(s, "dir(", 4) == 0)
+		return ASSET_DIR_OWNER_MODE;
+	if (strncmp(s, "sample(", 7) == 0)
+		return ASSET_SAMPLE_OWNER_MODE;
 
-    for (size_t i = 0; i < sizeof(command_map_table) / sizeof(command_map_table[0]); i++) {
-        if (STRING_EQ(s, command_map_table[i].name))
-            return command_map_table[i].type;
-    }
+	for (size_t i = 0; i < sizeof(command_map_table) / sizeof(command_map_table[0]); i++) {
+		if (STRING_EQ(s, command_map_table[i].name))
+			return command_map_table[i].type;
+	}
 
-    return ASSET_INVALID;
+	return ASSET_INVALID;
 }
-
-
-

--- a/libmport/service.c
+++ b/libmport/service.c
@@ -43,14 +43,13 @@ extern char **environ;
 
 static int run_service_cmd(mportInstance *mport, const char *rc_script, char *command);
 
-int 
-mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_action_t action) 
+int
+mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_action_t action)
 {
 	sqlite3_stmt *stmt;
 	char *service;
 	const unsigned char *rc_script;
 	char *handle_rc_script;
-
 
 	// don't turn off services if MPORT_GUI is set.  This can drop someone out of an X session.
 	// TODO: we should handle this with triggers eventually.
@@ -59,11 +58,12 @@ mport_start_stop_service(mportInstance *mport, mportPackageMeta *pack, service_a
 
 	// if handle rc scripts is disabled, we don't need to do anything
 	handle_rc_script = mport_setting_get(mport, MPORT_SETTING_HANDLE_RC_SCRIPTS);
-	bool skip = (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script));
+	bool skip =
+	    (getenv("HANDLE_RC_SCRIPTS") == NULL && !mport_check_answer_bool(handle_rc_script));
 	free(handle_rc_script);
 	if (skip)
-	    return (MPORT_OK);
-	
+		return (MPORT_OK);
+
 	/* stop any services that might exist; this replaces @stopdaemon */
 	if (mport_db_prepare(mport->db, &stmt,
 		"select data from assets where data like '/usr/local/etc/rc.d/%%' and type=%i and pkg=%Q",
@@ -113,7 +113,8 @@ run_service_cmd(mportInstance *mport, const char *rc_script, char *command)
 	argv[2] = command;
 	argv[3] = NULL;
 
-	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL, (char **)argv, environ)) != 0) {
+	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL, (char **)argv, environ)) !=
+	    0) {
 		errno = error;
 		mport_call_msg_cb(mport, "Unable to %s service %s\n", command, rc_script);
 		return (-1);

--- a/libmport/setting.c
+++ b/libmport/setting.c
@@ -49,11 +49,10 @@ mport_setting_get(mportInstance *mport, const char *name)
 	}
 
 	switch (sqlite3_step(stmt)) {
-	case SQLITE_ROW:
-		{
-			const unsigned char *row_val = sqlite3_column_text(stmt, 0);
-			val = (row_val == NULL) ? NULL : strdup((const char *)row_val);
-		}
+	case SQLITE_ROW: {
+		const unsigned char *row_val = sqlite3_column_text(stmt, 0);
+		val = (row_val == NULL) ? NULL : strdup((const char *)row_val);
+	}
 		sqlite3_finalize(stmt);
 		if (val == NULL) {
 			SET_ERROR(MPORT_ERR_FATAL, "Malformed setting row.");
@@ -101,7 +100,7 @@ mport_setting_list(mportInstance *mport)
 
 	if (mport_db_count(mport->db, &count, "SELECT count(*) FROM settings") != MPORT_OK) {
 		return NULL;
-	}	
+	}
 
 	list = calloc(count + 1, sizeof(char *));
 	if (list == NULL)

--- a/libmport/stats.c
+++ b/libmport/stats.c
@@ -38,7 +38,7 @@
 MPORT_PUBLIC_API mportStats *
 mport_stats_new(void)
 {
-	return (mportStats *) calloc(1, sizeof(mportStats));
+	return (mportStats *)calloc(1, sizeof(mportStats));
 }
 
 MPORT_PUBLIC_API int
@@ -73,10 +73,9 @@ mport_stats(mportInstance *mport, mportStats **stats)
 		goto cleanup;
 	}
 
-	s->pkg_installed = (unsigned int) sqlite3_column_int(stmt, 0);
+	s->pkg_installed = (unsigned int)sqlite3_column_int(stmt, 0);
 	sqlite3_finalize(stmt);
 	stmt = NULL;
-
 
 	if (mport_db_prepare(db, &stmt, "SELECT sum(flatsize) FROM packages") != MPORT_OK) {
 		result = mport_err_code();
@@ -95,8 +94,10 @@ mport_stats(mportInstance *mport, mportStats **stats)
 
 	if (mport_db_prepare(db, &stmt, "SELECT COUNT(*) FROM idx.packages") != MPORT_OK) {
 		int errcode = sqlite3_errcode(db);
-		/* If the index is missing or detached, we still want to return what we have for local */
-		if (errcode == SQLITE_ERROR && strstr(sqlite3_errmsg(db), "no such table") != NULL) {
+		/* If the index is missing or detached, we still want to return what we have for
+		 * local */
+		if (errcode == SQLITE_ERROR &&
+		    strstr(sqlite3_errmsg(db), "no such table") != NULL) {
 			s->pkg_available = 0;
 			sqlite3_finalize(stmt);
 			stmt = NULL;
@@ -108,7 +109,7 @@ mport_stats(mportInstance *mport, mportStats **stats)
 		if (sqlite3_step(stmt) != SQLITE_ROW) {
 			s->pkg_available = 0;
 		} else {
-			s->pkg_available = (unsigned int) sqlite3_column_int(stmt, 0);
+			s->pkg_available = (unsigned int)sqlite3_column_int(stmt, 0);
 		}
 		sqlite3_finalize(stmt);
 		stmt = NULL;

--- a/libmport/update.c
+++ b/libmport/update.c
@@ -32,7 +32,8 @@
 #include <stdlib.h>
 
 MPORT_PUBLIC_API int
-mport_update(mportInstance *mport, const char *packageName) {
+mport_update(mportInstance *mport, const char *packageName)
+{
 	char *path = NULL;
 	mportDependsEntry **depends = NULL;
 	mportDependsEntry **depends_orig = NULL;
@@ -43,37 +44,42 @@ mport_update(mportInstance *mport, const char *packageName) {
 		return (MPORT_ERR_WARN);
 	}
 
-	if (mport_index_select_pkgname(mport, packageName, "Multiple packages match your query.", &indexEntries, &indexEntry) !=
-	    MPORT_OK)
+	if (mport_index_select_pkgname(mport, packageName, "Multiple packages match your query.",
+		&indexEntries, &indexEntry) != MPORT_OK)
 		return mport_err_code();
 
-	int result = mport_download(mport, indexEntry == NULL ? packageName : indexEntry->pkgname, false, false, &path);
-	if (result != MPORT_OK)
-	{
+	int result = mport_download(
+	    mport, indexEntry == NULL ? packageName : indexEntry->pkgname, false, false, &path);
+	if (result != MPORT_OK) {
 		mport_index_entry_free_vec(indexEntries);
 		return result;
 	}
 
-	/* in the event the package is not found in the index, it could be user generated, and we still want to update it if
-	   present */
+	/* in the event the package is not found in the index, it could be user generated, and we
+	   still want to update it if present */
 	if (indexEntry == NULL) {
 		mport_call_msg_cb(mport, "Package %s not found in the index\n", packageName);
 	} else {
 		/* get the dependency list and start updating/installing missing entries */
-		if (mport_index_depends_list(mport, indexEntry->pkgname, indexEntry->version, &depends_orig) != MPORT_OK) {
-			mport_call_msg_cb(mport, "Failed to get dependency list for %s: %s\n", packageName, mport_err_string());
+		if (mport_index_depends_list(mport, indexEntry->pkgname, indexEntry->version,
+			&depends_orig) != MPORT_OK) {
+			mport_call_msg_cb(mport, "Failed to get dependency list for %s: %s\n",
+			    packageName, mport_err_string());
 			mport_index_entry_free_vec(indexEntries);
 			return mport_err_code();
 		}
 
 		depends = depends_orig;
 		while (*depends != NULL) {
-			if (mport_install_depends(mport, (*depends)->d_pkgname, (*depends)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
+			if (mport_install_depends(mport, (*depends)->d_pkgname,
+				(*depends)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
 				mport_index_depends_free_vec(depends);
 				mport_index_entry_free_vec(indexEntries);
 				if (mport->ignoreMissing) {
-					mport_call_msg_cb(mport, "Ignoring missing dependency %s-%s\n", (*depends)->d_pkgname, (*depends)->d_version);
+					mport_call_msg_cb(mport,
+					    "Ignoring missing dependency %s-%s\n",
+					    (*depends)->d_pkgname, (*depends)->d_version);
 					depends++;
 					continue;
 				}

--- a/libmport/update_primative.c
+++ b/libmport/update_primative.c
@@ -34,112 +34,115 @@
 
 static int set_prefix_to_installed(mportInstance *, mportPackageMeta *);
 
-
 MPORT_PUBLIC_API int
 mport_update_primative(mportInstance *mport, const char *filename)
 {
-    mportBundleRead *bundle = NULL;
-    mportPackageMeta **pkgs = NULL;
-    mportPackageMeta *pkg = NULL;
-    mportPackageMeta **packs_start = NULL;
-    mportPackageMeta **already_installed = NULL;
+	mportBundleRead *bundle = NULL;
+	mportPackageMeta **pkgs = NULL;
+	mportPackageMeta *pkg = NULL;
+	mportPackageMeta **packs_start = NULL;
+	mportPackageMeta **already_installed = NULL;
 
-    if ((bundle = mport_bundle_read_new()) == NULL)
-        RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
+	if ((bundle = mport_bundle_read_new()) == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory.");
 
-    if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
-        RETURN_CURRENT_ERROR;
+	if (mport_bundle_read_init(bundle, filename) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
-    if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
-        RETURN_CURRENT_ERROR;
+	if (mport_bundle_read_prep_for_install(mport, bundle) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
-    if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
-        RETURN_CURRENT_ERROR;
+	if (mport_pkgmeta_read_stub(mport, &pkgs) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
-    packs_start = pkgs;
-    for (int i = 0; *(pkgs + i) != NULL; i++) {
-        pkg = pkgs[i];
+	packs_start = pkgs;
+	for (int i = 0; *(pkgs + i) != NULL; i++) {
+		pkg = pkgs[i];
 		pkg->install_date = mport_get_time();
 
-        if (!mport_is_age_verified(mport, pkg)) {
-			mport_call_msg_cb(mport, "Unable to install %s-%s: package is age restricted and user does not meet the requirements.", pkg->name, pkg->version);
-            mport_set_err(MPORT_OK, NULL);
-            continue;
+		if (!mport_is_age_verified(mport, pkg)) {
+			mport_call_msg_cb(mport,
+			    "Unable to install %s-%s: package is age restricted and user does not meet the requirements.",
+			    pkg->name, pkg->version);
+			mport_set_err(MPORT_OK, NULL);
+			continue;
 		}
 
-        /* retain automatic flag from previous install. */
-        if (mport_pkgmeta_search_master(mport, &already_installed, "pkg=%Q", pkg->name) == MPORT_OK) {
-            if (already_installed != NULL && already_installed[0] != NULL) {
-              pkg->automatic = already_installed[0]->automatic;
-              pkg->locked = already_installed[0]->locked;
+		/* retain automatic flag from previous install. */
+		if (mport_pkgmeta_search_master(mport, &already_installed, "pkg=%Q", pkg->name) ==
+		    MPORT_OK) {
+			if (already_installed != NULL && already_installed[0] != NULL) {
+				pkg->automatic = already_installed[0]->automatic;
+				pkg->locked = already_installed[0]->locked;
 
-              mport_pkgmeta_vec_free(already_installed);
-            }
-        }
+				mport_pkgmeta_vec_free(already_installed);
+			}
+		}
 
-        if (mport_lock_islocked(pkg) == MPORT_LOCKED) {
-            mport_call_msg_cb(mport, "Unable to update %s-%s: package is locked.", pkg->name, pkg->version);
-            mport_set_err(MPORT_OK, NULL);
-            continue;
-        }
+		if (mport_lock_islocked(pkg) == MPORT_LOCKED) {
+			mport_call_msg_cb(mport, "Unable to update %s-%s: package is locked.",
+			    pkg->name, pkg->version);
+			mport_set_err(MPORT_OK, NULL);
+			continue;
+		}
 
-        int flag = MPORT_PRECHECK_CONFLICTS;
-        if (!mport->ignoreMissing)
-            flag = flag | MPORT_PRECHECK_DEPENDS;
-        if (!mport->force)
-            flag = flag | MPORT_PRECHECK_UPGRADEABLE;
+		int flag = MPORT_PRECHECK_CONFLICTS;
+		if (!mport->ignoreMissing)
+			flag = flag | MPORT_PRECHECK_DEPENDS;
+		if (!mport->force)
+			flag = flag | MPORT_PRECHECK_UPGRADEABLE;
 
-        if (
-            (mport_check_preconditions(mport, pkg, flag) != MPORT_OK) ||
-            (set_prefix_to_installed(mport, pkg) != MPORT_OK) ||
-            (mport_bundle_read_update_pkg(mport, bundle, pkg) != MPORT_OK)
-        ) {
-            mport_call_msg_cb(mport, "Unable to update %s-%s: %s", pkg->name, pkg->version, mport_err_string());
-            mport_set_err(MPORT_OK, NULL);
-        }
-    }
+		if ((mport_check_preconditions(mport, pkg, flag) != MPORT_OK) ||
+		    (set_prefix_to_installed(mport, pkg) != MPORT_OK) ||
+		    (mport_bundle_read_update_pkg(mport, bundle, pkg) != MPORT_OK)) {
+			mport_call_msg_cb(mport, "Unable to update %s-%s: %s", pkg->name,
+			    pkg->version, mport_err_string());
+			mport_set_err(MPORT_OK, NULL);
+		}
+	}
 
-    mport_pkgmeta_vec_free(packs_start);
+	mport_pkgmeta_vec_free(packs_start);
 
-    if (mport_bundle_read_finish(mport, bundle) != MPORT_OK)
-        RETURN_CURRENT_ERROR;
+	if (mport_bundle_read_finish(mport, bundle) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
-    return MPORT_OK;
+	return MPORT_OK;
 }
 
 static int
 set_prefix_to_installed(mportInstance *mport, mportPackageMeta *pkg)
 {
-    sqlite3_stmt *stmt;
-    int ret = MPORT_OK;
-    const char *prefix;
+	sqlite3_stmt *stmt;
+	int ret = MPORT_OK;
+	const char *prefix;
 
-    if (mport_db_prepare(mport->db, &stmt, "SELECT prefix FROM packages WHERE pkg=%Q", pkg->name) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt, "SELECT prefix FROM packages WHERE pkg=%Q",
+		pkg->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
 
-    switch (sqlite3_step(stmt)) {
-        case SQLITE_ROW:
-            prefix = sqlite3_column_text(stmt, 0);
+	switch (sqlite3_step(stmt)) {
+	case SQLITE_ROW:
+		prefix = sqlite3_column_text(stmt, 0);
 
-            if (strcmp(prefix, pkg->prefix) != 0) {
-                free(pkg->prefix);
-                if ((pkg->prefix = strdup(prefix)) == NULL) {
-                    ret = MPORT_ERR_FATAL;
-                }
-            }
-            break;
-        case SQLITE_DONE:
-            ret = SET_ERRORX(MPORT_ERR_FATAL, "%s not in master db, after passing precondition check!", pkg->name);
-            break;
-        default:
-            ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-            break;
-    }
+		if (strcmp(prefix, pkg->prefix) != 0) {
+			free(pkg->prefix);
+			if ((pkg->prefix = strdup(prefix)) == NULL) {
+				ret = MPORT_ERR_FATAL;
+			}
+		}
+		break;
+	case SQLITE_DONE:
+		ret = SET_ERRORX(MPORT_ERR_FATAL,
+		    "%s not in master db, after passing precondition check!", pkg->name);
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
+	}
 
-    sqlite3_finalize(stmt);
+	sqlite3_finalize(stmt);
 
-    return ret;
+	return ret;
 }
-

--- a/libmport/upgrade.c
+++ b/libmport/upgrade.c
@@ -43,11 +43,12 @@
 #include <ohash.h>
 #endif
 
-static void * ecalloc(size_t, void *);
+static void *ecalloc(size_t, void *);
 static void efree(void *, size_t, void *);
 
 static void *
-ecalloc(size_t s1, void *data) {
+ecalloc(size_t s1, void *data)
+{
 	void *p;
 
 	if (!(p = malloc(s1)))
@@ -57,12 +58,14 @@ ecalloc(size_t s1, void *data) {
 }
 
 static void
-efree(void *p, size_t s1, void *data){
+efree(void *p, size_t s1, void *data)
+{
 	free(p);
 }
 
 MPORT_PUBLIC_API int
-mport_upgrade(mportInstance *mport) {
+mport_upgrade(mportInstance *mport)
+{
 	mportPackageMeta **packs, **packs_orig = NULL;
 	int total = 0;
 	int updated = 0;
@@ -90,21 +93,21 @@ mport_upgrade(mportInstance *mport) {
 
 #if defined(__MidnightBSD__)
 	ohash_init(&h, 6, &info);
-	#endif
+#endif
 
 	// check for moved/expired packages first
 	packs = packs_orig;
 	while (*packs != NULL) {
 		mportIndexMovedEntry **movedEntries;
 
-		#if defined(__MidnightBSD__)
+#if defined(__MidnightBSD__)
 		slot = ohash_qlookup(&h, (*packs)->name);
 		key = ohash_find(&h, slot);
 		if (key != NULL) {
 			packs++;
 			continue;
 		}
-		#endif
+#endif
 
 		if (mport_moved_lookup(mport, (*packs)->origin, &movedEntries) != MPORT_OK ||
 		    movedEntries == NULL || *movedEntries == NULL) {
@@ -113,25 +116,31 @@ mport_upgrade(mportInstance *mport) {
 		}
 
 		if ((*movedEntries)->date[0] != '\0') {
-			asprintf(&msg, "Package %s is deprecated with expiration date %s. Do you want to remove it?", (*packs)->name, (*movedEntries)->date);
+			asprintf(&msg,
+			    "Package %s is deprecated with expiration date %s. Do you want to remove it?",
+			    (*packs)->name, (*movedEntries)->date);
 			if ((mport->confirm_cb)(msg, "Delete", "Don't delete", 1) == MPORT_OK) {
 				(*packs)->action = MPORT_ACTION_DELETE;
 				mport_delete_primative(mport, (*packs), true);
-				#if defined(__MidnightBSD__)
+#if defined(__MidnightBSD__)
 				ohash_insert(&h, slot, (*packs)->name);
-				#endif
-			}	
+#endif
+			}
 
 			packs++;
 			continue;
-		}		
+		}
 
-		if ((*movedEntries)->moved_to_pkgname != NULL && (*movedEntries)->moved_to_pkgname[0]!= '\0') {   
-			mport_call_msg_cb(mport, "Package %s has moved to %s. Migrating %s\n", (*packs)->name, (*movedEntries)->moved_to_pkgname,  (*movedEntries)->moved_to_pkgname);
+		if ((*movedEntries)->moved_to_pkgname != NULL &&
+		    (*movedEntries)->moved_to_pkgname[0] != '\0') {
+			mport_call_msg_cb(mport, "Package %s has moved to %s. Migrating %s\n",
+			    (*packs)->name, (*movedEntries)->moved_to_pkgname,
+			    (*movedEntries)->moved_to_pkgname);
 			(*packs)->action = MPORT_ACTION_UPGRADE;
 			mport_delete_primative(mport, (*packs), true);
 			// TODO: how to mark this action as an update?
-			mport_install_single(mport, (*movedEntries)->moved_to_pkgname,  NULL, NULL, (*packs)->automatic);
+			mport_install_single(mport, (*movedEntries)->moved_to_pkgname, NULL, NULL,
+			    (*packs)->automatic);
 #if defined(__MidnightBSD__)
 			ohash_insert(&h, slot, (*packs)->name);
 			slot = ohash_qlookup(&h, (*movedEntries)->moved_to_pkgname);
@@ -141,26 +150,28 @@ mport_upgrade(mportInstance *mport) {
 		packs++;
 	}
 
-    // update packages that haven't moved already
+	// update packages that haven't moved already
 	packs = packs_orig;
 	while (*packs != NULL) {
 #if defined(__MidnightBSD__)
 		slot = ohash_qlookup(&h, (*packs)->name);
 		key = ohash_find(&h, slot);
 		if (key == NULL) {
-		#endif
+#endif
 			int match = mport_index_check(mport, *packs);
 			if (match == 1) {
 				(*packs)->action = MPORT_ACTION_UPGRADE;
-				#if defined(__MidnightBSD__)
+#if defined(__MidnightBSD__)
 				updated += mport_update_down(mport, *packs, &info, &h);
-				#else
-				updated += mport_update_down(mport, *packs, NULL, NULL);
-				#endif
+#else
+			updated += mport_update_down(mport, *packs, NULL, NULL);
+#endif
 			} else if (match == 2) {
 				mportIndexEntry **ieUpdateMe;
-				if (mport_index_lookup_pkgname(mport, (*packs)->origin, &ieUpdateMe) != MPORT_OK) {
-					SET_ERRORX(MPORT_ERR_WARN, "Error Looking up package origin %s", (*packs)->origin);
+				if (mport_index_lookup_pkgname(
+					mport, (*packs)->origin, &ieUpdateMe) != MPORT_OK) {
+					SET_ERRORX(MPORT_ERR_WARN,
+					    "Error Looking up package origin %s", (*packs)->origin);
 					return (0);
 				}
 
@@ -170,17 +181,19 @@ mport_upgrade(mportInstance *mport) {
 				}
 
 				char *msg = NULL;
-				(void)asprintf(
-					&msg, "The package you have installed %s appears to have been replaced by %s. Do you want to update?",
-					 (*packs)->name, (*ieUpdateMe)->pkgname);
-				if ((mport->confirm_cb)(msg, "Update", "Don't Update", 0) != MPORT_OK) {
+				(void)asprintf(&msg,
+				    "The package you have installed %s appears to have been replaced by %s. Do you want to update?",
+				    (*packs)->name, (*ieUpdateMe)->pkgname);
+				if ((mport->confirm_cb)(msg, "Update", "Don't Update", 0) !=
+				    MPORT_OK) {
 					(*packs)->action = MPORT_ACTION_UPGRADE;
 					mport_delete_primative(mport, (*packs), true);
 					// TODO: how to mark this action as an update?
-					mport_install_single(mport, (*ieUpdateMe)->pkgname,  NULL, NULL, (*packs)->automatic);
-					#if defined(__MidnightBSD__)
+					mport_install_single(mport, (*ieUpdateMe)->pkgname, NULL,
+					    NULL, (*packs)->automatic);
+#if defined(__MidnightBSD__)
 					ohash_insert(&h, slot, (*ieUpdateMe)->pkgname);
-					#endif
+#endif
 					updated++;
 				}
 				free(msg);
@@ -203,7 +216,9 @@ mport_upgrade(mportInstance *mport) {
 }
 
 int
-mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_info *info, struct ohash *h) {
+mport_update_down(
+    mportInstance *mport, mportPackageMeta *pack, struct ohash_info *info, struct ohash *h)
+{
 	mportPackageMeta **depends, **depends_orig;
 	int ret = 0;
 	unsigned int slot;
@@ -211,17 +226,18 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 
 	if (mport_pkgmeta_get_downdepends(mport, pack, &depends_orig) == MPORT_OK) {
 		if (depends_orig == NULL) {
-			
-			#if defined(__MidnightBSD__)
+
+#if defined(__MidnightBSD__)
 			slot = ohash_qlookup(h, pack->name);
 			key = ohash_find(h, slot);
-			#endif
+#endif
 			if (key == NULL) {
 				if (mport_index_check(mport, pack)) {
 					mport_call_msg_cb(mport, "Updating %s\n", pack->name);
 					pack->action = MPORT_ACTION_UPGRADE;
-					if (mport_update(mport, pack->name) !=0) {
-						mport_call_msg_cb(mport, "Error updating %s\n", pack->name);
+					if (mport_update(mport, pack->name) != 0) {
+						mport_call_msg_cb(
+						    mport, "Error updating %s\n", pack->name);
 						ret = 0;
 					} else {
 						ret = 1;
@@ -244,10 +260,13 @@ mport_update_down(mportInstance *mport, mportPackageMeta *pack, struct ohash_inf
 				if (key == NULL) {
 					ret += mport_update_down(mport, (*depends), info, h);
 					if (mport_index_check(mport, *depends)) {
-						mport_call_msg_cb(mport, "Updating depends %s\n", (*depends)->name);
+						mport_call_msg_cb(mport, "Updating depends %s\n",
+						    (*depends)->name);
 						(*depends)->action = MPORT_ACTION_UPGRADE;
 						if (mport_update(mport, (*depends)->name) != 0) {
-							mport_call_msg_cb(mport, "Error updating %s\n", (*depends)->name);
+							mport_call_msg_cb(mport,
+							    "Error updating %s\n",
+							    (*depends)->name);
 						} else {
 							ret++;
 #if defined(__MidnightBSD__)

--- a/libmport/util.c
+++ b/libmport/util.c
@@ -74,7 +74,7 @@ mport_createextras_new(void)
 	extra->pkg_filename[0] = '\0';
 	extra->sourcedir[0] = '\0';
 	extra->mtree = NULL;
-	
+
 	extra->pkginstall = NULL;
 	extra->pkgdeinstall = NULL;
 	extra->luapkgpostdeinstall = NULL;
@@ -158,48 +158,46 @@ mport_verify_hash(const char *filename, const char *hash)
 	return 0;
 }
 
-char* 
+char *
 mport_extract_hash_from_file(const char *filename)
 {
 
-    FILE *file = fopen(filename, "r");
-    if (!file) {
-        perror("Failed to open file");
-        return NULL;
-    }
+	FILE *file = fopen(filename, "r");
+	if (!file) {
+		perror("Failed to open file");
+		return NULL;
+	}
 
-    char *hash = calloc(65, sizeof(char)); // SHA256 hash is 64 characters + null terminator
-    if (!hash) {
-        perror("Failed to allocate memory");
-        fclose(file);
-        return NULL;
-    }
+	char *hash = calloc(65, sizeof(char)); // SHA256 hash is 64 characters + null terminator
+	if (!hash) {
+		perror("Failed to allocate memory");
+		fclose(file);
+		return NULL;
+	}
 
-    char buffer[256];
-    if (fgets(buffer, sizeof(buffer), file) == NULL) {
-        perror("Failed to read hash from file");
-        free(hash);
-        fclose(file);
-        return NULL;
-    }
+	char buffer[256];
+	if (fgets(buffer, sizeof(buffer), file) == NULL) {
+		perror("Failed to read hash from file");
+		free(hash);
+		fclose(file);
+		return NULL;
+	}
 
-    fclose(file);
+	fclose(file);
 
-    // Extract the hash from the format "SHA256 (index.db.zst) = <hash>"
-    char *hash_start = strchr(buffer, '=');
-    if (hash_start == NULL) {
-        perror("Invalid hash format");
-        free(hash);
-        return NULL;
-    }
+	// Extract the hash from the format "SHA256 (index.db.zst) = <hash>"
+	char *hash_start = strchr(buffer, '=');
+	if (hash_start == NULL) {
+		perror("Invalid hash format");
+		free(hash);
+		return NULL;
+	}
 
-    hash_start += 2; // Skip the "= " part
-    strlcpy(hash, hash_start, 65);
+	hash_start += 2; // Skip the "= " part
+	strlcpy(hash, hash_start, 65);
 
-    return hash;
+	return hash;
 }
-
-
 
 bool
 mport_starts_with(const char *pre, const char *str)
@@ -275,14 +273,15 @@ mport_chdir(mportInstance *mport, const char *dir)
 	return (MPORT_OK);
 }
 
-static int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
+static int
+unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
 {
-    int rv = remove(fpath);
+	int rv = remove(fpath);
 
-    if (rv)
-        perror(fpath);
+	if (rv)
+		perror(fpath);
 
-    return rv;
+	return rv;
 }
 
 /* deletes the entire directory tree at filename.
@@ -293,7 +292,7 @@ mport_rmtree(const char *filename)
 {
 	int ret = nftw(filename, unlink_cb, 64, FTW_DEPTH | FTW_MOUNT | FTW_PHYS | FTW_CHDIR);
 
-	if (ret!= 0)
+	if (ret != 0)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Error removing directory tree");
 	return MPORT_OK;
 }
@@ -329,24 +328,25 @@ mport_copy_file(const char *fromName, const char *toName)
 	return (MPORT_OK);
 }
 
-
 int
 mport_copy_fd(int from_fd, int to_fd)
 {
-    char buf[BUFSIZ];
-    ssize_t size;
+	char buf[BUFSIZ];
+	ssize_t size;
 
-    while ((size = read(from_fd, buf, BUFSIZ)) > 0) {
-        if (write(to_fd, buf, size) != size) {
-            RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't write to destination file descriptor: %s", strerror(errno));
-        }
-    }
+	while ((size = read(from_fd, buf, BUFSIZ)) > 0) {
+		if (write(to_fd, buf, size) != size) {
+			RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "Couldn't write to destination file descriptor: %s", strerror(errno));
+		}
+	}
 
-    if (size < 0) {
-        RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't read from source file descriptor: %s", strerror(errno));
-    }
+	if (size < 0) {
+		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't read from source file descriptor: %s",
+		    strerror(errno));
+	}
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 /*
@@ -379,8 +379,9 @@ mport_rmdir(const char *dir, int ignore_nonempty)
 		if (ignore_nonempty && (errno == ENOTEMPTY || errno == ENOENT)) {
 			return (MPORT_OK);
 		} else {
-			RETURN_ERRORX(
-			    MPORT_ERR_FATAL, "Couldn't rmdir %s: %s. With ZFS, this could indicate a snapshot is blocking removal.", dir, strerror(errno));
+			RETURN_ERRORX(MPORT_ERR_FATAL,
+			    "Couldn't rmdir %s: %s. With ZFS, this could indicate a snapshot is blocking removal.",
+			    dir, strerror(errno));
 		}
 	}
 
@@ -389,25 +390,29 @@ mport_rmdir(const char *dir, int ignore_nonempty)
 
 /**
  * @brief remove all flags from a directory rooted at root
- * 
- * @param root 
- * @param dir 
- * @return int 
+ *
+ * @param root
+ * @param dir
+ * @return int
  */
-int mport_removeflags(const char *root, const char *dir) {
+int
+mport_removeflags(const char *root, const char *dir)
+{
 	struct stat st;
 	int statresult;
-	
+
 	int rootfd = open(root, O_RDONLY | O_DIRECTORY);
 
 	if (mport_starts_with(root, dir)) {
 		statresult = lstat(dir, &st);
 	} else {
 		statresult = fstatat(rootfd, dir, &st, AT_SYMLINK_NOFOLLOW);
-	} 
+	}
 
 	if (statresult != -1) {
-		if (st.st_flags & (UF_IMMUTABLE | UF_APPEND | UF_NOUNLINK | SF_IMMUTABLE | SF_APPEND | SF_NOUNLINK)) {
+		if (st.st_flags &
+		    (UF_IMMUTABLE | UF_APPEND | UF_NOUNLINK | SF_IMMUTABLE | SF_APPEND |
+			SF_NOUNLINK)) {
 			/* Disable all flags*/
 			chflagsat(rootfd, dir, 0, AT_SYMLINK_NOFOLLOW);
 		}
@@ -419,8 +424,8 @@ int mport_removeflags(const char *root, const char *dir) {
 }
 
 /**
- * @brief register a new user shell 
- * 
+ * @brief register a new user shell
+ *
  * @param shell_file path to shell file
  * @return int MPORT_OK on success, MPORT_ERR_FATAL on failure
  */
@@ -447,35 +452,34 @@ mport_shell_unregister(const char *shell_file)
 	if (shell_file == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Shell to unregister is invalid.");
 
-	return mport_xsystem(NULL,
-	    "/usr/bin/grep -v %s %s > %s.bak && mv %s.bak %s",
-	    shell_file, _PATH_SHELLS, _PATH_SHELLS, _PATH_SHELLS, _PATH_SHELLS);
+	return mport_xsystem(NULL, "/usr/bin/grep -v %s %s > %s.bak && mv %s.bak %s", shell_file,
+	    _PATH_SHELLS, _PATH_SHELLS, _PATH_SHELLS, _PATH_SHELLS);
 }
 
 /**
  * @brief Remove a character from a string
- * 
- * @param str 
- * @param ch 
+ *
+ * @param str
+ * @param ch
  * @return char* (must be freed)
  */
-char * 
+char *
 mport_str_remove(const char *str, const char ch)
 {
 	size_t i;
 	size_t x;
 	size_t len;
 	char *output = NULL;
-	
+
 	if (str == NULL)
 		return NULL;
-	
+
 	len = strlen(str);
-	
+
 	output = calloc(len + 1, sizeof(char));
 	if (output == NULL)
 		return NULL;
-	
+
 	for (i = 0, x = 0; i <= len; i++) {
 		if (str[i] != ch) {
 			output[x] = str[i];
@@ -483,9 +487,9 @@ mport_str_remove(const char *str, const char ch)
 		}
 	}
 	output[len] = '\0';
-	
+
 	return (output);
-} 
+}
 
 /*
  * Quick test to see if a file exists.
@@ -527,7 +531,8 @@ mport_directory(const char *path)
 
 			char *lastSlash = strrchr(fullPath, '/');
 			if (lastSlash != NULL) {
-				*lastSlash = '\0'; // Null-terminate at the last slash to get the directory
+				*lastSlash =
+				    '\0'; // Null-terminate at the last slash to get the directory
 			}
 
 			return fullPath;
@@ -655,7 +660,8 @@ mport_exec_command(mportInstance *mport, const char *path, char *const argv[], b
 	if ((error = posix_spawn_file_actions_init(&action)) != 0) {
 		free(spawn_argv);
 		errno = error;
-		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't initialize spawn actions: %s", strerror(errno));
+		RETURN_ERRORX(
+		    MPORT_ERR_FATAL, "Couldn't initialize spawn actions: %s", strerror(errno));
 	}
 
 	if (quiet) {
@@ -663,16 +669,20 @@ mport_exec_command(mportInstance *mport, const char *path, char *const argv[], b
 		if (devnull < 0) {
 			posix_spawn_file_actions_destroy(&action);
 			free(spawn_argv);
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't open /dev/null: %s", strerror(errno));
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "Couldn't open /dev/null: %s", strerror(errno));
 		}
 
-		if ((error = posix_spawn_file_actions_adddup2(&action, devnull, STDOUT_FILENO)) != 0 ||
-		    (error = posix_spawn_file_actions_adddup2(&action, devnull, STDERR_FILENO)) != 0) {
+		if ((error = posix_spawn_file_actions_adddup2(&action, devnull, STDOUT_FILENO)) !=
+			0 ||
+		    (error = posix_spawn_file_actions_adddup2(&action, devnull, STDERR_FILENO)) !=
+			0) {
 			close(devnull);
 			posix_spawn_file_actions_destroy(&action);
 			free(spawn_argv);
 			errno = error;
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't redirect command output: %s", strerror(errno));
+			RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't redirect command output: %s",
+			    strerror(errno));
 		}
 	}
 
@@ -686,7 +696,8 @@ mport_exec_command(mportInstance *mport, const char *path, char *const argv[], b
 	if (error != 0) {
 		free(spawn_argv);
 		errno = error;
-		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't execute %s: %s", run_path, strerror(errno));
+		RETURN_ERRORX(
+		    MPORT_ERR_FATAL, "Couldn't execute %s: %s", run_path, strerror(errno));
 	}
 
 	while (waitpid(pid, &pstat, 0) == -1) {
@@ -875,7 +886,6 @@ mport_parselist_tll(char *opt, stringlist_t *list)
 	input = NULL;
 }
 
-
 /*
  * mport_run_asset_exec(fmt, cwd, last_file)
  *
@@ -991,107 +1001,108 @@ mport_free_vec(void *vec)
 	vec = NULL;
 }
 
-int 
+int
 mport_decompress_zstd(const char *input, const char *output)
 {
-    FILE *f;
-    FILE *fout;
-    size_t const buffInSize = ZSTD_DStreamInSize();
-    size_t const buffOutSize = ZSTD_DStreamOutSize();
-    void* const buffIn = malloc(buffInSize);
-    void* const buffOut = malloc(buffOutSize);
-    ZSTD_DStream* const dstream = ZSTD_createDStream();
-    size_t const initResult = ZSTD_initDStream(dstream);
+	FILE *f;
+	FILE *fout;
+	size_t const buffInSize = ZSTD_DStreamInSize();
+	size_t const buffOutSize = ZSTD_DStreamOutSize();
+	void *const buffIn = malloc(buffInSize);
+	void *const buffOut = malloc(buffOutSize);
+	ZSTD_DStream *const dstream = ZSTD_createDStream();
+	size_t const initResult = ZSTD_initDStream(dstream);
 
-    if (buffIn == NULL || buffOut == NULL || dstream == NULL) {
-        free(buffIn);
-        free(buffOut);
-        ZSTD_freeDStream(dstream);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
-    }
+	if (buffIn == NULL || buffOut == NULL || dstream == NULL) {
+		free(buffIn);
+		free(buffOut);
+		ZSTD_freeDStream(dstream);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
+	}
 
-    if (ZSTD_isError(initResult)) {
-        free(buffIn);
-        free(buffOut);
-        ZSTD_freeDStream(dstream);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Failed to initialize ZSTD decompression stream");
-    }
+	if (ZSTD_isError(initResult)) {
+		free(buffIn);
+		free(buffOut);
+		ZSTD_freeDStream(dstream);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Failed to initialize ZSTD decompression stream");
+	}
 
-    f = fopen(input, "rb");
-    if (!f) {
-        free(buffIn);
-        free(buffOut);
-        ZSTD_freeDStream(dstream);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't open zstd file for reading");
-    }
+	f = fopen(input, "rb");
+	if (!f) {
+		free(buffIn);
+		free(buffOut);
+		ZSTD_freeDStream(dstream);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't open zstd file for reading");
+	}
 
-    fout = fopen(output, "wb");
-    if (!fout) {
-        fclose(f);
-        free(buffIn);
-        free(buffOut);
-        ZSTD_freeDStream(dstream);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't open file for writing");
-    }
+	fout = fopen(output, "wb");
+	if (!fout) {
+		fclose(f);
+		free(buffIn);
+		free(buffOut);
+		ZSTD_freeDStream(dstream);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Couldn't open file for writing");
+	}
 
-    const char *outpath = output;
-    size_t toRead = buffInSize;
-    size_t result = 1;
-    while (1) {
-        size_t const read = fread(buffIn, 1, toRead, f);
-        if (read == 0) {
-            if (ferror(f) != 0) {
-                fclose(f);
-                fclose(fout);
-                free(buffIn);
-                free(buffOut);
-                ZSTD_freeDStream(dstream);
-                RETURN_ERROR(MPORT_ERR_FATAL, "Error reading zstd input file");
-            }
-            break;
-        }
+	const char *outpath = output;
+	size_t toRead = buffInSize;
+	size_t result = 1;
+	while (1) {
+		size_t const read = fread(buffIn, 1, toRead, f);
+		if (read == 0) {
+			if (ferror(f) != 0) {
+				fclose(f);
+				fclose(fout);
+				free(buffIn);
+				free(buffOut);
+				ZSTD_freeDStream(dstream);
+				RETURN_ERROR(MPORT_ERR_FATAL, "Error reading zstd input file");
+			}
+			break;
+		}
 
-        ZSTD_inBuffer input = { buffIn, read, 0 };
-        while (input.pos < input.size) {
-            ZSTD_outBuffer output = { buffOut, buffOutSize, 0 };
-            result = ZSTD_decompressStream(dstream, &output, &input);
-            if (ZSTD_isError(result)) {
-                fclose(f);
-                fclose(fout);
-                free(buffIn);
-                free(buffOut);
-                ZSTD_freeDStream(dstream);
-                RETURN_ERROR(MPORT_ERR_FATAL, "Error decompressing zstd file");
-            }
-            if (output.pos > 0 && fwrite(buffOut, 1, output.pos, fout) != output.pos) {
-                fclose(f);
-                fclose(fout);
-                unlink(outpath);
-                free(buffIn);
-                free(buffOut);
-                ZSTD_freeDStream(dstream);
-                RETURN_ERROR(MPORT_ERR_FATAL, "Error writing decompressed output file");
-            }
-        }
-    }
+		ZSTD_inBuffer input = { buffIn, read, 0 };
+		while (input.pos < input.size) {
+			ZSTD_outBuffer output = { buffOut, buffOutSize, 0 };
+			result = ZSTD_decompressStream(dstream, &output, &input);
+			if (ZSTD_isError(result)) {
+				fclose(f);
+				fclose(fout);
+				free(buffIn);
+				free(buffOut);
+				ZSTD_freeDStream(dstream);
+				RETURN_ERROR(MPORT_ERR_FATAL, "Error decompressing zstd file");
+			}
+			if (output.pos > 0 && fwrite(buffOut, 1, output.pos, fout) != output.pos) {
+				fclose(f);
+				fclose(fout);
+				unlink(outpath);
+				free(buffIn);
+				free(buffOut);
+				ZSTD_freeDStream(dstream);
+				RETURN_ERROR(
+				    MPORT_ERR_FATAL, "Error writing decompressed output file");
+			}
+		}
+	}
 
-    if (result != 0) {
-        fclose(f);
-        fclose(fout);
-        unlink(outpath);
-        free(buffIn);
-        free(buffOut);
-        ZSTD_freeDStream(dstream);
-        RETURN_ERROR(MPORT_ERR_FATAL, "Incomplete zstd stream");
-    }
+	if (result != 0) {
+		fclose(f);
+		fclose(fout);
+		unlink(outpath);
+		free(buffIn);
+		free(buffOut);
+		ZSTD_freeDStream(dstream);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Incomplete zstd stream");
+	}
 
-    fclose(f);
-    fclose(fout);
-    free(buffIn);
-    free(buffOut);
-    ZSTD_freeDStream(dstream);
+	fclose(f);
+	fclose(fout);
+	free(buffIn);
+	free(buffOut);
+	ZSTD_freeDStream(dstream);
 
-    return (MPORT_OK);
+	return (MPORT_OK);
 }
 
 MPORT_PUBLIC_API char *
@@ -1238,8 +1249,8 @@ mport_version(mportInstance *mport)
 {
 	char *version = NULL;
 	char *osrel = mport_get_osrelease(mport);
-	if (asprintf(&version, "mport %s for MidnightBSD %s, Bundle Version %s\n", MPORT_VERSION, osrel,
-	    MPORT_BUNDLE_VERSION_STR) == -1) {
+	if (asprintf(&version, "mport %s for MidnightBSD %s, Bundle Version %s\n", MPORT_VERSION,
+		osrel, MPORT_BUNDLE_VERSION_STR) == -1) {
 		free(osrel);
 		return NULL;
 	}
@@ -1305,16 +1316,19 @@ mport_drop_privileges(void)
  * @param packs mport package metadata
  * @return PURL URI or NULL
  */
-MPORT_PUBLIC_API char * 
-mport_purl_uri(mportPackageMeta *packs) 
+MPORT_PUBLIC_API char *
+mport_purl_uri(mportPackageMeta *packs)
 {
 	char *purl = NULL;
 
 	// https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst
-	//asprintf(&purl, "pkg:mport/midnightbsd/%s@%s?arch=%s&osrel=%s", (*indexEntry)->pkgname, (*packs)->version, MPORT_ARCH, os_release);
-	// the purl format requires registration.  i'm switching to generic and requested above from them.
-		
-	int ret = asprintf(&purl, "pkg:generic/%s@%s?arch=%s&distro=midnightbsd-%s", packs->name, packs->version, MPORT_ARCH, packs->os_release);
+	// asprintf(&purl, "pkg:mport/midnightbsd/%s@%s?arch=%s&osrel=%s", (*indexEntry)->pkgname,
+	// (*packs)->version, MPORT_ARCH, os_release);
+	// the purl format requires registration.  i'm switching to generic and requested above from
+	// them.
+
+	int ret = asprintf(&purl, "pkg:generic/%s@%s?arch=%s&distro=midnightbsd-%s", packs->name,
+	    packs->version, MPORT_ARCH, packs->os_release);
 	if (ret == -1) {
 		return NULL;
 	}
@@ -1323,21 +1337,21 @@ mport_purl_uri(mportPackageMeta *packs)
 }
 
 bool
-mport_check_answer_bool(char *ans) 
+mport_check_answer_bool(char *ans)
 {
 	if (ans == NULL)
-	    return (false);
+		return (false);
 
-	if (*ans == 'Y' || *ans == 'y' || *ans == 't' || *ans == 'T' || *ans == '1') 
+	if (*ans == 'Y' || *ans == 'y' || *ans == 't' || *ans == 'T' || *ans == '1')
 		return (true);
-	if (*ans == 'N' || *ans == 'n' || *ans == 'f' || *ans == 'F' || *ans == '0') 
+	if (*ans == 'N' || *ans == 'n' || *ans == 'f' || *ans == 'F' || *ans == '0')
 		return (false);
 
 	return (false);
 }
 
-MPORT_PUBLIC_API mportVerbosity 
-mport_verbosity(bool quiet, bool verbose, bool brief) 
+MPORT_PUBLIC_API mportVerbosity
+mport_verbosity(bool quiet, bool verbose, bool brief)
 {
 
 	/* if both are specified, we need quiet for backward compatibility */
@@ -1350,7 +1364,7 @@ mport_verbosity(bool quiet, bool verbose, bool brief)
 
 	if (verbose)
 		return (MPORT_VVERBOSE);
-		
+
 	return (MPORT_VNORMAL);
 }
 
@@ -1373,7 +1387,7 @@ mport_string_replace(const char *str, const char *old, const char *new)
 
 	ret = malloc(retlen + 1);
 	if (ret == NULL)
-	    return NULL;
+		return NULL;
 
 	for (r = ret, p = str; (q = strstr(p, old)) != NULL; p = q + oldlen) {
 		ptrdiff_t l = q - p;
@@ -1402,18 +1416,18 @@ mport_count_spaces(const char *str)
 	return (spaces);
 }
 
-/* 
+/*
  * A bit like strsep(), except it accounts for "double" and 'single' quotes.
- * Unlike strsep(), this function returns the next argument string, trimmed of 
- * whitespace or enclosing quotes, and updates **args to point at the character 
- * after that. 
- * 
+ * Unlike strsep(), this function returns the next argument string, trimmed of
+ * whitespace or enclosing quotes, and updates **args to point at the character
+ * after that.
+ *
  * Sets *args to NULL when it has been processed.
- * 
- * Quoted strings run from the first quote mark to the next one of 
- * the same type or the terminating NULL. Quoted strings can contain the other 
- * type of quote mark, which loses any special meaning. 
- * 
+ *
+ * Quoted strings run from the first quote mark to the next one of
+ * the same type or the terminating NULL. Quoted strings can contain the other
+ * type of quote mark, which loses any special meaning.
+ *
  * There is no escape character.
  */
 char *
@@ -1486,89 +1500,91 @@ finish:
 	return (p_start);
 }
 
-
-#define ELF_MAGIC "\x7F""ELF"
+#define ELF_MAGIC \
+	"\x7F"    \
+	"ELF"
 #define ELF_MAGIC_SIZE 4
 
-MPORT_PUBLIC_API bool 
-mport_is_elf_file(const char *file) 
+MPORT_PUBLIC_API bool
+mport_is_elf_file(const char *file)
 {
-    FILE *f = fopen(file, "rb");
-    if (f == NULL) {
-        perror("fopen");
-        return false;
-    }
+	FILE *f = fopen(file, "rb");
+	if (f == NULL) {
+		perror("fopen");
+		return false;
+	}
 
-    char magic[ELF_MAGIC_SIZE];
-    if (fread(magic, 1, ELF_MAGIC_SIZE, f) != ELF_MAGIC_SIZE) {
-        fclose(f);
-        return false;
-    }
+	char magic[ELF_MAGIC_SIZE];
+	if (fread(magic, 1, ELF_MAGIC_SIZE, f) != ELF_MAGIC_SIZE) {
+		fclose(f);
+		return false;
+	}
 
-    fclose(f);
+	fclose(f);
 
-    // Compare the magic number
-    return (memcmp(magic, ELF_MAGIC, ELF_MAGIC_SIZE) == 0);
+	// Compare the magic number
+	return (memcmp(magic, ELF_MAGIC, ELF_MAGIC_SIZE) == 0);
 }
 
-MPORT_PUBLIC_API bool 
-mport_is_statically_linked(const char *file) {
-    if (elf_version(EV_CURRENT) == EV_NONE) {
-        fprintf(stderr, "ELF library initialization failed: %s\n", elf_errmsg(-1));
-        return false;
-    }
+MPORT_PUBLIC_API bool
+mport_is_statically_linked(const char *file)
+{
+	if (elf_version(EV_CURRENT) == EV_NONE) {
+		fprintf(stderr, "ELF library initialization failed: %s\n", elf_errmsg(-1));
+		return false;
+	}
 
-    int fd = open(file, O_RDONLY);
-    if (fd < 0) {
-        perror("open");
-        return false;
-    }
+	int fd = open(file, O_RDONLY);
+	if (fd < 0) {
+		perror("open");
+		return false;
+	}
 
-    Elf *elf = elf_begin(fd, ELF_C_READ, NULL);
-    if (elf == NULL) {
-        fprintf(stderr, "elf_begin failed: %s\n", elf_errmsg(-1));
-        close(fd);
-        return false;
-    }
+	Elf *elf = elf_begin(fd, ELF_C_READ, NULL);
+	if (elf == NULL) {
+		fprintf(stderr, "elf_begin failed: %s\n", elf_errmsg(-1));
+		close(fd);
+		return false;
+	}
 
-    // Check if the file is an ELF file
-    if (elf_kind(elf) != ELF_K_ELF) {
-        fprintf(stderr, "%s is not an ELF file\n", file);
-        elf_end(elf);
-        close(fd);
-        return false;
-    }
+	// Check if the file is an ELF file
+	if (elf_kind(elf) != ELF_K_ELF) {
+		fprintf(stderr, "%s is not an ELF file\n", file);
+		elf_end(elf);
+		close(fd);
+		return false;
+	}
 
-    // Iterate through the sections to find the .dynamic section
-    size_t shstrndx;
-    if (elf_getshdrstrndx(elf, &shstrndx) != 0) {
-        fprintf(stderr, "elf_getshdrstrndx failed: %s\n", elf_errmsg(-1));
-        elf_end(elf);
-        close(fd);
-        return false;
-    }
+	// Iterate through the sections to find the .dynamic section
+	size_t shstrndx;
+	if (elf_getshdrstrndx(elf, &shstrndx) != 0) {
+		fprintf(stderr, "elf_getshdrstrndx failed: %s\n", elf_errmsg(-1));
+		elf_end(elf);
+		close(fd);
+		return false;
+	}
 
-    Elf_Scn *scn = NULL;
-    while ((scn = elf_nextscn(elf, scn)) != NULL) {
-        GElf_Shdr shdr;
-        if (gelf_getshdr(scn, &shdr) != &shdr) {
-            fprintf(stderr, "gelf_getshdr failed: %s\n", elf_errmsg(-1));
-            elf_end(elf);
-            close(fd);
-            return false;
-        }
+	Elf_Scn *scn = NULL;
+	while ((scn = elf_nextscn(elf, scn)) != NULL) {
+		GElf_Shdr shdr;
+		if (gelf_getshdr(scn, &shdr) != &shdr) {
+			fprintf(stderr, "gelf_getshdr failed: %s\n", elf_errmsg(-1));
+			elf_end(elf);
+			close(fd);
+			return false;
+		}
 
-        const char *section_name = elf_strptr(elf, shstrndx, shdr.sh_name);
-        if (section_name != NULL && strcmp(section_name, ".dynamic") == 0) {
-            // Found the .dynamic section, meaning the file is dynamically linked
-            elf_end(elf);
-            close(fd);
-            return false;
-        }
-    }
+		const char *section_name = elf_strptr(elf, shstrndx, shdr.sh_name);
+		if (section_name != NULL && strcmp(section_name, ".dynamic") == 0) {
+			// Found the .dynamic section, meaning the file is dynamically linked
+			elf_end(elf);
+			close(fd);
+			return false;
+		}
+	}
 
-    // If no .dynamic section is found, the file is statically linked
-    elf_end(elf);
-    close(fd);
-    return true;
+	// If no .dynamic section is found, the file is statically linked
+	elf_end(elf);
+	close(fd);
+	return true;
 }

--- a/libmport/verify.c
+++ b/libmport/verify.c
@@ -57,9 +57,10 @@ mport_verify_package(mportInstance *mport, mportPackageMeta *pack)
 	const char *data, *checksum;
 	struct stat st;
 	char hash[65];
-	
+
 	mport_call_msg_cb(mport, "Verifying %s-%s", pack->name, pack->version);
-	if (mport_db_prepare(mport->db, &stmt, "SELECT type,data,checksum FROM assets WHERE pkg=%Q", pack->name) != MPORT_OK) {
+	if (mport_db_prepare(mport->db, &stmt, "SELECT type,data,checksum FROM assets WHERE pkg=%Q",
+		pack->name) != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		RETURN_CURRENT_ERROR;
 	}
@@ -77,14 +78,15 @@ mport_verify_package(mportInstance *mport, mportPackageMeta *pack)
 			RETURN_CURRENT_ERROR;
 		}
 
-		type = (mportAssetListEntryType) sqlite3_column_int(stmt, 0);
+		type = (mportAssetListEntryType)sqlite3_column_int(stmt, 0);
 		data = sqlite3_column_text(stmt, 1);
 		checksum = sqlite3_column_text(stmt, 2);
 
 		char file[FILENAME_MAX];
 		/* XXX TMP */
 		if (data == NULL) {
-			/* XXX data is null when ASSET_CHMOD (mode) or similar commands are in plist */
+			/* XXX data is null when ASSET_CHMOD (mode) or similar commands are in plist
+			 */
 			snprintf(file, sizeof(file), "%s", mport->root);
 		} else if (*data == '/') {
 			/* we don't use mport->root because it's an absolute path like /var */
@@ -117,20 +119,21 @@ mport_verify_package(mportInstance *mport, mportPackageMeta *pack)
 					mport_call_msg_cb(
 					    mport, "Source checksum missing %s", file);
 				} else {
-                    size_t len = strlen(checksum);
-                    if (len < 34) {
-					    if (MD5File(file, hash) == NULL) {
-						    mport_call_msg_cb(mport, "Can't MD5 %s: %s", file,
-						        strerror(errno));
-                            continue;
-                        }
-                    } else {
-					    if (SHA256_File(file, hash) == NULL) {
-						    mport_call_msg_cb(mport, "Can't SHA256 %s: %s",
-						        file, strerror(errno));
-                            continue;
-                        }
-                    }
+					size_t len = strlen(checksum);
+					if (len < 34) {
+						if (MD5File(file, hash) == NULL) {
+							mport_call_msg_cb(mport, "Can't MD5 %s: %s",
+							    file, strerror(errno));
+							continue;
+						}
+					} else {
+						if (SHA256_File(file, hash) == NULL) {
+							mport_call_msg_cb(mport,
+							    "Can't SHA256 %s: %s", file,
+							    strerror(errno));
+							continue;
+						}
+					}
 
 					if (strcmp(hash, checksum) != 0)
 						mport_call_msg_cb(mport,
@@ -163,9 +166,8 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 	pid_t pid;
 	int error, pstat;
 
-	(void)snprintf(mtree_path, sizeof(mtree_path), "%s%s/%s-%s/%s",
-	    mport->root, MPORT_INST_INFRA_DIR, pack->name, pack->version,
-	    MPORT_MTREE_FILE);
+	(void)snprintf(mtree_path, sizeof(mtree_path), "%s%s/%s-%s/%s", mport->root,
+	    MPORT_INST_INFRA_DIR, pack->name, pack->version, MPORT_MTREE_FILE);
 
 	if (!mport_file_exists(mtree_path))
 		return;
@@ -180,8 +182,8 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 	if ((error = posix_spawn_file_actions_init(&action)) != 0) {
 		close(pipefd[0]);
 		close(pipefd[1]);
-		mport_call_msg_cb(mport, "mtree verify: posix_spawn_file_actions_init: %s",
-		    strerror(error));
+		mport_call_msg_cb(
+		    mport, "mtree verify: posix_spawn_file_actions_init: %s", strerror(error));
 		return;
 	}
 	if ((error = posix_spawn_file_actions_adddup2(&action, pipefd[1], STDOUT_FILENO)) != 0 ||
@@ -193,8 +195,7 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 		return;
 	}
 
-	char *const args[] = { MPORT_MTREE_BIN, "-f", mtree_path, "-d", "-e",
-	    "-p", prefix, NULL };
+	char *const args[] = { MPORT_MTREE_BIN, "-f", mtree_path, "-d", "-e", "-p", prefix, NULL };
 
 	error = posix_spawn(&pid, MPORT_MTREE_BIN, &action, NULL, args, environ);
 	posix_spawn_file_actions_destroy(&action);
@@ -214,8 +215,8 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 			if (len > 0 && line[len - 1] == '\n')
 				line[len - 1] = '\0';
 			if (line[0] != '\0')
-				mport_call_msg_cb(mport, "mtree %s-%s: %s",
-				    pack->name, pack->version, line);
+				mport_call_msg_cb(
+				    mport, "mtree %s-%s: %s", pack->name, pack->version, line);
 		}
 		fclose(fp);
 	} else {
@@ -228,15 +229,15 @@ verify_mtree(mportInstance *mport, mportPackageMeta *pack)
 	} while (wres == -1 && errno == EINTR);
 
 	if (wres == -1) {
-		mport_call_msg_cb(mport, "mtree %s-%s: waitpid failed: %s",
-		    pack->name, pack->version, strerror(errno));
+		mport_call_msg_cb(mport, "mtree %s-%s: waitpid failed: %s", pack->name,
+		    pack->version, strerror(errno));
 	} else if (WIFSIGNALED(pstat)) {
-		mport_call_msg_cb(mport, "mtree %s-%s: terminated by signal %d",
-		    pack->name, pack->version, WTERMSIG(pstat));
+		mport_call_msg_cb(mport, "mtree %s-%s: terminated by signal %d", pack->name,
+		    pack->version, WTERMSIG(pstat));
 	} else if (WIFEXITED(pstat) && WEXITSTATUS(pstat) > 1) {
 		/* exit 1 means discrepancies found (normal); >1 indicates a tool error */
-		mport_call_msg_cb(mport, "mtree %s-%s: exited with status %d",
-		    pack->name, pack->version, WEXITSTATUS(pstat));
+		mport_call_msg_cb(mport, "mtree %s-%s: exited with status %d", pack->name,
+		    pack->version, WEXITSTATUS(pstat));
 	}
 }
 
@@ -265,11 +266,11 @@ mport_recompute_checksums(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-    if (mport_db_do(mport->db, "BEGIN TRANSACTION") != MPORT_OK) {
+	if (mport_db_do(mport->db, "BEGIN TRANSACTION") != MPORT_OK) {
 		sqlite3_finalize(stmt);
 		sqlite3_finalize(update_stmt);
 		RETURN_CURRENT_ERROR;
-    }
+	}
 
 	while (1) {
 		ret = sqlite3_step(stmt);
@@ -280,7 +281,7 @@ mport_recompute_checksums(mportInstance *mport, mportPackageMeta *pack)
 		if (ret != SQLITE_ROW) {
 			/* some error occured */
 			SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
-            mport_db_do(mport->db, "ROLLBACK");
+			mport_db_do(mport->db, "ROLLBACK");
 			sqlite3_finalize(stmt);
 			sqlite3_finalize(update_stmt);
 			RETURN_CURRENT_ERROR;
@@ -327,7 +328,7 @@ mport_recompute_checksums(mportInstance *mport, mportPackageMeta *pack)
 					mport_call_msg_cb(
 					    mport, "Source checksum missing %s", file);
 				} else {
-                    size_t len = strlen(checksum);
+					size_t len = strlen(checksum);
 					if (len < 34) {
 						if (MD5File(file, hash) == NULL) {
 							mport_call_msg_cb(mport, "Can't MD5 %s: %s",
@@ -375,8 +376,8 @@ mport_recompute_checksums(mportInstance *mport, mportPackageMeta *pack)
 	sqlite3_finalize(stmt);
 	sqlite3_finalize(update_stmt);
 
-    if (mport_db_do(mport->db, "COMMIT") != MPORT_OK)
-        RETURN_CURRENT_ERROR;
+	if (mport_db_do(mport->db, "COMMIT") != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
 	return (MPORT_OK);
 }
@@ -396,32 +397,30 @@ mport_check_missing_depends(mportInstance *mport)
 	int ret;
 
 	if (mport_db_prepare(mport->db, &stmt,
-	    "SELECT d.pkg, d.depend_pkgname, d.depend_pkgversion "
-	    "FROM depends d "
-	    "WHERE EXISTS ("
-	    "  SELECT 1 FROM packages p WHERE p.pkg = d.pkg"
-	    ") "
-	    "AND NOT EXISTS ("
-	    "  SELECT 1 FROM packages p2 WHERE p2.pkg = d.depend_pkgname"
-	    ") "
-	    "ORDER BY d.pkg, d.depend_pkgname") != MPORT_OK) {
+		"SELECT d.pkg, d.depend_pkgname, d.depend_pkgversion "
+		"FROM depends d "
+		"WHERE EXISTS ("
+		"  SELECT 1 FROM packages p WHERE p.pkg = d.pkg"
+		") "
+		"AND NOT EXISTS ("
+		"  SELECT 1 FROM packages p2 WHERE p2.pkg = d.depend_pkgname"
+		") "
+		"ORDER BY d.pkg, d.depend_pkgname") != MPORT_OK) {
 		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
 		return (-1);
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		const char *pkg     = (const char *)sqlite3_column_text(stmt, 0);
-		const char *dep     = (const char *)sqlite3_column_text(stmt, 1);
-		const char *ver     = (const char *)sqlite3_column_text(stmt, 2);
+		const char *pkg = (const char *)sqlite3_column_text(stmt, 0);
+		const char *dep = (const char *)sqlite3_column_text(stmt, 1);
+		const char *ver = (const char *)sqlite3_column_text(stmt, 2);
 
 		if (ver != NULL && *ver != '\0') {
 			mport_call_msg_cb(mport,
-			    "Missing dependency: %s requires %s-%s (not installed)",
-			    pkg, dep, ver);
+			    "Missing dependency: %s requires %s-%s (not installed)", pkg, dep, ver);
 		} else {
-			mport_call_msg_cb(mport,
-			    "Missing dependency: %s requires %s (not installed)",
-			    pkg, dep);
+			mport_call_msg_cb(
+			    mport, "Missing dependency: %s requires %s (not installed)", pkg, dep);
 		}
 		missing++;
 	}

--- a/libmport/version_cmp.c
+++ b/libmport/version_cmp.c
@@ -57,7 +57,7 @@ mport_version_cmp(const char *astr, const char *bstr)
 	struct version a;
 	struct version b;
 	int result;
-  
+
 	if (parse_version(astr, &a) != MPORT_OK)
 		return 0;
 	if (parse_version(bstr, &b) != MPORT_OK)
@@ -79,34 +79,32 @@ mport_version_cmp(const char *astr, const char *bstr)
 	a.version = NULL;
 	free(b.version);
 	b.version = NULL;
-  
+
 	return (result);
 }
-
 
 /* version of mport_version_cmp() that is bound to the sqlite3 database. */
 void
 mport_version_cmp_sqlite(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
-    char *a = NULL;
+	char *a = NULL;
 	char *b = NULL;
 
-    assert(argc == 2);
+	assert(argc == 2);
 
-    a = strdup(sqlite3_value_text(argv[0]));
-    b = strdup(sqlite3_value_text(argv[1]));
+	a = strdup(sqlite3_value_text(argv[0]));
+	b = strdup(sqlite3_value_text(argv[1]));
 
-    assert(a != NULL);
-    assert(b != NULL);
+	assert(a != NULL);
+	assert(b != NULL);
 
-    sqlite3_result_int(context, mport_version_cmp(a, b));
+	sqlite3_result_int(context, mport_version_cmp(a, b));
 
-    free(a);
+	free(a);
 	a = NULL;
-    free(b);
+	free(b);
 	b = NULL;
-}  
-
+}
 
 /* Returns 0 if baseline meets the given requirement, -1 if the requirement
  * was not met, and a value greater than 0 on error.  some examples:
@@ -120,17 +118,17 @@ mport_version_cmp_sqlite(sqlite3_context *context, int argc, sqlite3_value **arg
 int
 mport_version_require_check(const char *baseline, const char *require)
 {
-    int ret = 0;
+	int ret = 0;
 
-    bool multi = false;
-    int greater[2] = {-1,-1} ;
-    int less[2] = {-1,-1};
-    int equal[2] = {-1,-1};
-    size_t version_size = strlen(require);
+	bool multi = false;
+	int greater[2] = { -1, -1 };
+	int less[2] = { -1, -1 };
+	int equal[2] = { -1, -1 };
+	size_t version_size = strlen(require);
 
-    if (version_size < 2) {
-    	return 1; // impossible to validate
-    }
+	if (version_size < 2) {
+		return 1; // impossible to validate
+	}
 
 	for (size_t i = 0; i < version_size; i++) {
 		if (require[i] == '>') {
@@ -155,7 +153,8 @@ mport_version_require_check(const char *baseline, const char *require)
 	}
 
 #ifdef DEBUG
-	printf(" g0 %d g1 %d l0 %d l1 %d eq0 %d\n", greater[0], greater[1], less[0], less[1], equal[0]);
+	printf(" g0 %d g1 %d l0 %d l1 %d eq0 %d\n", greater[0], greater[1], less[0], less[1],
+	    equal[0]);
 #endif
 
 	if (greater[0] == -1 && less[0] == -1 && equal[0] == -1) {
@@ -183,7 +182,8 @@ mport_version_require_check(const char *baseline, const char *require)
 				ret = (mport_version_cmp(baseline, &require[1]) > 0) ? 0 : -1;
 			}
 		} else {
-			RETURN_ERRORX(MPORT_ERR_FATAL, "Malformed version requirement: %s", require);
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "Malformed version requirement: %s", require);
 		}
 	} else {
 		char *s = strdup(require);
@@ -231,14 +231,16 @@ mport_version_require_check(const char *baseline, const char *require)
 			// second one is greater
 			s[greater[1]] = '\0';
 			if (s[greater[1] + 1] == '=') {
-				ret = (mport_version_cmp(baseline, &s[greater[1] + 2]) >= 0) ? 0 : -1;
+				ret =
+				    (mport_version_cmp(baseline, &s[greater[1] + 2]) >= 0) ? 0 : -1;
 				if (ret == -1) {
 					free(s);
 					s = NULL;
 					return (ret);
 				}
 			} else {
-				ret = (mport_version_cmp(baseline, &s[greater[1] + 1]) > 0) ? 0 : -1;
+				ret =
+				    (mport_version_cmp(baseline, &s[greater[1] + 1]) > 0) ? 0 : -1;
 				if (ret == -1) {
 					free(s);
 					s = NULL;
@@ -249,14 +251,16 @@ mport_version_require_check(const char *baseline, const char *require)
 			// second one is greater
 			s[greater[0]] = '\0';
 			if (s[greater[0] + 1] == '=') {
-				ret = (mport_version_cmp(baseline, &s[greater[0] + 2]) >= 0) ? 0 : -1;
+				ret =
+				    (mport_version_cmp(baseline, &s[greater[0] + 2]) >= 0) ? 0 : -1;
 				if (ret == -1) {
 					free(s);
 					s = NULL;
 					return (ret);
 				}
 			} else {
-				ret = (mport_version_cmp(baseline, &s[greater[0] + 1]) > 0) ? 0 : -1;
+				ret =
+				    (mport_version_cmp(baseline, &s[greater[0] + 1]) > 0) ? 0 : -1;
 				if (ret == -1) {
 					free(s);
 					s = NULL;
@@ -287,26 +291,27 @@ mport_version_require_check(const char *baseline, const char *require)
 		s = NULL;
 	}
 
-    return (ret);
+	return (ret);
 }
 
 static int
-parse_version(const char *in, struct version *v) 
+parse_version(const char *in, struct version *v)
 {
-    char *s = strdup(in);
-    char *underscore;
+	char *s = strdup(in);
+	char *underscore;
 
 	if (s == NULL)
 		return MPORT_ERR_FATAL;
 
-    char *comma;
-    // greater than and less than prevent multiversion strings from getting parsed incorrectly
-    // so 2.0<1.5 would just be 2.0. Ideally we need to catch this upstream and do the right check.
-    char *lessthan;
-    char *greaterthan;
+	char *comma;
+	// greater than and less than prevent multiversion strings from getting parsed incorrectly
+	// so 2.0<1.5 would just be 2.0. Ideally we need to catch this upstream and do the right
+	// check.
+	char *lessthan;
+	char *greaterthan;
 
-    underscore = rindex(s, '_');
-    comma = rindex(s, ',');
+	underscore = rindex(s, '_');
+	comma = rindex(s, ',');
 	lessthan = rindex(s, '<');
 	greaterthan = rindex(s, '>');
 
@@ -318,76 +323,76 @@ parse_version(const char *in, struct version *v)
 		*greaterthan = '\0';
 	}
 
-    if (comma == NULL) {
-        v->epoch = 0;
-    } else {
-        *comma = '\0';
-        v->epoch = (int) strtol(comma + 1, NULL, 10);
-    }
+	if (comma == NULL) {
+		v->epoch = 0;
+	} else {
+		*comma = '\0';
+		v->epoch = (int)strtol(comma + 1, NULL, 10);
+	}
 
-    if (underscore == NULL) {
-        v->revision = 0;
-    } else {
-        *underscore = '\0';
-        v->revision = (int) strtol(underscore + 1, NULL, 10);
-    }
+	if (underscore == NULL) {
+		v->revision = 0;
+	} else {
+		*underscore = '\0';
+		v->revision = (int)strtol(underscore + 1, NULL, 10);
+	}
 
-    v->version = s;
+	v->version = s;
 
 	return MPORT_OK;
 }
 
 static int
-cmp_ints(int a, int b) 
+cmp_ints(int a, int b)
 {
 
-    if (a == b)
-        return 0;
-    if (a < b)
-        return -1;
+	if (a == b)
+		return 0;
+	if (a < b)
+		return -1;
 
-    return 1;
+	return 1;
 }
 
 static int
 cmp_versions(char *a, char *b)
 {
-    int a_sub, b_sub, result = 0;
+	int a_sub, b_sub, result = 0;
 
-    while (*a || *b) {
-        if (*a) {
-            while (*a == '.' || *a == '+')
-                a++;
+	while (*a || *b) {
+		if (*a) {
+			while (*a == '.' || *a == '+')
+				a++;
 
-            if (isdigit(*a)) {
-                a_sub = (int) strtol(a, &a, 10);
-            } else {
-                a_sub = (int) *a;
-                a++;
-            }
-        } else {
-            a_sub = 0;
-        }
+			if (isdigit(*a)) {
+				a_sub = (int)strtol(a, &a, 10);
+			} else {
+				a_sub = (int)*a;
+				a++;
+			}
+		} else {
+			a_sub = 0;
+		}
 
-        if (*b) {
-            while (*b == '.' || *b == '+')
-                b++;
+		if (*b) {
+			while (*b == '.' || *b == '+')
+				b++;
 
-            if (isdigit(*b)) {
-                b_sub = (int) strtol(b, &b, 10);
-            } else {
-                b_sub = (int) *b;
-                b++;
-            }
-        } else {
-            b_sub = 0;
-        }
+			if (isdigit(*b)) {
+				b_sub = (int)strtol(b, &b, 10);
+			} else {
+				b_sub = (int)*b;
+				b++;
+			}
+		} else {
+			b_sub = 0;
+		}
 
-        result = cmp_ints(a_sub, b_sub);
+		result = cmp_ints(a_sub, b_sub);
 
-        if (result != 0)
-            break;
-    }
+		if (result != 0)
+			break;
+	}
 
-    return (result);
-}    
+	return (result);
+}

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -112,9 +112,9 @@ static int annotate_delete(/*@notnull@*/ mportInstance *mport,
 static int annotate_add(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageName,
     /*@notnull@*/ const char *tagName, /*@notnull@*/ const char *tagValue);
 
-
 static mportPackageMeta **
-sort_dependencies_topological(mportInstance *mport, mportPackageMeta **flat_packs, int package_count, bool reverse_edges)
+sort_dependencies_topological(
+    mportInstance *mport, mportPackageMeta **flat_packs, int package_count, bool reverse_edges)
 {
 	mportPackageMeta **sorted_packs = calloc((size_t)package_count, sizeof(mportPackageMeta *));
 	int *in_degree = calloc((size_t)package_count, sizeof(int));
@@ -135,10 +135,11 @@ sort_dependencies_topological(mportInstance *mport, mportPackageMeta **flat_pack
 	for (int i = 0; i < package_count; i++) {
 		mportPackageMeta **downdeps = NULL;
 		if (mport_pkgmeta_get_downdepends(mport, flat_packs[i], &downdeps) != MPORT_OK) {
-			warnx("Error getting dependencies for %s: %s", flat_packs[i]->name, mport_err_string());
+			warnx("Error getting dependencies for %s: %s", flat_packs[i]->name,
+			    mport_err_string());
 			goto error;
 		}
-		
+
 		if (downdeps != NULL) {
 			for (mportPackageMeta **d = downdeps; *d != NULL; d++) {
 				for (int j = 0; j < package_count; j++) {
@@ -159,7 +160,8 @@ sort_dependencies_topological(mportInstance *mport, mportPackageMeta **flat_pack
 						}
 
 						if (!duplicate) {
-							struct edge *new_edge = malloc(sizeof(struct edge));
+							struct edge *new_edge =
+							    malloc(sizeof(struct edge));
 							if (new_edge == NULL) {
 								warnx("Out of memory");
 								mport_pkgmeta_vec_free(downdeps);
@@ -188,7 +190,8 @@ sort_dependencies_topological(mportInstance *mport, mportPackageMeta **flat_pack
 		}
 
 		if (i == package_count) {
-			warnx("Dependency cycle detected among packages. Ordering may be sub-optimal.");
+			warnx(
+			    "Dependency cycle detected among packages. Ordering may be sub-optimal.");
 			for (i = 0; i < package_count; i++) {
 				if (!queued[i])
 					break;
@@ -251,7 +254,8 @@ updateMany(mportInstance *mport, int argc, char **argv)
 
 	if (argc > 1 && strchr(argv[1], '*') != NULL) {
 		char *pkg = mport_string_replace(argv[1], "*", "%");
-		if (mport_pkgmeta_search_master(mport, &results[0], "pkg like %Q", pkg) != MPORT_OK) {
+		if (mport_pkgmeta_search_master(mport, &results[0], "pkg like %Q", pkg) !=
+		    MPORT_OK) {
 			warnx("%s", mport_err_string());
 			free(pkg);
 			free(results);
@@ -317,7 +321,8 @@ updateMany(mportInstance *mport, int argc, char **argv)
 		package_count = flat_idx;
 	}
 
-	mportPackageMeta **sorted_packs = sort_dependencies_topological(mport, flat_packs, package_count, true);
+	mportPackageMeta **sorted_packs =
+	    sort_dependencies_topological(mport, flat_packs, package_count, true);
 	if (sorted_packs == NULL) {
 		resultCode = MPORT_ERR_FATAL;
 		free(flat_packs);
@@ -328,8 +333,8 @@ updateMany(mportInstance *mport, int argc, char **argv)
 		int tempResultCode = mport_update(mport, sorted_packs[i]->name);
 		if (tempResultCode != MPORT_OK) {
 			resultCode = tempResultCode;
-			mport_call_msg_cb(mport, "Error updating package %s: %s", sorted_packs[i]->name,
-			    mport_err_string());
+			mport_call_msg_cb(mport, "Error updating package %s: %s",
+			    sorted_packs[i]->name, mport_err_string());
 		}
 	}
 
@@ -588,8 +593,8 @@ main(int argc, char *argv[])
 			resultCode = mport_download(mport, NULL, true, false, &path);
 		} else {
 			for (i = 0; i < local_argc; i++) {
-				tempResultCode = mport_download(
-				    mport, local_argv[i], false, dflag == 1, &path);
+				tempResultCode =
+				    mport_download(mport, local_argv[i], false, dflag == 1, &path);
 				if (tempResultCode != 0) {
 					resultCode = tempResultCode;
 				} else if (path != NULL) {
@@ -855,8 +860,8 @@ main(int argc, char *argv[])
 			} else if (nmissing == 0) {
 				printf("All dependencies are satisfied.\n");
 			} else {
-				printf("%d missing dependenc%s found.\n",
-				    nmissing, nmissing == 1 ? "y" : "ies");
+				printf("%d missing dependenc%s found.\n", nmissing,
+				    nmissing == 1 ? "y" : "ies");
 				resultCode = MPORT_ERR_WARN;
 			}
 		}
@@ -1112,8 +1117,8 @@ search(/*@notnull@*/ mportInstance *mport, /*@null@*/ char **query)
 		if (mport_index_search_term(mport, &indexEntry, *query) == MPORT_OK &&
 		    indexEntry != NULL) {
 			for (mportIndexEntry **e = indexEntry; *e != NULL; e++) {
-				fprintf(stdout, "%s\t%s\t%s\n", (*e)->pkgname,
-				    (*e)->version, (*e)->comment);
+				fprintf(stdout, "%s\t%s\t%s\n", (*e)->pkgname, (*e)->version,
+				    (*e)->comment);
 			}
 		}
 		if (indexEntry != NULL) {
@@ -1268,7 +1273,8 @@ install(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *packageNam
 			}
 			const char *v = &d[loc + 1];
 			d[loc] = '\0'; /* hack off the version number */
-			mport_index_entry_free_vec(indexEntry); /* free the empty result from the full-name lookup */
+			mport_index_entry_free_vec(
+			    indexEntry); /* free the empty result from the full-name lookup */
 			indexEntry = lookupIndex(mport, d);
 			if (indexEntry == NULL || (*indexEntry) == NULL ||
 			    strcmp(v, (*indexEntry)->version) != 0) {
@@ -1549,7 +1555,8 @@ deleteMany(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *arg
 		package_count = flat_idx;
 	}
 
-	mportPackageMeta **sorted_packs = sort_dependencies_topological(mport, flat_packs, package_count, false);
+	mportPackageMeta **sorted_packs =
+	    sort_dependencies_topological(mport, flat_packs, package_count, false);
 	if (sorted_packs == NULL) {
 		resultCode = MPORT_ERR_FATAL;
 		free(flat_packs);
@@ -1906,8 +1913,7 @@ deleteAll(/*@notnull@*/ mportInstance *mport)
 			if (mport_pkgmeta_get_updepends(mport, *p, &depends) == MPORT_OK) {
 				if (depends == NULL) {
 					if (delete (mport, (*p)->name) != MPORT_OK) {
-						fprintf(
-						    stderr, "Error deleting %s\n", (*p)->name);
+						fprintf(stderr, "Error deleting %s\n", (*p)->name);
 						errors++;
 					}
 					total++;


### PR DESCRIPTION
## Summary
- Format tracked C source files with clang-format19.
- Leave headers and third-party external sources untouched.
- Keep the PR intentionally format-only to reduce conflicts in future feature PRs.

## Validation
- make
- kyua test -k tests/Kyuafile
- ./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh ran clang-format/cppcheck, but cppcheck reports pre-existing findings across the broad staged C set.
- ./skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh reports pre-existing Splint/preprocessor issues across the broad staged C set.