### PR TITLE
🧪 [test] Add test coverage for mport_get_osrelease

### DIFF
--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -6,3 +6,4 @@ atf_test_program{name="mport_create_test", }
 atf_test_program{name="mport_libexec_test", }
 atf_test_program{name="mport_cli_test", }
 atf_test_program{name="mport_fetch_test", }
+atf_test_program{name="mport_osrelease_test", }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,12 +2,20 @@ PACKAGE=	mport
 TESTSDIR=	${TESTSBASE}/mport
 KYUAFILE=	no
 
-ATF_TESTS_C+=	mport_fetch_test
+ATF_TESTS_C+=	mport_fetch_test \
+		mport_osrelease_test
+
 LDFLAGS.mport_fetch_test+=	-L${.CURDIR}/../libmport \
 				-L${LOCALBASE}/lib \
 				-Wl,-rpath,${.CURDIR}/../libmport \
 				-Wl,-rpath,${LOCALBASE}/lib
 LDADD.mport_fetch_test+=	-lmport -latf-c
+
+LDFLAGS.mport_osrelease_test+=	-L${.CURDIR}/../libmport \
+				-L${LOCALBASE}/lib \
+				-Wl,-rpath,${.CURDIR}/../libmport \
+				-Wl,-rpath,${LOCALBASE}/lib
+LDADD.mport_osrelease_test+=	-lmport -latf-c
 
 mportFILES=	Kyuafile \
 		mport_create_test \

--- a/tests/mport_osrelease_test.c
+++ b/tests/mport_osrelease_test.c
@@ -1,0 +1,104 @@
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include <atf-c.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../libmport/mport.h"
+#include "../libmport/mport_private.h"
+
+ATF_TC_WITH_CLEANUP(osrelease_from_settings);
+ATF_TC_HEAD(osrelease_from_settings, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mport_get_osrelease honors MPORT_SETTING_TARGET_OS");
+}
+ATF_TC_BODY(osrelease_from_settings, tc)
+{
+	mportInstance *mport;
+	char *version;
+
+	mport = mport_instance_new();
+	ATF_REQUIRE(mport != NULL);
+	ATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, false));
+
+	ATF_REQUIRE_EQ(MPORT_OK, mport_setting_set(mport, MPORT_SETTING_TARGET_OS, "9.9-TEST"));
+
+	version = mport_get_osrelease(mport);
+	ATF_REQUIRE(version != NULL);
+	ATF_REQUIRE_STREQ("9.9-TEST", version);
+
+	free(version);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(osrelease_from_settings, tc)
+{
+	(void)tc;
+}
+
+ATF_TC_WITH_CLEANUP(osrelease_null_instance);
+ATF_TC_HEAD(osrelease_null_instance, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_get_osrelease handles NULL instance (falls back to system tools)");
+}
+ATF_TC_BODY(osrelease_null_instance, tc)
+{
+	char *version;
+
+	/* On a real MidnightBSD system this will return the OS release,
+	 * on Linux/others it might return NULL.
+	 * We just ensure it doesn't crash.
+	 */
+	version = mport_get_osrelease(NULL);
+	if (version != NULL) {
+		free(version);
+	}
+}
+ATF_TC_CLEANUP(osrelease_null_instance, tc)
+{
+	(void)tc;
+}
+
+ATF_TC_WITH_CLEANUP(osrelease_settings_null);
+ATF_TC_HEAD(osrelease_settings_null, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_get_osrelease handles missing MPORT_SETTING_TARGET_OS");
+}
+ATF_TC_BODY(osrelease_settings_null, tc)
+{
+	mportInstance *mport;
+	char *version;
+
+	mport = mport_instance_new();
+	ATF_REQUIRE(mport != NULL);
+	ATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, false));
+
+	// make sure the setting does not exist or we clear it
+	mport_db_do(mport->db, "DELETE FROM settings WHERE name=%Q", MPORT_SETTING_TARGET_OS);
+
+	version = mport_get_osrelease(mport);
+	// this shouldn't crash, and will try system methods
+	if (version != NULL) {
+		free(version);
+	}
+
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(osrelease_settings_null, tc)
+{
+	(void)tc;
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, osrelease_from_settings);
+	ATF_TP_ADD_TC(tp, osrelease_null_instance);
+	ATF_TP_ADD_TC(tp, osrelease_settings_null);
+
+	return atf_no_error();
+}

--- a/tests/mport_osrelease_test.c
+++ b/tests/mport_osrelease_test.c
@@ -23,7 +23,7 @@ ATF_TC_BODY(osrelease_from_settings, tc)
 
 	mport = mport_instance_new();
 	ATF_REQUIRE(mport != NULL);
-	ATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, false));
+\tATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, MPORT_VQUIET));
 
 	ATF_REQUIRE_EQ(MPORT_OK, mport_setting_set(mport, MPORT_SETTING_TARGET_OS, "9.9-TEST"));
 

--- a/tests/mport_osrelease_test.c
+++ b/tests/mport_osrelease_test.c
@@ -76,7 +76,7 @@ ATF_TC_BODY(osrelease_settings_null, tc)
 
 	mport = mport_instance_new();
 	ATF_REQUIRE(mport != NULL);
-	ATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, false));
+\tATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, MPORT_VQUIET));
 
 	// make sure the setting does not exist or we clear it
 	mport_db_do(mport->db, "DELETE FROM settings WHERE name=%Q", MPORT_SETTING_TARGET_OS);

--- a/tests/mport_osrelease_test.c
+++ b/tests/mport_osrelease_test.c
@@ -79,7 +79,7 @@ ATF_TC_BODY(osrelease_settings_null, tc)
 \tATF_REQUIRE_EQ(MPORT_OK, mport_instance_init(mport, NULL, "root", false, MPORT_VQUIET));
 
 	// make sure the setting does not exist or we clear it
-	mport_db_do(mport->db, "DELETE FROM settings WHERE name=%Q", MPORT_SETTING_TARGET_OS);
+\tATF_REQUIRE_EQ(MPORT_OK, mport_db_do(mport->db, "DELETE FROM settings WHERE name=%Q", MPORT_SETTING_TARGET_OS));
 
 	version = mport_get_osrelease(mport);
 	// this shouldn't crash, and will try system methods


### PR DESCRIPTION
🎯 **What:** Added tests to cover the untested `mport_get_osrelease` function.
📊 **Coverage:** Added coverage for:
- When an `mportInstance` exists and has `MPORT_SETTING_TARGET_OS` configured.
- When an `mportInstance` is passed as `NULL`.
- When an `mportInstance` exists but the `MPORT_SETTING_TARGET_OS` setting is missing.
✨ **Result:** Improved overall codebase reliability by providing automated verifications for `mport_get_osrelease` behavior across happy paths and error/fallback edge cases.

---
*PR created automatically by Jules for task [8053533075184245001](https://jules.google.com/task/8053533075184245001) started by @laffer1*

## Summary by Sourcery

Add automated tests to cover mport_get_osrelease behavior under various configuration scenarios.

Tests:
- Add a new mport_osrelease_test covering target OS from settings, NULL instance handling, and missing target OS settings.
- Register the new osrelease test in the tests Makefile and test suite configuration so it is built and executed.