### PR TITLE
🧪 test: Add unit tests for mport_mkdir function

### DIFF
--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -6,3 +6,4 @@ atf_test_program{name="mport_create_test", }
 atf_test_program{name="mport_libexec_test", }
 atf_test_program{name="mport_cli_test", }
 atf_test_program{name="mport_fetch_test", }
+atf_test_program{name="mport_util_test", }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,12 +2,18 @@ PACKAGE=	mport
 TESTSDIR=	${TESTSBASE}/mport
 KYUAFILE=	no
 
-ATF_TESTS_C+=	mport_fetch_test
+ATF_TESTS_C+=	mport_fetch_test mport_util_test
 LDFLAGS.mport_fetch_test+=	-L${.CURDIR}/../libmport \
 				-L${LOCALBASE}/lib \
 				-Wl,-rpath,${.CURDIR}/../libmport \
 				-Wl,-rpath,${LOCALBASE}/lib
 LDADD.mport_fetch_test+=	-lmport -latf-c
+
+LDFLAGS.mport_util_test+=	-L${.CURDIR}/../libmport \
+				-L${LOCALBASE}/lib \
+				-Wl,-rpath,${.CURDIR}/../libmport \
+				-Wl,-rpath,${LOCALBASE}/lib
+LDADD.mport_util_test+=	-lmport -latf-c
 
 mportFILES=	Kyuafile \
 		mport_create_test \

--- a/tests/mport_util_test.c
+++ b/tests/mport_util_test.c
@@ -1,0 +1,90 @@
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include <atf-c.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "../libmport/mport.h"
+#include "../libmport/mport_private.h"
+
+#define TEST_DIR "test_mport_mkdir_dir"
+
+ATF_TC_WITH_CLEANUP(mport_mkdir_success);
+ATF_TC_HEAD(mport_mkdir_success, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test mport_mkdir creates a directory successfully with mode 755");
+}
+ATF_TC_BODY(mport_mkdir_success, tc)
+{
+	struct stat sb;
+	mode_t old_umask;
+
+	(void)tc;
+
+	/* Ensure the directory does not exist before starting */
+	(void)rmdir(TEST_DIR);
+
+	/* Set a known umask to verify permissions accurately */
+	old_umask = umask(0022);
+
+	/* Call mport_mkdir */
+	ATF_REQUIRE_EQ(MPORT_OK, mport_mkdir(TEST_DIR));
+
+	/* Verify the directory was created */
+	ATF_REQUIRE_EQ(0, stat(TEST_DIR, &sb));
+
+	/* Verify the directory is actually a directory */
+	ATF_REQUIRE(S_ISDIR(sb.st_mode));
+
+	/* Verify the mode is 755 - umask(022) = 755 */
+	ATF_REQUIRE_EQ(0755, sb.st_mode & 0777);
+
+	/* Restore umask */
+	umask(old_umask);
+}
+ATF_TC_CLEANUP(mport_mkdir_success, tc)
+{
+	(void)tc;
+	(void)rmdir(TEST_DIR);
+}
+
+ATF_TC_WITH_CLEANUP(mport_mkdir_existing);
+ATF_TC_HEAD(mport_mkdir_existing, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test mport_mkdir returns MPORT_OK if directory already exists");
+}
+ATF_TC_BODY(mport_mkdir_existing, tc)
+{
+	struct stat sb;
+
+	(void)tc;
+
+	/* Ensure directory doesn't exist, then create it */
+	(void)rmdir(TEST_DIR);
+	ATF_REQUIRE_EQ(0, mkdir(TEST_DIR, 0755));
+
+	/* Call mport_mkdir on the existing directory */
+	ATF_REQUIRE_EQ(MPORT_OK, mport_mkdir(TEST_DIR));
+
+	/* Verify it still exists */
+	ATF_REQUIRE_EQ(0, stat(TEST_DIR, &sb));
+	ATF_REQUIRE(S_ISDIR(sb.st_mode));
+}
+ATF_TC_CLEANUP(mport_mkdir_existing, tc)
+{
+	(void)tc;
+	(void)rmdir(TEST_DIR);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, mport_mkdir_success);
+	ATF_TP_ADD_TC(tp, mport_mkdir_existing);
+
+	return atf_no_error();
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `mport_mkdir` function within `libmport/util.c` lacked test coverage, which left its behavior—specifically creating directories with specific permissions and handling already-existing directories—unverified. 

📊 **Coverage:** What scenarios are now tested
- Creating a completely new directory, validating that it correctly sets permissions according to mode 755 (and the active umask).
- Creating a directory that already exists, ensuring it handles the `EEXIST` errno and returns `MPORT_OK`.

✨ **Result:** The improvement in test coverage
The codebase now includes an ATF test suite in `tests/mport_util_test.c` for utility functions like `mport_mkdir`. The new test file has been hooked into the test build process (`Makefile` and `Kyuafile`). This ensures `mport_mkdir` is continuously regression-tested going forward.

---
*PR created automatically by Jules for task [10888687137324270073](https://jules.google.com/task/10888687137324270073) started by @laffer1*

## Summary by Sourcery

Add automated tests for the mport_mkdir utility function and integrate them into the test suite.

Tests:
- Introduce an ATF-based test case verifying mport_mkdir creates a new directory with the expected permissions under a known umask.
- Introduce an ATF-based test case verifying mport_mkdir returns success when the target directory already exists.
- Register the new mport_util_test binary in the tests Makefile and configure its linkage against libmport and atf-c.