### PR TITLE
🧹 Fix redundant null check and possible null dereference in libmport

### DIFF
--- a/libmport/check_preconditions.c
+++ b/libmport/check_preconditions.c
@@ -93,7 +93,7 @@ check_if_moved(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (movedEntries == NULL || *movedEntries != NULL) {
+	if (movedEntries == NULL || *movedEntries == NULL) {
 		return MPORT_OK;
 	}
 
@@ -119,7 +119,7 @@ check_if_deprecated(mportInstance *mport, mportPackageMeta *pack)
 		RETURN_CURRENT_ERROR;
 	}
 
-	if (movedEntries == NULL || *movedEntries != NULL) {
+	if (movedEntries == NULL || *movedEntries == NULL) {
 		return MPORT_OK;
 	}
 


### PR DESCRIPTION
🎯 **What:** Fixed redundant null check and a guaranteed null pointer dereference in `check_if_moved` and `check_if_deprecated` functions in `libmport/check_preconditions.c`.
💡 **Why:** The code was checking `if (movedEntries == NULL || *movedEntries != NULL) return MPORT_OK;` which means it would return early when entries actually existed and proceed only if `*movedEntries` was `NULL`. Proceeding with a `NULL` pointer then caused a crash when attempting to access `(*movedEntries)->date[0]`. By changing the condition to `*movedEntries == NULL`, the functions now correctly return early when there are no entries and safely process valid entries, preventing crashes.
✅ **Verification:** Verified the code compiles correctly and requested code review which evaluated the fix as safe and fully correct.
✨ **Result:** Prevented crashes in package precondition checks, improving the safety and stability of the codebase without changing the expected behavior.

---
*PR created automatically by Jules for task [17808107971985731458](https://jules.google.com/task/17808107971985731458) started by @laffer1*

## Summary by Sourcery

Bug Fixes:
- Correct precondition checks in check_if_moved and check_if_deprecated to return early when movedEntries is null, preventing null pointer dereferences.