### PR TITLE
🧪 Add coverage for mport_is_elf_file

### DIFF
--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -6,3 +6,4 @@ atf_test_program{name="mport_create_test", }
 atf_test_program{name="mport_libexec_test", }
 atf_test_program{name="mport_cli_test", }
 atf_test_program{name="mport_fetch_test", }
+atf_test_program{name="mport_util_test", }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,12 +2,18 @@ PACKAGE=	mport
 TESTSDIR=	${TESTSBASE}/mport
 KYUAFILE=	no
 
-ATF_TESTS_C+=	mport_fetch_test
+ATF_TESTS_C+=	mport_fetch_test \
+		mport_util_test
 LDFLAGS.mport_fetch_test+=	-L${.CURDIR}/../libmport \
 				-L${LOCALBASE}/lib \
 				-Wl,-rpath,${.CURDIR}/../libmport \
 				-Wl,-rpath,${LOCALBASE}/lib
 LDADD.mport_fetch_test+=	-lmport -latf-c
+LDFLAGS.mport_util_test+=	-L${.CURDIR}/../libmport \
+				-L${LOCALBASE}/lib \
+				-Wl,-rpath,${.CURDIR}/../libmport \
+				-Wl,-rpath,${LOCALBASE}/lib
+LDADD.mport_util_test+=		-lmport -latf-c
 
 mportFILES=	Kyuafile \
 		mport_create_test \

--- a/tests/mport_util_test.c
+++ b/tests/mport_util_test.c
@@ -1,0 +1,108 @@
+#include <sys/cdefs.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+
+#include <atf-c.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "../libmport/mport.h"
+
+/* Splint does not understand ATF's generated test-case wrappers. */
+/*@-boundsread -boundswrite -compdef -compdestroy -dependenttrans -fullinitblock@*/
+/*@-mustfreefresh -noeffect -nullderef -nullpass -nullret -nullstate@*/
+/*@-retvalint -retvalother -type -unrecog@*/
+
+static void
+create_file(const char *filename, const void *data, size_t len)
+{
+	FILE *f = fopen(filename, "wb");
+	ATF_REQUIRE(f != NULL);
+	if (len > 0) {
+		ATF_REQUIRE_EQ(len, fwrite(data, 1, len, f));
+	}
+	fclose(f);
+}
+
+ATF_TC_WITH_CLEANUP(is_elf_file_true);
+ATF_TC_HEAD(is_elf_file_true, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mport_is_elf_file returns true for an ELF file");
+}
+ATF_TC_BODY(is_elf_file_true, tc)
+{
+	const char *filename = "test_elf_file";
+	const char magic[] = "\x7F"
+			     "ELF"
+			     "some other data";
+	create_file(filename, magic, sizeof(magic) - 1); // exclude null terminator
+
+	ATF_CHECK(mport_is_elf_file(filename));
+}
+ATF_TC_CLEANUP(is_elf_file_true, tc)
+{
+	unlink("test_elf_file");
+}
+
+ATF_TC_WITH_CLEANUP(is_elf_file_false_text);
+ATF_TC_HEAD(is_elf_file_false_text, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mport_is_elf_file returns false for a plain text file");
+}
+ATF_TC_BODY(is_elf_file_false_text, tc)
+{
+	const char *filename = "test_text_file.txt";
+	const char content[] = "Hello World!";
+	create_file(filename, content, sizeof(content) - 1);
+
+	ATF_CHECK(!mport_is_elf_file(filename));
+}
+ATF_TC_CLEANUP(is_elf_file_false_text, tc)
+{
+	unlink("test_text_file.txt");
+}
+
+ATF_TC_WITH_CLEANUP(is_elf_file_false_small);
+ATF_TC_HEAD(is_elf_file_false_small, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_is_elf_file returns false for a file smaller than ELF magic");
+}
+ATF_TC_BODY(is_elf_file_false_small, tc)
+{
+	const char *filename = "test_small_file";
+	const char content[] = "ELF"; // Only 3 bytes
+	create_file(filename, content, sizeof(content) - 1);
+
+	ATF_CHECK(!mport_is_elf_file(filename));
+}
+ATF_TC_CLEANUP(is_elf_file_false_small, tc)
+{
+	unlink("test_small_file");
+}
+
+ATF_TC_WITH_CLEANUP(is_elf_file_false_missing);
+ATF_TC_HEAD(is_elf_file_false_missing, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mport_is_elf_file returns false for a missing file");
+}
+ATF_TC_BODY(is_elf_file_false_missing, tc)
+{
+	ATF_CHECK(!mport_is_elf_file("nonexistent_file_that_should_not_exist"));
+}
+ATF_TC_CLEANUP(is_elf_file_false_missing, tc)
+{
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, is_elf_file_true);
+	ATF_TP_ADD_TC(tp, is_elf_file_false_text);
+	ATF_TP_ADD_TC(tp, is_elf_file_false_small);
+	ATF_TP_ADD_TC(tp, is_elf_file_false_missing);
+
+	return atf_no_error();
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the untested `mport_is_elf_file` function in `libmport/util.c`. I have added a new test suite file `tests/mport_util_test.c` specifically for testing utilities.
📊 **Coverage:** I have added coverage for:
- Detecting an actual ELF file (by mocking an ELF magic number payload).
- Correctly identifying a text file is not an ELF file.
- Correctly detecting that a file smaller than the 4-byte ELF magic is not an ELF file.
- Correctly returning false when the file does not exist.
✨ **Result:** Test suite reliability has increased by validating the utility function detects the magic signature effectively, covering all common edge cases.

---
*PR created automatically by Jules for task [4343989290548358675](https://jules.google.com/task/4343989290548358675) started by @laffer1*

## Summary by Sourcery

Add a new test suite for validating ELF file detection utilities and integrate it into the test harness.

Tests:
- Introduce mport_util_test to cover mport_is_elf_file for valid ELF files, non-ELF text files, too-small files, and missing files.
- Register the new mport_util_test binary in the tests Makefile so it is built and run with the existing test suite.