### PR TITLE
[codex] Fix update backup rollback handling

### DIFF
--- a/libmport/bundle_read_update_pkg.c
+++ b/libmport/bundle_read_update_pkg.c
@@ -38,6 +38,8 @@
 
 static int make_backup_bundle(mportInstance *, mportPackageMeta *, char *);
 static int install_backup_bundle(mportInstance *, char *);
+static int detach_update_stub_for_backup(
+    /*@notnull@*/ mportInstance *, /*@notnull@*/ mportBundleRead *);
 static int build_create_extras(mportInstance *, mportPackageMeta *, char *, mportCreateExtras **);
 static int build_create_extras_copy_metafiles(const mportPackageMeta *, mportCreateExtras *);
 static int build_create_extras_depends(mportInstance *, mportPackageMeta *, mportCreateExtras *);
@@ -63,8 +65,22 @@ mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, mpor
 	}
 
 	pkg->action = MPORT_ACTION_UPDATE;
-	if ((mport_delete_primative(mport, pkg, 1) != MPORT_OK) ||
-	    (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK)) {
+	if (mport_delete_primative(mport, pkg, 1) != MPORT_OK) {
+		int err = mport_err_code();
+
+		(void)mport_rmtree(tmpfile2);
+		return (err);
+	}
+
+	if (mport_bundle_read_install_pkg(mport, bundle, pkg) != MPORT_OK) {
+		if (detach_update_stub_for_backup(mport, bundle) != MPORT_OK) {
+			int err = mport_err_code();
+
+			mport_call_msg_cb(
+			    mport, "Error preparing to restore backup package %s", pkg->name);
+			(void)mport_rmtree(tmpfile2);
+			return (err);
+		}
 		if (install_backup_bundle(mport, tmpfile2) == MPORT_OK) {
 			(void)mport_rmtree(tmpfile2);
 		} else {
@@ -75,6 +91,21 @@ mport_bundle_read_update_pkg(mportInstance *mport, mportBundleRead *bundle, mpor
 
 	/* if we can't delete the tmpfile, just move on. */
 	(void)mport_rmtree(tmpfile2);
+
+	return (MPORT_OK);
+}
+
+static int
+detach_update_stub_for_backup(/*@notnull@*/ mportInstance *mport,
+    /*@notnull@*/ mportBundleRead *bundle)
+{
+	if (!bundle->stub_attached)
+		return (MPORT_OK);
+
+	if (mport_detach_stub_db(mport->db) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	bundle->stub_attached = 0;
 
 	return (MPORT_OK);
 }


### PR DESCRIPTION
## Summary
- stop update rollback from trying to restore a backup when deleting the existing package failed
- detach the update bundle stub before installing the backup package after a new-install failure
- mark the update bundle stub detached so final cleanup does not attempt a second DETACH

## Root cause
The update path used one combined failure branch for deleting the old package and installing the new package. If delete failed, backup restore could run while the old package was still registered, leading to an already-installed error. If new install failed, backup restore used the same SQLite stub alias as the outer update bundle; that could detach or replace the outer stub and make final cleanup report DETACH stub: no such database.

## Validation
- make -C libmport
- git diff --cached --check
- ./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh

## Notes
The ffmpeg4 gnutls failure looks like a separate dependency precondition failure before update rollback runs. Splint still fails before analysis on existing mport_private.h preprocessing issues.

## Summary by Sourcery

Improve update rollback handling when package installation fails to avoid conflicting database state and cleanup errors.

Bug Fixes:
- Abort update rollback without restoring the backup if deletion of the existing package fails.
- Detach the update bundle stub before restoring the backup package after a failed new install to prevent stub conflicts and double-detach errors.