### PR TITLE
[codex] Allow delete to continue after rmdir warnings

### DIFF
--- a/libmport/delete_primative.c
+++ b/libmport/delete_primative.c
@@ -70,6 +70,7 @@ static int run_special_unexec(mportInstance *, mportPackageMeta *);
 static int run_pkg_deinstall(mportInstance *, mportPackageMeta *, const char *);
 static int delete_pkg_infra(mportInstance *, mportPackageMeta *);
 static int check_for_upwards_depends(mportInstance *, mportPackageMeta *);
+static void warn_ignored_rmdir_error(/*@notnull@*/ mportInstance *, /*@notnull@*/ const char *);
 static bool is_safe_to_delete_dir(mportInstance *, mportPackageMeta *, const char *);
 static bool is_system_dir(const char *path);
 
@@ -369,9 +370,7 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 			if (is_safe_to_delete_dir(mport, pack, file)) {
 				mport_removeflags(mport->root, file);
 				if (mport_rmdir(file, type == ASSET_DIRRMTRY ? 1 : 0) != MPORT_OK) {
-					mport_call_msg_cb(mport,
-					    "Could not remove directory '%s': %s", file,
-					    mport_err_string());
+					warn_ignored_rmdir_error(mport, file);
 				}
 			} else if (type != ASSET_DIRRMTRY) {
 				mport_call_msg_cb(
@@ -438,6 +437,16 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 	syslog(LOG_NOTICE, "%s-%s deinstalled", pack->name, pack->version);
 
 	return (MPORT_OK);
+}
+
+static void
+warn_ignored_rmdir_error(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *dir)
+{
+	const char *err_msg = mport_err_string();
+
+	mport_call_msg_cb(mport, "Could not remove directory '%s': %s", dir,
+	    err_msg != NULL ? err_msg : "unknown error");
+	mport_set_err(MPORT_OK, NULL);
 }
 
 static bool
@@ -640,8 +649,7 @@ run_special_unexec(mportInstance *mport, mportPackageMeta *pkg)
 			 * module, if it's not /boot/modules */
 			if (strcmp("/boot/modules", data) != 0 &&
 			    mport_rmdir(data, 1) != MPORT_OK) {
-				mport_call_msg_cb(mport, "Could not remove directory '%s': %s",
-				    data, mport_err_string());
+				warn_ignored_rmdir_error(mport, data);
 			}
 			break;
 		case ASSET_DESKTOP_FILE_UTILS:

--- a/tests/mport_libexec_test
+++ b/tests/mport_libexec_test
@@ -132,6 +132,36 @@ update_reports_bad_chroot_body()
 		"${MPORT_UPDATE}" -c "${PWD}/missing-root" old.mport new.mport
 }
 
+atf_test_case delete_ignores_missing_registered_dir
+delete_ignores_missing_registered_dir_head()
+{
+	atf_set "descr" "mport.delete unregisters a package when registered directories are already missing"
+	atf_set "require.user" "root"
+}
+delete_ignores_missing_registered_dir_body()
+{
+	mkdir -p root/var/db/mport root/usr/local/share/licenses
+
+	sqlite3 root/var/db/mport/master.db \
+		"CREATE TABLE packages (pkg text NOT NULL, version text NOT NULL, origin text NOT NULL, prefix text NOT NULL, lang text, options text, status text default 'dirty', comment text, os_release text NOT NULL default '1.0', cpe text, locked int NOT NULL default '0', deprecated text default '', expiration_date int64 NOT NULL default '0', no_provide_shlib int default '0', flavor text default '', automatic int default '0', install_date int64 NOT NULL default '0', type int NOT NULL default '0', flatsize int64 NOT NULL default '0');" \
+		"CREATE UNIQUE INDEX packages_pkg ON packages (pkg);" \
+		"CREATE TABLE depends (pkg text NOT NULL, depend_pkgname text NOT NULL, depend_pkgversion text, depend_port text NOT NULL);" \
+		"CREATE TABLE log (pkg text NOT NULL, version text NOT NULL, date int NOT NULL, msg text NOT NULL);" \
+		"CREATE TABLE assets (pkg text NOT NULL, type int NOT NULL, data text, checksum text, owner text, grp text, mode text);" \
+		"CREATE TABLE categories (pkg text NOT NULL, category text NOT NULL);" \
+		"CREATE TABLE conflicts (pkg text NOT NULL, conflict_pkg text NOT NULL, conflict_version text NOT NULL);" \
+		"CREATE TABLE annotation (pkg text NOT NULL, tag TEXT NOT NULL, val TEXT NOT NULL, PRIMARY KEY (pkg, tag));" \
+		"INSERT INTO packages (pkg, version, origin, prefix, lang, options, status, comment, os_release, cpe, locked, deprecated, expiration_date, no_provide_shlib, flavor, automatic, install_date, type, flatsize) VALUES ('gperf', '3.1', 'devel/gperf', '/usr/local', '', '', 'clean', '', '3.2', '', 0, '', 0, 0, '', 0, 0, 0, 682000);" \
+		"INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) VALUES ('gperf', 24, '/usr/local/share/licenses/gperf-3.1', NULL, NULL, NULL, NULL);"
+
+	atf_check -s exit:0 -o ignore -e empty \
+		"${MPORT_DELETE}" -c "${PWD}/root" -f -n gperf
+
+	atf_check -s exit:0 -o inline:"0\n" -e empty \
+		sqlite3 root/var/db/mport/master.db \
+		"SELECT count(*) FROM packages WHERE pkg='gperf';"
+}
+
 setup_fake_tree()
 {
 	mkdir -p root/usr/local/share/testpkg
@@ -172,4 +202,5 @@ atf_init_test_cases()
 	atf_add_test_case list_rejects_extra_args
 	atf_add_test_case init_reports_bad_chroot
 	atf_add_test_case update_reports_bad_chroot
+	atf_add_test_case delete_ignores_missing_registered_dir
 }


### PR DESCRIPTION
## Summary
- clear ignored directory-removal errors during package delete so DB unregister can continue
- reuse the warning path for best-effort KLD directory cleanup
- add an ATF regression covering a registered package directory that is already missing

## Root cause
The delete path logged non-critical rmdir failures but left the global mport error set. Later RETURN_CURRENT_ERROR checks could then report the stale rmdir error after the package files had already been removed, leaving the package registered but partially uninstalled.

## Validation
- make -C liblua
- make -C libmport
- make -C libexec/mport.delete
- kyua test -k tests/Kyuafile mport_libexec_test:delete_ignores_missing_registered_dir
- git diff --check

## Notes
Full mport_libexec_test was not clean in this checkout because several unrelated libexec helper binaries were not built; the new delete regression passed.

## Summary by Sourcery

Ensure package deletion can proceed after non-critical directory removal failures by clearing ignored rmdir errors and adding regression coverage.

Bug Fixes:
- Prevent stale rmdir errors from leaving packages partially uninstalled and still registered after deletion.

Enhancements:
- Centralize best-effort directory removal warnings through a helper that logs and clears ignored rmdir errors.

Tests:
- Add a regression test covering package deletion when the registered package directory has already been removed.