### PR TITLE
[codex] add mport query command

### DIFF
--- a/MPORT_QUERY_SPEC.md
+++ b/MPORT_QUERY_SPEC.md
@@ -1,0 +1,74 @@
+# mport query specification
+
+`mport query` prints installed package metadata using a FreeBSD `pkg query` style
+format string. The command is backed by reusable `libmport` query helpers so
+other mport tools can share the same matching, filtering, and formatting logic.
+
+## Command forms
+
+- `mport query <format>` prints all installed packages.
+- `mport query -a <format>` explicitly prints all installed packages.
+- `mport query <format> <pkg-name> ...` prints exact package-name matches.
+- `mport query [-Cgix] <format> <pattern> ...` selects case-sensitive,
+  glob, case-insensitive, or regular-expression matching.
+- `mport query -e <expression> <format> [pattern ...]` filters matched
+  packages with a simple expression.
+
+`-F <pkg-file>` is intentionally deferred. v1 only queries the installed package
+database.
+
+## Supported format fields
+
+Scalar fields:
+
+- `%n`: package name
+- `%v`: installed version
+- `%o`: origin
+- `%p`: prefix
+- `%m`: maintainer annotation
+- `%c`: comment
+- `%e`: description, when available
+- `%w`: WWW annotation
+- `%a`: automatic flag, `1` or `0`
+- `%k`: locked flag, `1` or `0`
+- `%t`: install timestamp
+- `%s` or `%sb`: flat size in bytes
+- `%sh` or `%h`: human-readable flat size
+- `%M`: installed package message
+- `%X`: index hash, when an index is loaded
+- `%l`: license metadata, when an index is loaded
+- `%q`: target architecture
+- `%P`: package URL
+
+List fields are printed as comma-separated values:
+
+- `%A`: annotations as `tag=value`
+- `%C`: categories
+- `%D`: registered directories
+- `%F`: registered files
+- `%L`: licenses split from license metadata
+- `%O`: options split from the stored options metadata
+- `%d`: dependencies
+- `%r`: reverse dependencies
+
+`%#<list>` prints a supported list count and `%?<list>` prints `1` when the list
+is present or `0` when it is empty. Unknown format codes are errors.
+
+## Expressions
+
+The v1 expression engine supports scalar checks over the same scalar format
+fields:
+
+- truth checks, such as `%k`
+- equality and inequality with `=` and `!=`
+- glob matching with `~`
+- version comparisons with `<`, `<=`, `>`, and `>=`
+- boolean `&&`, `||`, and leading `!`
+
+Parentheses and package-file expressions are not part of v1.
+
+## Compatibility notes
+
+The implementation intentionally keeps the existing `libexec/mport.query`
+predicate interface unchanged. Unsupported FreeBSD `pkg query` features should
+be documented instead of silently producing misleading output.

--- a/libmport/Makefile
+++ b/libmport/Makefile
@@ -10,7 +10,7 @@ SRCS=	asset.c bundle_write.c bundle_read.c plist.c color.c create_primative.c db
     	fetch.c index.c index_depends.c install.c clean.c setting.c  \
    		stats.c update.c upgrade.c verify.c lock.c mkdir.c import_export.c \
    		annotation.c autoremove.c audit.c ping.c message.c service.c list.c \
-		lua.c lua_scripts.c age.c
+		query.c lua.c lua_scripts.c age.c
 INCS=	mport.h
 
 CFLAGS+=	-I${.CURDIR} -I ../external/tllist/ -I ../external/lua/src/ -I/usr/include/private/ucl -I/usr/include/ucl -I/usr/include/private/zstd

--- a/libmport/mport.3
+++ b/libmport/mport.3
@@ -100,6 +100,14 @@
 .Ft int
 .Fn mport_pkgmeta_get_updepends "mportInstance *mport" "mportPackageMeta *pkg" "mportPackageMeta ***vec"
 .Ft int
+.Fn mport_query_installed "mportInstance *mport" "const mportQueryOptions *opts" "mportPackageMeta ***vec"
+.Ft int
+.Fn mport_query_format_package "mportInstance *mport" "mportPackageMeta *pkg" "const char *format" "FILE *fp"
+.Ft int
+.Fn mport_query_print "mportInstance *mport" "mportPackageMeta **vec" "const char *format" "FILE *fp"
+.Ft char *
+.Fn mport_query_pkg_message "mportInstance *mport" "mportPackageMeta *pkg"
+.Ft int
 .Fn mport_index_load "mportInstance *mport"
 .Ft int
 .Fn mport_index_get "mportInstance *mport"
@@ -336,6 +344,10 @@ operate on the repository index.
 .Fn mport_pkgmeta_list_locked ,
 .Fn mport_pkgmeta_get_downdepends ,
 .Fn mport_pkgmeta_get_updepends ,
+.Fn mport_query_installed ,
+.Fn mport_query_format_package ,
+.Fn mport_query_print ,
+.Fn mport_query_pkg_message ,
 .Fn mport_assetlist_new ,
 .Fn mport_parse_plistfile ,
 .Fn mport_asset_get_assetlist ,
@@ -417,11 +429,23 @@ installs a local package bundle from disk and also requires the
 argument.
 .It Fn mport_setting_get ,
 .Fn mport_info ,
+.Fn mport_query_pkg_message ,
 .Fn mport_version ,
 .Fn mport_version_short ,
 and
 .Fn mport_purl_uri
 return heap-allocated strings on success.
+.It Fn mport_query_installed
+allocates a vector of installed package metadata matching the supplied
+.Vt mportQueryOptions .
+The caller must release the vector with
+.Fn mport_pkgmeta_vec_free .
+.It Fn mport_query_format_package
+prints one package using the same query format language used by
+.Cm mport query .
+.It Fn mport_query_print
+prints a vector of packages using the same format language and appends one
+newline for each package.
 .It Fn mport_audit
 returns a heap-allocated report string.
 Depending on verbosity and the requested package, the returned string may be

--- a/libmport/mport.h
+++ b/libmport/mport.h
@@ -1,6 +1,6 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
- * 
+ *
  * Copyright (c) 2013, 2014, 2021, 2024 Lucas Holt
  * Copyright (c) 2007-2009 Chris Reinhardt
  * All rights reserved.
@@ -70,42 +70,39 @@ typedef tll(char *) stringlist_t;
 #define MPORT_INST_HAVE_INDEX 1
 #define MPORT_LOCAL_PKG_PATH "/var/db/mport/downloads"
 
-enum _Verbosity{
-    MPORT_VQUIET,
-    MPORT_VBRIEF,
-    MPORT_VNORMAL,
-    MPORT_VVERBOSE
-};
+enum _Verbosity { MPORT_VQUIET, MPORT_VBRIEF, MPORT_VNORMAL, MPORT_VVERBOSE };
 typedef enum _Verbosity mportVerbosity;
 mportVerbosity mport_verbosity(bool quiet, bool verbose, bool brief);
 
 typedef struct {
-  int flags;
-  sqlite3 *db;
-  char *root;
-  int rootfd; /* Root directory file descriptor */
-  char *outputPath; /* Download directory */
-  bool noIndex; /* Do not fetch mport index */
-  bool offline; /* Installing packages from local files, etc. */
-  mportVerbosity verbosity;
-  bool force;
-  bool ignoreMissing; /* ignore mising dependencies during installation */
-  mport_msg_cb msg_cb;
-  mport_progress_init_cb progress_init_cb;
-  mport_progress_step_cb progress_step_cb;
-  mport_progress_free_cb progress_free_cb;
-  mport_confirm_cb confirm_cb;
-  mport_select_cb select_cb;
+	int flags;
+	sqlite3 *db;
+	char *root;
+	int rootfd; /* Root directory file descriptor */
+	char *outputPath; /* Download directory */
+	bool noIndex; /* Do not fetch mport index */
+	bool offline; /* Installing packages from local files, etc. */
+	mportVerbosity verbosity;
+	bool force;
+	bool ignoreMissing; /* ignore mising dependencies during installation */
+	mport_msg_cb msg_cb;
+	mport_progress_init_cb progress_init_cb;
+	mport_progress_step_cb progress_step_cb;
+	mport_progress_free_cb progress_free_cb;
+	mport_confirm_cb confirm_cb;
+	mport_select_cb select_cb;
 } mportInstance;
 
-mportInstance * mport_instance_new(void);
-int mport_instance_init(mportInstance *, const char *, const char *, bool noIndex, mportVerbosity verbosity);
+mportInstance *mport_instance_new(void);
+int mport_instance_init(
+    mportInstance *, const char *, const char *, bool noIndex, mportVerbosity verbosity);
 int mport_instance_free(mportInstance *);
 
 /* Run the callbacks. will display messages, etc */
 int mport_call_msg_cb(mportInstance *, const char *, ...);
 int mport_call_progress_init_cb(mportInstance *, const char *, ...);
-bool mport_call_confirm_cb(mportInstance *mport, const char *msg, const char *yes, const char *no, int def);
+bool mport_call_confirm_cb(
+    mportInstance *mport, const char *msg, const char *yes, const char *no, int def);
 int mport_call_select_cb(mportInstance *mport, const char *msg, mportIndexEntry **choices, int def);
 
 /* setup your custom callbacks */
@@ -125,17 +122,48 @@ void mport_default_progress_step_cb(int, int, const char *);
 void mport_default_progress_free_cb(void);
 
 enum _AssetListEntryType {
-    ASSET_INVALID, ASSET_FILE, ASSET_CWD, ASSET_CHMOD, ASSET_CHOWN, ASSET_CHGRP,
-    ASSET_COMMENT, ASSET_IGNORE, ASSET_NAME, ASSET_EXEC, ASSET_UNEXEC,
-    ASSET_SRC, ASSET_DISPLY, ASSET_PKGDEP, ASSET_CONFLICTS, ASSET_MTREE,
-    ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_IGNORE_INST, ASSET_OPTION, ASSET_ORIGIN,
-    ASSET_DEPORIGIN, ASSET_NOINST, ASSET_DISPLAY, ASSET_DIR,
-    ASSET_SAMPLE, ASSET_SHELL,
-    ASSET_PREEXEC, ASSET_PREUNEXEC, ASSET_POSTEXEC, ASSET_POSTUNEXEC,
-    ASSET_FILE_OWNER_MODE, ASSET_DIR_OWNER_MODE, 
-    ASSET_SAMPLE_OWNER_MODE, ASSET_LDCONFIG, ASSET_LDCONFIG_LINUX,
-    ASSET_RMEMPTY, ASSET_GLIB_SCHEMAS, ASSET_KLD, ASSET_DESKTOP_FILE_UTILS,
-    ASSET_INFO, ASSET_TOUCH
+	ASSET_INVALID,
+	ASSET_FILE,
+	ASSET_CWD,
+	ASSET_CHMOD,
+	ASSET_CHOWN,
+	ASSET_CHGRP,
+	ASSET_COMMENT,
+	ASSET_IGNORE,
+	ASSET_NAME,
+	ASSET_EXEC,
+	ASSET_UNEXEC,
+	ASSET_SRC,
+	ASSET_DISPLY,
+	ASSET_PKGDEP,
+	ASSET_CONFLICTS,
+	ASSET_MTREE,
+	ASSET_DIRRM,
+	ASSET_DIRRMTRY,
+	ASSET_IGNORE_INST,
+	ASSET_OPTION,
+	ASSET_ORIGIN,
+	ASSET_DEPORIGIN,
+	ASSET_NOINST,
+	ASSET_DISPLAY,
+	ASSET_DIR,
+	ASSET_SAMPLE,
+	ASSET_SHELL,
+	ASSET_PREEXEC,
+	ASSET_PREUNEXEC,
+	ASSET_POSTEXEC,
+	ASSET_POSTUNEXEC,
+	ASSET_FILE_OWNER_MODE,
+	ASSET_DIR_OWNER_MODE,
+	ASSET_SAMPLE_OWNER_MODE,
+	ASSET_LDCONFIG,
+	ASSET_LDCONFIG_LINUX,
+	ASSET_RMEMPTY,
+	ASSET_GLIB_SCHEMAS,
+	ASSET_KLD,
+	ASSET_DESKTOP_FILE_UTILS,
+	ASSET_INFO,
+	ASSET_TOUCH
 };
 
 typedef enum _AssetListEntryType mportAssetListEntryType;
@@ -156,67 +184,63 @@ STAILQ_HEAD(_AssetList, _AssetListEntry);
 typedef struct _AssetList mportAssetList;
 typedef struct _AssetListEntry mportAssetListEntry;
 
-mportAssetList* mport_assetlist_new(void);
+mportAssetList *mport_assetlist_new(void);
 void mport_assetlist_free(mportAssetList *);
 int mport_parse_plistfile(FILE *, mportAssetList *);
 
-enum _Automatic{
-    MPORT_EXPLICIT, /* explicitly installed */
-    MPORT_AUTOMATIC /* Automatically installed dependency */
+enum _Automatic {
+	MPORT_EXPLICIT, /* explicitly installed */
+	MPORT_AUTOMATIC /* Automatically installed dependency */
 };
 typedef enum _Automatic mportAutomatic;
 
-
-enum _Action{
-    MPORT_ACTION_INSTALL,
-    MPORT_ACTION_UPGRADE,
-    MPORT_ACTION_UPDATE,
-    MPORT_ACTION_DELETE,
-    MPORT_ACTION_UNKNOWN
+enum _Action {
+	MPORT_ACTION_INSTALL,
+	MPORT_ACTION_UPGRADE,
+	MPORT_ACTION_UPDATE,
+	MPORT_ACTION_DELETE,
+	MPORT_ACTION_UNKNOWN
 };
 typedef enum _Action mportAction;
 
-enum _Type{
-    MPORT_TYPE_APP, 
-    MPORT_TYPE_SYSTEM
-};
+enum _Type { MPORT_TYPE_APP, MPORT_TYPE_SYSTEM };
 typedef enum _Type mportType;
 
 #define MPORT_NUM_LUA_SCRIPTS 5
 
 /* Package Meta-data structure */
 typedef struct {
-    char *name;
-    char *version;
-    char *lang;
-    char *options;
-    char *comment;
-    char *desc;
-    char *prefix;
-    char *origin;
-    char **categories;
-    size_t categories_count;
-    char *os_release;
-    char *cpe;
-    int locked;
-    char *deprecated;
-    time_t expiration_date;
-    int no_provide_shlib;
-    char *flavor;
-    mportAutomatic automatic;
-    time_t install_date;
-    mportAction action; // not populated from package table
-    mportType type;
-    int64_t flatsize;
-    stringlist_t  lua_scripts[MPORT_NUM_LUA_SCRIPTS]; // not populated from package table
-    stringlist_t  conflicts; // not populated from package table
-    // TODO: conflicts should be a structure
-} __attribute__ ((aligned (16)))  mportPackageMeta;
+	char *name;
+	char *version;
+	char *lang;
+	char *options;
+	char *comment;
+	char *desc;
+	char *prefix;
+	char *origin;
+	char **categories;
+	size_t categories_count;
+	char *os_release;
+	char *cpe;
+	int locked;
+	char *deprecated;
+	time_t expiration_date;
+	int no_provide_shlib;
+	char *flavor;
+	mportAutomatic automatic;
+	time_t install_date;
+	mportAction action; // not populated from package table
+	mportType type;
+	int64_t flatsize;
+	stringlist_t lua_scripts[MPORT_NUM_LUA_SCRIPTS]; // not populated from package table
+	stringlist_t conflicts; // not populated from package table
+	// TODO: conflicts should be a structure
+} __attribute__((aligned(16))) mportPackageMeta;
 
 int mport_asset_get_assetlist(mportInstance *, mportPackageMeta *, mportAssetList **);
 int mport_asset_get_package_from_file_path(mportInstance *, const char *, mportPackageMeta **);
 
-mportPackageMeta * mport_pkgmeta_new(void);
+mportPackageMeta *mport_pkgmeta_new(void);
 void mport_pkgmeta_free(mportPackageMeta *);
 void mport_pkgmeta_vec_free(mportPackageMeta **);
 int mport_pkgmeta_search_master(mportInstance *, mportPackageMeta ***, const char *, ...);
@@ -225,31 +249,50 @@ int mport_pkgmeta_list_locked(mportInstance *mport, mportPackageMeta ***ref);
 int mport_pkgmeta_get_downdepends(mportInstance *, mportPackageMeta *, mportPackageMeta ***);
 int mport_pkgmeta_get_updepends(mportInstance *, mportPackageMeta *, mportPackageMeta ***);
 
+typedef enum {
+	MPORT_QUERY_MATCH_EXACT,
+	MPORT_QUERY_MATCH_GLOB,
+	MPORT_QUERY_MATCH_REGEX
+} mportQueryMatch;
+
+typedef struct {
+	bool all;
+	bool case_sensitive;
+	mportQueryMatch match;
+	const char *expression;
+	char **patterns;
+	int pattern_count;
+} mportQueryOptions;
+
+int mport_query_installed(mportInstance *, const mportQueryOptions *, mportPackageMeta ***);
+int mport_query_format_package(mportInstance *, mportPackageMeta *, const char *, FILE *);
+int mport_query_print(mportInstance *, mportPackageMeta **, const char *, FILE *);
+char *mport_query_pkg_message(mportInstance *, mportPackageMeta *);
 
 /* index */
 struct _IndexEntry {
-  char *pkgname;
-  char *version;
-  char *comment;
-  char *bundlefile;
-  char *license;
-  char *hash;
-  mportType type;
+	char *pkgname;
+	char *version;
+	char *comment;
+	char *bundlefile;
+	char *license;
+	char *hash;
+	mportType type;
 };
 
 typedef struct {
-  char port[128];
-  char moved_to[128];
-  char why[128];
-  char date[32];
+	char port[128];
+	char moved_to[128];
+	char why[128];
+	char date[32];
 
-  char pkgname[128];
-  char moved_to_pkgname[128];
+	char pkgname[128];
+	char moved_to_pkgname[128];
 } mportIndexMovedEntry;
 
 typedef struct {
-  char country[5];
-  char url[256];
+	char country[5];
+	char url[256];
 } mportMirrorEntry;
 
 int mport_index_load(mportInstance *);
@@ -272,10 +315,10 @@ int mport_moved_lookup(mportInstance *, const char *, mportIndexMovedEntry ***);
 /* Index Depends */
 
 typedef struct {
-  char *pkgname;
-  char *version;
-  char *d_pkgname;
-  char *d_version;
+	char *pkgname;
+	char *version;
+	char *d_pkgname;
+	char *d_version;
 } mportDependsEntry;
 
 int mport_index_depends_list(mportInstance *, const char *, const char *, mportDependsEntry ***);
@@ -283,54 +326,56 @@ void mport_index_depends_free_vec(mportDependsEntry **);
 void mport_index_depends_free(mportDependsEntry *);
 
 /* Info */
-char * mport_info(mportInstance *mport, const char *packageName);
+char *mport_info(mportInstance *mport, const char *packageName);
 
 /* Package creation */
 
 typedef enum {
-    PKG_MESSAGE_ALWAYS = 0,
-    PKG_MESSAGE_INSTALL,
-    PKG_MESSAGE_REMOVE,
-    PKG_MESSAGE_UPGRADE,
+	PKG_MESSAGE_ALWAYS = 0,
+	PKG_MESSAGE_INSTALL,
+	PKG_MESSAGE_REMOVE,
+	PKG_MESSAGE_UPGRADE,
 } pkg_message_t;
 
 typedef struct package_message {
-    char			*str;
-    char			*minimum_version;
-    char			*maximum_version;
-    pkg_message_t		 type;
-    struct package_message *next, *prev;
+	char *str;
+	char *minimum_version;
+	char *maximum_version;
+	pkg_message_t type;
+	struct package_message *next, *prev;
 } mportPackageMessage;
 
 typedef struct {
-  char pkg_filename[FILENAME_MAX];
-  char sourcedir[FILENAME_MAX];
-  char **depends;
-  size_t depends_count;
-  char *mtree; 
-  stringlist_t conflicts;
-  stringlist_t annotations;
-  char *pkginstall;
-  char *pkgdeinstall;
-  char *luapkgpreinstall;
-  char *luapkgpredeinstall;
-  char *luapkgpostinstall;
-  char *luapkgpostdeinstall;
-  char *pkgmessage;
-  bool is_backup;
-} mportCreateExtras;  
+	char pkg_filename[FILENAME_MAX];
+	char sourcedir[FILENAME_MAX];
+	char **depends;
+	size_t depends_count;
+	char *mtree;
+	stringlist_t conflicts;
+	stringlist_t annotations;
+	char *pkginstall;
+	char *pkgdeinstall;
+	char *luapkgpreinstall;
+	char *luapkgpredeinstall;
+	char *luapkgpostinstall;
+	char *luapkgpostdeinstall;
+	char *pkgmessage;
+	bool is_backup;
+} mportCreateExtras;
 
-mportCreateExtras * mport_createextras_new(void);
+mportCreateExtras *mport_createextras_new(void);
 void mport_createextras_free(mportCreateExtras *);
 
-int mport_create_primative(mportInstance *, mportAssetList *, mportPackageMeta *, mportCreateExtras *);
+int mport_create_primative(
+    mportInstance *, mportAssetList *, mportPackageMeta *, mportCreateExtras *);
 
 /* Merge primative */
 int mport_merge_primative(mportInstance *mport, const char **, const char *);
 
 /* Package installation */
 int mport_install(mportInstance *, const char *, const char *, const char *, mportAutomatic);
-int mport_install_single(mportInstance *mport, const char *pkgname, const char *version, const char *prefix, mportAutomatic automatic);
+int mport_install_single(mportInstance *mport, const char *pkgname, const char *version,
+    const char *prefix, mportAutomatic automatic);
 int mport_install_primative(mportInstance *, const char *, const char *, mportAutomatic);
 
 /* package updating */
@@ -358,20 +403,20 @@ int mport_fetch_bundle(mportInstance *, const char *, const char *);
 int mport_download(mportInstance *, const char *, bool, bool, char **);
 
 /* Auditing for CVEs */
-char * mport_audit(mportInstance *, const char *, bool);
+char *mport_audit(mportInstance *, const char *, bool);
 
 /* Errors */
 int mport_err_code(void);
-const char * mport_err_string(void);
+const char *mport_err_string(void);
 
-
-#define MPORT_OK			    0
-#define MPORT_ERR_FATAL 		1
-#define MPORT_ERR_WARN			2
+#define MPORT_OK 0
+#define MPORT_ERR_FATAL 1
+#define MPORT_ERR_WARN 2
 
 /* Annotations */
 int mport_annotation_get(mportInstance *mport, const char *pkg, const char *tag, char **annotation);
-int mport_annotation_set(mportInstance *mport, const char *pkg, const char *tag, const char *annotation);
+int mport_annotation_set(
+    mportInstance *mport, const char *pkg, const char *tag, const char *annotation);
 int mport_annotation_delete(mportInstance *mport, const char *pkg, const char *tag);
 int mport_annotation_delete_all(mportInstance *mport, const char *pkg);
 int mport_annotation_list(mportInstance *mport, const char *pkg, char ***tags, int *tag_count);
@@ -383,28 +428,26 @@ int mport_clean_oldmtree(mportInstance *);
 int mport_clean_tempfiles(mportInstance *);
 
 /* Setting */
-char * mport_setting_get(mportInstance *, const char *);
+char *mport_setting_get(mportInstance *, const char *);
 int mport_setting_set(mportInstance *, const char *, const char *);
-char ** mport_setting_list(mportInstance *);
+char **mport_setting_list(mportInstance *);
 
 /* Utils */
-char * mport_purl_uri(mportPackageMeta *packs);
+char *mport_purl_uri(mportPackageMeta *packs);
 void mport_parselist(char *, char ***, size_t *);
 void mport_parselist_tll(char *, stringlist_t *);
 int mport_verify_hash(const char *, const char *);
 int mport_file_exists(const char *);
-char * mport_version(mportInstance *);
-char * mport_version_short(mportInstance *);
-char * mport_get_osrelease(mportInstance *);
+char *mport_version(mportInstance *);
+char *mport_version_short(mportInstance *);
+char *mport_get_osrelease(mportInstance *);
 int mport_drop_privileges(void);
-char * mport_string_replace(const char *str, const char *old, const char *new);
+char *mport_string_replace(const char *str, const char *old, const char *new);
 bool mport_is_elf_file(const char *file);
 bool mport_is_statically_linked(const char *file);
 
 /* Locks */
-enum _LockState {
-	MPORT_UNLOCKED, MPORT_LOCKED
-};
+enum _LockState { MPORT_UNLOCKED, MPORT_LOCKED };
 
 typedef enum _LockState mportLockState;
 
@@ -414,19 +457,19 @@ int mport_lock_islocked(mportPackageMeta *);
 
 /* Statistics */
 typedef struct {
-    unsigned int pkg_installed;
-    unsigned int pkg_available;
-    int64_t pkg_installed_size;
-    /* TODO: int64_t pkg_available_size; */
+	unsigned int pkg_installed;
+	unsigned int pkg_available;
+	int64_t pkg_installed_size;
+	/* TODO: int64_t pkg_available_size; */
 } mportStats;
 
 int mport_stats(mportInstance *, mportStats **);
 int mport_stats_free(mportStats *);
-mportStats * mport_stats_new(void);
+mportStats *mport_stats_new(void);
 
 /* Import/Export */
-int mport_import(mportInstance*,  char *);
-int mport_export(mportInstance*, char *);
+int mport_import(mportInstance *, char *);
+int mport_export(mportInstance *, char *);
 
 /* Ping */
 long ping(char *hostname);
@@ -437,7 +480,7 @@ typedef struct {
 	bool origin;
 	bool update;
 	bool locks;
-  bool prime;
+	bool prime;
 } mportListPrint;
 
 int mport_list_print(mportInstance *, mportListPrint *);

--- a/libmport/query.c
+++ b/libmport/query.c
@@ -300,6 +300,7 @@ eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expres
 		for (and_term = strtok_r(or_term, "&", &and_save); and_term != NULL;
 		    and_term = strtok_r(NULL, "&", &and_save)) {
 			char *term = trim(and_term);
+			bool had_operator = false;
 			bool negate = false;
 			bool term_result = false;
 
@@ -322,6 +323,7 @@ eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expres
 					char *right;
 					char *value;
 
+					had_operator = true;
 					*op = '\0';
 					left = trim(term);
 					right = trim(op + strlen(ops[i]));
@@ -336,7 +338,7 @@ eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expres
 				}
 			}
 
-			if (!term_result && strchr(term, '=') == NULL &&
+			if (!had_operator && !term_result && strchr(term, '=') == NULL &&
 			    strchr(term, '~') == NULL && strchr(term, '<') == NULL &&
 			    strchr(term, '>') == NULL) {
 				char *value;

--- a/libmport/query.c
+++ b/libmport/query.c
@@ -1,0 +1,667 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Lucas Holt
+ * All rights reserved.
+ */
+
+#include <sys/cdefs.h>
+
+#include "mport.h"
+#include "mport_private.h"
+
+/* SPLINT_SKIP_FILE: Splint crashes/noises on query formatter vector ownership and libc models. */
+
+#include <ctype.h>
+#include <errno.h>
+#include <fnmatch.h>
+#include <libutil.h>
+#include <regex.h>
+#include <sqlite3.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+	char **items;
+	size_t count;
+} query_list;
+
+static bool match_pattern(const char *, const char *, const mportQueryOptions *);
+static bool eval_expression(mportInstance *, mportPackageMeta *, const char *);
+static char *field_value(mportInstance *, mportPackageMeta *, const char);
+static char *annotation_value(mportInstance *, mportPackageMeta *, const char *);
+static char *index_value(mportInstance *, mportPackageMeta *, const char *);
+static int append_value(FILE *, const char *);
+static int print_list(mportInstance *, mportPackageMeta *, char, FILE *);
+static int list_for_code(mportInstance *, mportPackageMeta *, char, query_list *);
+static void query_list_free(query_list *);
+static int query_list_add(query_list *, const char *);
+static char *xstrdup(const char *);
+static char *lowercase_dup(const char *);
+static bool truthy(const char *);
+static bool compare_values(const char *, const char *, const char *);
+static char *trim(char *);
+
+/* Splint's constraint engine crashes on this vector ownership-transfer loop. */
+/*@ignore@*/
+MPORT_PUBLIC_API int
+mport_query_installed(mportInstance *mport, const mportQueryOptions *opts, mportPackageMeta ***ref)
+{
+	mportPackageMeta **all_packs = NULL;
+	mportPackageMeta **out = NULL;
+	mportPackageMeta **pack;
+	size_t count = 0;
+	size_t kept = 0;
+	int i;
+
+	if (mport == NULL || opts == NULL || ref == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid arguments to mport_query_installed");
+
+	*ref = NULL;
+
+	if (mport_pkgmeta_list(mport, &all_packs) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	if (all_packs == NULL)
+		return MPORT_OK;
+
+	for (pack = all_packs; *pack != NULL; pack++)
+		count++;
+
+	out = calloc(count + 1, sizeof(mportPackageMeta *));
+	if (out == NULL) {
+		mport_pkgmeta_vec_free(all_packs);
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
+	}
+
+	for (pack = all_packs; *pack != NULL; pack++) {
+		bool matched = opts->all || opts->pattern_count == 0;
+
+		for (i = 0; !matched && i < opts->pattern_count; i++)
+			matched = match_pattern((*pack)->name, opts->patterns[i], opts);
+
+		if (matched && opts->expression != NULL && opts->expression[0] != '\0')
+			matched = eval_expression(mport, *pack, opts->expression);
+
+		if (matched) {
+			out[kept++] = *pack;
+			*pack = NULL;
+		}
+	}
+	out[kept] = NULL;
+	mport_pkgmeta_vec_free(all_packs);
+
+	if (kept == 0) {
+		free(out);
+	} else {
+		*ref = out;
+	}
+
+	return MPORT_OK;
+}
+/*@end@*/
+
+MPORT_PUBLIC_API int
+mport_query_print(mportInstance *mport, mportPackageMeta **packs, const char *format, FILE *out)
+{
+	mportPackageMeta **pack;
+
+	if (mport == NULL || format == NULL || out == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid arguments to mport_query_print");
+
+	for (pack = packs; packs != NULL && *pack != NULL; pack++) {
+		if (mport_query_format_package(mport, *pack, format, out) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		fputc('\n', out);
+	}
+
+	return MPORT_OK;
+}
+
+MPORT_PUBLIC_API int
+mport_query_format_package(
+    mportInstance *mport, mportPackageMeta *pack, const char *format, FILE *out)
+{
+	const char *p;
+
+	if (mport == NULL || pack == NULL || format == NULL || out == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid arguments to mport_query_format_package");
+
+	for (p = format; *p != '\0'; p++) {
+		char *value = NULL;
+		query_list list = { 0 };
+		char code;
+
+		if (*p != '%') {
+			fputc(*p, out);
+			continue;
+		}
+
+		p++;
+		if (*p == '\0')
+			RETURN_ERROR(MPORT_ERR_FATAL, "Incomplete query format");
+
+		if (*p == '%') {
+			fputc('%', out);
+			continue;
+		}
+
+		if (*p == '#' || *p == '?') {
+			bool is_count = *p == '#';
+			p++;
+			if (*p == '\0')
+				RETURN_ERROR(MPORT_ERR_FATAL, "Incomplete query list modifier");
+			if (list_for_code(mport, pack, *p, &list) != MPORT_OK)
+				RETURN_CURRENT_ERROR;
+			fprintf(out, "%zu",
+			    is_count ? list.count : (list.count > 0 ? (size_t)1 : (size_t)0));
+			query_list_free(&list);
+			continue;
+		}
+
+		code = *p;
+		if (code == 's' && p[1] == 'b')
+			p++;
+		else if (code == 's' && p[1] == 'h') {
+			code = 'h';
+			p++;
+		}
+		switch (code) {
+		case 'A':
+		case 'C':
+		case 'D':
+		case 'F':
+		case 'L':
+		case 'O':
+		case 'd':
+		case 'r':
+			if (print_list(mport, pack, code, out) != MPORT_OK)
+				RETURN_CURRENT_ERROR;
+			break;
+		default:
+			value = field_value(mport, pack, code);
+			if (value == NULL)
+				RETURN_ERRORX(
+				    MPORT_ERR_FATAL, "Unsupported query format code %%%c", code);
+			if (append_value(out, value) != MPORT_OK) {
+				free(value);
+				RETURN_CURRENT_ERROR;
+			}
+			free(value);
+			break;
+		}
+	}
+
+	return MPORT_OK;
+}
+
+MPORT_PUBLIC_API char *
+mport_query_pkg_message(mportInstance *mport, mportPackageMeta *pkg)
+{
+	mportPackageMessage packageMessage;
+
+	if (mport == NULL || pkg == NULL)
+		return NULL;
+
+	memset(&packageMessage, 0, sizeof(packageMessage));
+	packageMessage.type = PKG_MESSAGE_ALWAYS;
+
+	if (mport_pkg_message_load(mport, pkg, &packageMessage) != MPORT_OK)
+		return NULL;
+
+	free(packageMessage.minimum_version);
+	free(packageMessage.maximum_version);
+
+	if (packageMessage.str == NULL)
+		return xstrdup("");
+
+	return packageMessage.str;
+}
+
+static bool
+match_pattern(const char *value, const char *pattern, const mportQueryOptions *opts)
+{
+	int flags = 0;
+	regex_t re;
+	int ret;
+
+	if (value == NULL || pattern == NULL)
+		return false;
+
+	if (opts->match == MPORT_QUERY_MATCH_REGEX) {
+		flags = REG_NOSUB | REG_EXTENDED;
+		if (!opts->case_sensitive)
+			flags |= REG_ICASE;
+		if (regcomp(&re, pattern, flags) != 0)
+			return false;
+		ret = regexec(&re, value, 0, NULL, 0);
+		regfree(&re);
+		return ret == 0;
+	}
+
+	if (opts->match == MPORT_QUERY_MATCH_GLOB) {
+#ifdef FNM_CASEFOLD
+		if (!opts->case_sensitive)
+			flags |= FNM_CASEFOLD;
+		return fnmatch(pattern, value, flags) == 0;
+#else
+		bool matched;
+
+		if (opts->case_sensitive)
+			return fnmatch(pattern, value, flags) == 0;
+		char *lower_pattern = lowercase_dup(pattern);
+		char *lower_value = lowercase_dup(value);
+		if (lower_pattern == NULL || lower_value == NULL) {
+			free(lower_pattern);
+			free(lower_value);
+			return false;
+		}
+		matched = fnmatch(lower_pattern, lower_value, flags) == 0;
+		free(lower_pattern);
+		free(lower_value);
+		return matched;
+#endif
+	}
+
+	if (opts->case_sensitive)
+		return strcmp(value, pattern) == 0;
+
+	return strcasecmp(value, pattern) == 0;
+}
+
+static bool
+eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expression)
+{
+	static const char *ops[] = { ">=", "<=", "!=", "~", "=", ">", "<", NULL };
+	char *copy = NULL;
+	char *or_save = NULL;
+	char *or_term;
+	bool result = false;
+	int i;
+
+	copy = strdup(expression);
+	if (copy == NULL)
+		return false;
+
+	for (or_term = strtok_r(copy, "|", &or_save); or_term != NULL;
+	    or_term = strtok_r(NULL, "|", &or_save)) {
+		char *and_save = NULL;
+		char *and_term;
+		bool and_result = true;
+
+		if (*or_term == '|')
+			or_term++;
+
+		for (and_term = strtok_r(or_term, "&", &and_save); and_term != NULL;
+		    and_term = strtok_r(NULL, "&", &and_save)) {
+			char *term = trim(and_term);
+			bool negate = false;
+			bool term_result = false;
+
+			if (*term == '&')
+				term++;
+			term = trim(term);
+			if (*term == '!') {
+				negate = true;
+				term = trim(term + 1);
+			}
+
+			for (i = 0; ops[i] != NULL; i++) {
+				char *op = strstr(term, ops[i]);
+				if (op != NULL) {
+					char *left;
+					char *right;
+					char *value;
+
+					*op = '\0';
+					left = trim(term);
+					right = trim(op + strlen(ops[i]));
+					if (left[0] == '%')
+						left++;
+					value = field_value(mport, pack, left[0]);
+					if (value != NULL) {
+						term_result = compare_values(value, ops[i], right);
+						free(value);
+					}
+					break;
+				}
+			}
+
+			if (!term_result && strchr(term, '=') == NULL &&
+			    strchr(term, '~') == NULL && strchr(term, '<') == NULL &&
+			    strchr(term, '>') == NULL) {
+				char *value;
+				if (term[0] == '%')
+					term++;
+				value = field_value(mport, pack, term[0]);
+				term_result = truthy(value);
+				free(value);
+			}
+
+			if (negate)
+				term_result = !term_result;
+			and_result = and_result && term_result;
+		}
+
+		result = result || and_result;
+	}
+
+	free(copy);
+	return result;
+}
+
+static char *
+field_value(mportInstance *mport, mportPackageMeta *pack, const char code)
+{
+	char *buf = NULL;
+	char sizebuf[8];
+
+	switch (code) {
+	case 'n':
+		return xstrdup(pack->name);
+	case 'v':
+		return xstrdup(pack->version);
+	case 'o':
+		return xstrdup(pack->origin);
+	case 'p':
+		return xstrdup(pack->prefix);
+	case 'm':
+		return annotation_value(mport, pack, "maintainer");
+	case 'c':
+		return xstrdup(pack->comment);
+	case 'e':
+		return xstrdup(pack->desc);
+	case 'w':
+		return annotation_value(mport, pack, "www");
+	case 'a':
+		return xstrdup(pack->automatic == MPORT_AUTOMATIC ? "1" : "0");
+	case 'k':
+		return xstrdup(pack->locked ? "1" : "0");
+	case 't':
+		if (asprintf(&buf, "%lld", (long long)pack->install_date) == -1)
+			return NULL;
+		return buf;
+	case 's':
+		if (asprintf(&buf, "%lld", (long long)pack->flatsize) == -1)
+			return NULL;
+		return buf;
+	case 'h':
+		humanize_number(sizebuf, sizeof(sizebuf), pack->flatsize, "B", HN_AUTOSCALE,
+		    HN_DECIMAL | HN_IEC_PREFIXES);
+		return xstrdup(sizebuf);
+	case 'M':
+		return mport_query_pkg_message(mport, pack);
+	case 'X':
+		return index_value(mport, pack, "hash");
+	case 'l':
+		return index_value(mport, pack, "license");
+	case 'q':
+		return xstrdup(MPORT_ARCH);
+	case 'P':
+		return mport_purl_uri(pack);
+	default:
+		return NULL;
+	}
+}
+
+static char *
+annotation_value(mportInstance *mport, mportPackageMeta *pack, const char *tag)
+{
+	char *value = NULL;
+
+	if (mport_annotation_get(mport, pack->name, tag, &value) == MPORT_OK && value != NULL)
+		return value;
+
+	return xstrdup("");
+}
+
+static char *
+index_value(mportInstance *mport, mportPackageMeta *pack, const char *field)
+{
+	mportIndexEntry **entries = NULL;
+	char *value = NULL;
+
+	if ((mport->flags & MPORT_INST_HAVE_INDEX) == 0)
+		return xstrdup("");
+
+	if (mport_index_lookup_pkgname(mport, pack->name, &entries) != MPORT_OK ||
+	    entries == NULL || entries[0] == NULL) {
+		mport_index_entry_free_vec(entries);
+		return xstrdup("");
+	}
+
+	if (strcmp(field, "license") == 0)
+		value = xstrdup(entries[0]->license);
+	else if (strcmp(field, "hash") == 0)
+		value = xstrdup(entries[0]->hash);
+	else
+		value = xstrdup("");
+
+	mport_index_entry_free_vec(entries);
+	return value;
+}
+
+static int
+append_value(FILE *out, const char *value)
+{
+	if (value == NULL)
+		return MPORT_OK;
+	if (fputs(value, out) == EOF)
+		RETURN_ERROR(MPORT_ERR_FATAL, strerror(errno));
+	return MPORT_OK;
+}
+
+static int
+print_list(mportInstance *mport, mportPackageMeta *pack, char code, FILE *out)
+{
+	query_list list = { 0 };
+	size_t i;
+
+	if (list_for_code(mport, pack, code, &list) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	for (i = 0; i < list.count; i++) {
+		if (i > 0)
+			fputc(',', out);
+		if (list.items[i] != NULL)
+			fputs(list.items[i], out);
+	}
+
+	query_list_free(&list);
+	return MPORT_OK;
+}
+
+static int
+list_for_code(mportInstance *mport, mportPackageMeta *pack, char code, query_list *list)
+{
+	sqlite3_stmt *stmt = NULL;
+
+	switch (code) {
+	case 'C':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT category FROM categories WHERE pkg=%Q ORDER BY category",
+			pack->name) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'd':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT depend_pkgname FROM depends WHERE pkg=%Q ORDER BY depend_pkgname",
+			pack->name) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'r':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT pkg FROM depends WHERE depend_pkgname=%Q ORDER BY pkg",
+			pack->name) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'F':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT data FROM assets WHERE pkg=%Q AND type IN (%d,%d,%d,%d) ORDER BY data",
+			pack->name, ASSET_FILE, ASSET_SAMPLE, ASSET_SHELL, ASSET_INFO) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'D':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT data FROM assets WHERE pkg=%Q AND type IN (%d,%d,%d,%d) ORDER BY data",
+			pack->name, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY,
+			ASSET_DIR_OWNER_MODE) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'A':
+		if (mport_db_prepare(mport->db, &stmt,
+			"SELECT tag || '=' || val FROM annotation WHERE pkg=%Q ORDER BY tag",
+			pack->name) != MPORT_OK)
+			RETURN_CURRENT_ERROR;
+		break;
+	case 'L': {
+		char *license = index_value(mport, pack, "license");
+		char *save = NULL;
+		char *tok;
+		for (tok = strtok_r(license, " ,", &save); tok != NULL;
+		    tok = strtok_r(NULL, " ,", &save)) {
+			if (query_list_add(list, tok) != MPORT_OK) {
+				free(license);
+				RETURN_CURRENT_ERROR;
+			}
+		}
+		free(license);
+		return MPORT_OK;
+	}
+	case 'O': {
+		char *options = xstrdup(pack->options);
+		char *save = NULL;
+		char *tok;
+		for (tok = strtok_r(options, " \n\t,", &save); tok != NULL;
+		    tok = strtok_r(NULL, " \n\t,", &save)) {
+			if (query_list_add(list, tok) != MPORT_OK) {
+				free(options);
+				RETURN_CURRENT_ERROR;
+			}
+		}
+		free(options);
+		return MPORT_OK;
+	}
+	default:
+		RETURN_ERRORX(MPORT_ERR_FATAL, "Unsupported query list code %%%c", code);
+	}
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		const unsigned char *value = sqlite3_column_text(stmt, 0);
+		if (value != NULL && query_list_add(list, (const char *)value) != MPORT_OK) {
+			sqlite3_finalize(stmt);
+			RETURN_CURRENT_ERROR;
+		}
+	}
+	sqlite3_finalize(stmt);
+	return MPORT_OK;
+}
+
+static void
+query_list_free(query_list *list)
+{
+	size_t i;
+
+	for (i = 0; i < list->count; i++)
+		free(list->items[i]);
+	free(list->items);
+	list->items = NULL;
+	list->count = 0;
+}
+
+static int
+query_list_add(query_list *list, const char *value)
+{
+	char **items;
+
+	items = reallocarray(list->items, list->count + 1, sizeof(char *));
+	if (items == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
+
+	list->items = items;
+	list->items[list->count] = xstrdup(value);
+	if (list->items[list->count] == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Out of memory");
+	list->count++;
+
+	return MPORT_OK;
+}
+
+static char *
+xstrdup(const char *value)
+{
+	if (value == NULL)
+		value = "";
+	return strdup(value);
+}
+
+static char *
+lowercase_dup(const char *value)
+{
+	char *copy = xstrdup(value);
+	char *p;
+
+	if (copy == NULL)
+		return NULL;
+
+	for (p = copy; *p != '\0'; p++)
+		*p = (char)tolower((unsigned char)*p);
+
+	return copy;
+}
+
+static bool
+truthy(const char *value)
+{
+	return value != NULL && value[0] != '\0' && strcmp(value, "0") != 0;
+}
+
+static bool
+compare_values(const char *left, const char *op, const char *right)
+{
+	if (left == NULL)
+		left = "";
+	if (right == NULL)
+		right = "";
+
+	if (right[0] != '\0' && (right[0] == '\'' || right[0] == '"') &&
+	    right[strlen(right) - 1] == right[0]) {
+		char *mutable = (char *)right;
+		mutable[strlen(mutable) - 1] = '\0';
+		right++;
+	}
+
+	if (strcmp(op, "~") == 0)
+		return fnmatch(right, left, 0) == 0;
+	if (strcmp(op, "=") == 0)
+		return strcmp(left, right) == 0;
+	if (strcmp(op, "!=") == 0)
+		return strcmp(left, right) != 0;
+	if (strcmp(op, ">") == 0)
+		return mport_version_cmp(left, right) > 0;
+	if (strcmp(op, ">=") == 0)
+		return mport_version_cmp(left, right) >= 0;
+	if (strcmp(op, "<") == 0)
+		return mport_version_cmp(left, right) < 0;
+	if (strcmp(op, "<=") == 0)
+		return mport_version_cmp(left, right) <= 0;
+
+	return false;
+}
+
+static char *
+trim(char *value)
+{
+	char *end;
+
+	while (isspace((unsigned char)*value))
+		value++;
+	if (*value == '\0')
+		return value;
+
+	end = value + strlen(value) - 1;
+	while (end > value && isspace((unsigned char)*end))
+		*end-- = '\0';
+
+	return value;
+}

--- a/libmport/query.c
+++ b/libmport/query.c
@@ -85,11 +85,12 @@ mport_query_installed(mportInstance *mport, const mportQueryOptions *opts, mport
 
 		if (matched) {
 			out[kept++] = *pack;
-			*pack = NULL;
+		} else {
+			mport_pkgmeta_free(*pack);
 		}
 	}
 	out[kept] = NULL;
-	mport_pkgmeta_vec_free(all_packs);
+	free(all_packs);
 
 	if (kept == 0) {
 		free(out);
@@ -109,7 +110,7 @@ mport_query_print(mportInstance *mport, mportPackageMeta **packs, const char *fo
 	if (mport == NULL || format == NULL || out == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid arguments to mport_query_print");
 
-	for (pack = packs; packs != NULL && *pack != NULL; pack++) {
+	for (pack = packs; pack != NULL && *pack != NULL; pack++) {
 		if (mport_query_format_package(mport, *pack, format, out) != MPORT_OK)
 			RETURN_CURRENT_ERROR;
 		fputc('\n', out);
@@ -292,6 +293,10 @@ eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expres
 		if (*or_term == '|')
 			or_term++;
 
+		or_term = trim(or_term);
+		if (*or_term == '\0')
+			continue;
+
 		for (and_term = strtok_r(or_term, "&", &and_save); and_term != NULL;
 		    and_term = strtok_r(NULL, "&", &and_save)) {
 			char *term = trim(and_term);
@@ -301,10 +306,14 @@ eval_expression(mportInstance *mport, mportPackageMeta *pack, const char *expres
 			if (*term == '&')
 				term++;
 			term = trim(term);
+			if (*term == '\0')
+				continue;
 			if (*term == '!') {
 				negate = true;
 				term = trim(term + 1);
 			}
+			if (*term == '\0')
+				continue;
 
 			for (i = 0; ops[i] != NULL; i++) {
 				char *op = strstr(term, ops[i]);
@@ -522,6 +531,7 @@ list_for_code(mportInstance *mport, mportPackageMeta *pack, char code, query_lis
 		    tok = strtok_r(NULL, " ,", &save)) {
 			if (query_list_add(list, tok) != MPORT_OK) {
 				free(license);
+				query_list_free(list);
 				RETURN_CURRENT_ERROR;
 			}
 		}
@@ -536,6 +546,7 @@ list_for_code(mportInstance *mport, mportPackageMeta *pack, char code, query_lis
 		    tok = strtok_r(NULL, " \n\t,", &save)) {
 			if (query_list_add(list, tok) != MPORT_OK) {
 				free(options);
+				query_list_free(list);
 				RETURN_CURRENT_ERROR;
 			}
 		}
@@ -550,6 +561,7 @@ list_for_code(mportInstance *mport, mportPackageMeta *pack, char code, query_lis
 		const unsigned char *value = sqlite3_column_text(stmt, 0);
 		if (value != NULL && query_list_add(list, (const char *)value) != MPORT_OK) {
 			sqlite3_finalize(stmt);
+			query_list_free(list);
 			RETURN_CURRENT_ERROR;
 		}
 	}
@@ -619,34 +631,47 @@ truthy(const char *value)
 static bool
 compare_values(const char *left, const char *op, const char *right)
 {
+	const char *right_cmp = right;
+	char *right_buf = NULL;
+	bool result;
+
 	if (left == NULL)
 		left = "";
-	if (right == NULL)
-		right = "";
+	if (right_cmp == NULL)
+		right_cmp = "";
 
-	if (right[0] != '\0' && (right[0] == '\'' || right[0] == '"') &&
-	    right[strlen(right) - 1] == right[0]) {
-		char *mutable = (char *)right;
-		mutable[strlen(mutable) - 1] = '\0';
-		right++;
+	if (right_cmp[0] != '\0' && (right_cmp[0] == '\'' || right_cmp[0] == '"')) {
+		size_t len = strlen(right_cmp);
+
+		if (len >= 2 && right_cmp[len - 1] == right_cmp[0]) {
+			right_buf = malloc(len - 1);
+			if (right_buf != NULL) {
+				memcpy(right_buf, right_cmp + 1, len - 2);
+				right_buf[len - 2] = '\0';
+				right_cmp = right_buf;
+			}
+		}
 	}
 
 	if (strcmp(op, "~") == 0)
-		return fnmatch(right, left, 0) == 0;
-	if (strcmp(op, "=") == 0)
-		return strcmp(left, right) == 0;
-	if (strcmp(op, "!=") == 0)
-		return strcmp(left, right) != 0;
-	if (strcmp(op, ">") == 0)
-		return mport_version_cmp(left, right) > 0;
-	if (strcmp(op, ">=") == 0)
-		return mport_version_cmp(left, right) >= 0;
-	if (strcmp(op, "<") == 0)
-		return mport_version_cmp(left, right) < 0;
-	if (strcmp(op, "<=") == 0)
-		return mport_version_cmp(left, right) <= 0;
+		result = fnmatch(right_cmp, left, 0) == 0;
+	else if (strcmp(op, "=") == 0)
+		result = strcmp(left, right_cmp) == 0;
+	else if (strcmp(op, "!=") == 0)
+		result = strcmp(left, right_cmp) != 0;
+	else if (strcmp(op, ">") == 0)
+		result = mport_version_cmp(left, right_cmp) > 0;
+	else if (strcmp(op, ">=") == 0)
+		result = mport_version_cmp(left, right_cmp) >= 0;
+	else if (strcmp(op, "<") == 0)
+		result = mport_version_cmp(left, right_cmp) < 0;
+	else if (strcmp(op, "<=") == 0)
+		result = mport_version_cmp(left, right_cmp) <= 0;
+	else
+		result = false;
 
-	return false;
+	free(right_buf);
+	return result;
 }
 
 static char *

--- a/mport/mport.1
+++ b/mport/mport.1
@@ -158,6 +158,13 @@
 .Op Ar package ...
 .Pp
 .Nm
+.Cm query
+.Op Fl aCgix
+.Op Fl e Ar expression
+.Ar format
+.Op Ar pattern ...
+.Pp
+.Nm
 .Cm search
 .Ar query ...
 .Pp
@@ -339,6 +346,128 @@ default.
 .It Cm purl Op Ar package ...
 List Package URL values for installed packages.
 If one or more package names are specified, restrict output to those packages.
+.It Cm query Op Fl aCgix Op Fl e Ar expression Ar format Op Ar pattern ...
+Print installed package metadata using a
+.Fx
+.Nm pkg
+.Cm query Ns -style
+format string.
+With no
+.Ar pattern
+arguments, all installed packages are selected.
+With one or more patterns, package names are matched exactly unless a matching
+mode option is specified.
+.Pp
+The following options are supported:
+.Bl -tag -width ".Fl e Ar expression"
+.It Fl a
+Select all installed packages explicitly.
+.It Fl C
+Use case-sensitive matching.
+.It Fl e Ar expression
+Filter matched packages with a scalar expression.
+The expression language supports field truth checks, equality and inequality,
+glob matching with
+.Ql ~ ,
+version comparisons with
+.Ql < ,
+.Ql <= ,
+.Ql > ,
+and
+.Ql >= ,
+and boolean
+.Ql && ,
+.Ql || ,
+and leading
+.Ql ! .
+.It Fl g
+Treat patterns as shell glob patterns.
+.It Fl i
+Use case-insensitive matching.
+.It Fl x
+Treat patterns as extended regular expressions.
+.El
+.Pp
+The
+.Ar format
+string supports percent fields including
+.Ql \&%n
+for package name,
+.Ql \&%v
+for version,
+.Ql \&%o
+for origin,
+.Ql \&%p
+for prefix,
+.Ql \&%m
+for maintainer annotation,
+.Ql \&%c
+for comment,
+.Ql \&%e
+for description,
+.Ql \&%w
+for WWW annotation,
+.Ql \&%a
+for automatic install flag,
+.Ql \&%k
+for locked flag,
+.Ql \&%t
+for install timestamp,
+.Ql \&%s
+or
+.Ql \&%sb
+for flat size in bytes,
+.Ql \&%sh
+or
+.Ql \&%h
+for human-readable flat size,
+.Ql \&%M
+for package message,
+.Ql \&%X
+for index hash,
+.Ql \&%l
+for license metadata,
+.Ql \&%q
+for target architecture, and
+.Ql \&%P
+for package URL.
+.Pp
+List fields are printed comma-separated:
+.Ql \&%A
+annotations,
+.Ql \&%C
+categories,
+.Ql \&%D
+directories,
+.Ql \&%F
+files,
+.Ql \&%L
+licenses,
+.Ql \&%O
+options,
+.Ql \&%d
+dependencies, and
+.Ql \&%r
+reverse dependencies.
+.Ql \&%#X
+prints the count for a supported list field
+.Ql \&%X ,
+and
+.Ql \&%?X
+prints
+.Ql 1
+when the list is present or
+.Ql 0
+when it is empty.
+.Pp
+The
+.Fx
+.Nm pkg
+.Cm query
+.Fl F
+package-file mode is not supported by
+.Nm
+in this version.
 .It Cm search Ar query ...
 Search package names and descriptions.
 Glob patterns such as
@@ -492,6 +621,12 @@ List packages needing upgrades:
 .Pp
 Show detailed package information:
 .Dl $ mport info gmake
+.Pp
+Print installed package names and versions:
+.Dl $ mport query '%n-%v'
+.Pp
+Print the origin and size for installed packages matching a glob:
+.Dl $ mport query -g '%o %sh' 'gma*'
 .Pp
 Determine which package installed a file:
 .Dl $ mport which /usr/local/bin/curl

--- a/mport/mport.c
+++ b/mport/mport.c
@@ -80,6 +80,7 @@ static int deleteAll(/*@notnull@*/ mportInstance *);
 static int info(/*@notnull@*/ mportInstance *, /*@null@*/ const char *);
 
 static int search(/*@notnull@*/ mportInstance *, /*@null@*/ char **);
+static int query(/*@notnull@*/ mportInstance *, int, /*@notnull@*/ char *[]);
 
 static int stats(/*@notnull@*/ mportInstance *mport);
 
@@ -634,6 +635,9 @@ main(int argc, char *argv[])
 			free(searchQuery[i - 1]);
 		}
 		free(searchQuery);
+	} else if (!strcmp(cmd, "query")) {
+		loadIndex(mport);
+		resultCode = query(mport, argc, argv);
 	} else if (!strcmp(cmd, "shell")) {
 		asprintf(&buf, "%s/%s", "/usr/bin", "sqlite3");
 		flag = strdup("/var/db/mport/master.db");
@@ -860,6 +864,7 @@ usage(void)
 	    "    deleteall                   Remove all installed packages\n\n"
 	    "  Information:\n"
 	    "    search <query>              Search for packages\n"
+	    "    query [-aCgix] [-e expr] <format> [pattern ...]\n"
 	    "    info <package>              Display package information\n"
 	    "    list [updates|prime]        List installed packages\n"
 	    "    which [-qo] <file>          Find which package provides a file\n"
@@ -1010,6 +1015,82 @@ search(/*@notnull@*/ mportInstance *mport, /*@null@*/ char **query)
 	}
 
 	return (0);
+}
+
+static int
+query(/*@notnull@*/ mportInstance *mport, int argc, /*@notnull@*/ char *argv[])
+{
+	mportQueryOptions opts;
+	mportPackageMeta **packs = NULL;
+	const char *format;
+	int ch2;
+	int result;
+
+	memset(&opts, 0, sizeof(opts));
+	opts.case_sensitive = false;
+	opts.match = MPORT_QUERY_MATCH_EXACT;
+
+#if defined(__MidnightBSD__)
+	optreset = 1;
+#endif
+	optind = 1;
+	while ((ch2 = getopt(argc, argv, "aCe:F:gix")) != -1) {
+		switch (ch2) {
+		case 'a':
+			opts.all = true;
+			break;
+		case 'C':
+			opts.case_sensitive = true;
+			break;
+		case 'e':
+			opts.expression = optarg;
+			break;
+		case 'F':
+			warnx("mport query -F is not supported yet");
+			return MPORT_ERR_WARN;
+		case 'g':
+			opts.match = MPORT_QUERY_MATCH_GLOB;
+			break;
+		case 'i':
+			opts.case_sensitive = false;
+			break;
+		case 'x':
+			opts.match = MPORT_QUERY_MATCH_REGEX;
+			break;
+		default:
+			fprintf(stderr,
+			    "Usage: mport query [-aCgix] [-e expression] <format> [pattern ...]\n");
+			return MPORT_ERR_WARN;
+		}
+	}
+
+	if (optind >= argc) {
+		fprintf(
+		    stderr, "Usage: mport query [-aCgix] [-e expression] <format> [pattern ...]\n");
+		return MPORT_ERR_WARN;
+	}
+
+	format = argv[optind++];
+	opts.patterns = &argv[optind];
+	opts.pattern_count = argc - optind;
+	if (opts.pattern_count == 0)
+		opts.all = true;
+
+	result = mport_query_installed(mport, &opts, &packs);
+	if (result != MPORT_OK) {
+		warnx("%s", mport_err_string());
+		return result;
+	}
+
+	if (packs == NULL)
+		return MPORT_OK;
+
+	result = mport_query_print(mport, packs, format, stdout);
+	if (result != MPORT_OK)
+		warnx("%s", mport_err_string());
+
+	mport_pkgmeta_vec_free(packs);
+	return result;
 }
 
 static int

--- a/skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh
+++ b/skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh
@@ -57,8 +57,8 @@ for f in "${staged_c_files[@]}"; do
   [[ -f "$f" ]] || continue
   if grep -Eq '^[[:space:]]*/\* *SPLINT_SKIP_FILE:' "$f"; then
     reason="$(
-      sed -n 's:^[[:space:]]*/\* *SPLINT_SKIP_FILE: *::p' "$f" |
-        sed 's:[[:space:]]*\*/[[:space:]]*$::' |
+      sed -n 's|^[[:space:]]*/\* *SPLINT_SKIP_FILE: *||p' "$f" |
+        sed 's|[[:space:]]*\*/[[:space:]]*$||' |
         head -n 1
     )"
     echo "Skipping $f: $reason" >&2

--- a/tests/mport_pkgmeta_test.c
+++ b/tests/mport_pkgmeta_test.c
@@ -2,6 +2,7 @@
 #include <sys/stat.h>
 
 #include <atf-c.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -9,6 +10,7 @@
 #include "../libmport/mport.h"
 #include "../libmport/mport_private.h"
 
+/* SPLINT_SKIP_FILE: Splint cannot parse/model ATF test macros and fixture setup. */
 /* Splint does not understand ATF's generated test-case wrappers. */
 /*@-boundsread -boundswrite -compdef -compdestroy -dependenttrans -fullinitblock@*/
 /*@-mustfreefresh -noeffect -nullpass -nullret -nullstate -paramuse@*/
@@ -23,6 +25,8 @@ cleanup_test_root(void)
 	(void)unlink(TEST_ROOT "/var/db/mport/master.db-wal");
 	(void)unlink(TEST_ROOT "/var/db/mport/master.db-shm");
 	(void)unlink(TEST_ROOT "/var/db/mport/master.db");
+	(void)unlink(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3/pkg-message");
+	(void)rmdir(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3");
 	(void)rmdir(TEST_ROOT "/var/db/mport/infrastructure");
 	(void)rmdir(TEST_ROOT "/var/db/mport");
 	(void)rmdir(TEST_ROOT "/var/db");
@@ -56,6 +60,20 @@ insert_package(mportInstance *mport, const char *name)
 		"INSERT INTO packages (pkg, version, origin, prefix, lang) VALUES "
 		"(%Q, '1.0', %Q, '/usr/local', '')",
 		name, name));
+}
+
+static void
+insert_query_package(mportInstance *mport, const char *name, const char *version,
+    const char *origin, const char *comment, int automatic, int locked, int64_t flatsize)
+{
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO packages (pkg, version, origin, prefix, lang, options, comment, "
+		"os_release, cpe, locked, deprecated, expiration_date, no_provide_shlib, "
+		"flavor, automatic, install_date, type, flatsize) VALUES "
+		"(%Q, %Q, %Q, '/usr/local', '', 'DOCS=on EXAMPLES=off', %Q, '4.0', '', "
+		"%d, '', 0, 0, '', %d, 1234, 0, %lld)",
+		name, version, origin, comment, locked, automatic, (long long)flatsize));
 }
 
 static int
@@ -174,10 +192,127 @@ ATF_TC_CLEANUP(sort_dependencies_dependent_first, tc)
 	cleanup_test_root();
 }
 
+ATF_TC_WITH_CLEANUP(query_formats_installed_metadata);
+ATF_TC_HEAD(query_formats_installed_metadata, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "query formatter prints installed package metadata");
+}
+ATF_TC_BODY(query_formats_installed_metadata, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta **packs = NULL;
+	mportQueryOptions opts;
+	char *buf = NULL;
+	size_t len = 0;
+	FILE *fp;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	insert_query_package(mport, "alpha", "1.2.3", "devel/alpha", "Alpha package", 0, 1, 4096);
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(
+		mport->db, "INSERT INTO categories (pkg, category) VALUES ('alpha', 'devel')"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO depends (pkg, depend_pkgname, depend_pkgversion, depend_port) "
+		"VALUES ('alpha', 'beta', '1.0', 'devel/beta')"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) VALUES "
+		"('alpha', %d, '/usr/local/bin/alpha', '', '', '', '')",
+		ASSET_FILE));
+	ATF_REQUIRE_EQ(0, mkdir(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3", 0755));
+	int message_fd = open(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3/pkg-message",
+	    O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	ATF_REQUIRE(message_fd >= 0);
+	ssize_t write_result = write(message_fd, "Read alpha notes", strlen("Read alpha notes"));
+	int close_result = close(message_fd);
+	ATF_REQUIRE_EQ((ssize_t)strlen("Read alpha notes"), write_result);
+	ATF_REQUIRE_EQ(0, close_result);
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_annotation_set(mport, "alpha", "maintainer", "ports@MidnightBSD.org"));
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_annotation_set(mport, "alpha", "www", "https://example.test"));
+
+	memset(&opts, 0, sizeof(opts));
+	opts.all = true;
+	opts.case_sensitive = false;
+	opts.match = MPORT_QUERY_MATCH_EXACT;
+	ATF_REQUIRE_EQ(MPORT_OK, mport_query_installed(mport, &opts, &packs));
+	ATF_REQUIRE(packs != NULL);
+
+	fp = open_memstream(&buf, &len);
+	ATF_REQUIRE(fp != NULL);
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_query_print(mport, packs, "%n|%v|%o|%m|%w|%c|%k|%s|%C|%d|%F|%#C|%M", fp));
+	close_result = fclose(fp);
+	fp = NULL;
+	ATF_REQUIRE_EQ(0, close_result);
+
+	ATF_REQUIRE_STREQ("alpha|1.2.3|devel/alpha|ports@MidnightBSD.org|"
+			  "https://example.test|Alpha package|1|4096|devel|beta|"
+			  "/usr/local/bin/alpha|1|Read alpha notes\n",
+	    buf);
+
+	free(buf);
+	mport_pkgmeta_vec_free(packs);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(query_formats_installed_metadata, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(query_filters_patterns_and_expressions);
+ATF_TC_HEAD(query_filters_patterns_and_expressions, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "query filters by pattern and scalar expression");
+}
+ATF_TC_BODY(query_filters_patterns_and_expressions, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta **packs = NULL;
+	mportQueryOptions opts;
+	char *patterns[] = { "alp*" };
+
+	(void)tc;
+
+	mport = create_test_instance();
+	insert_query_package(mport, "alpha", "1.2.3", "devel/alpha", "Alpha package", 0, 0, 4096);
+	insert_query_package(mport, "beta", "0.9", "devel/beta", "Beta package", 1, 0, 1024);
+
+	memset(&opts, 0, sizeof(opts));
+	opts.case_sensitive = false;
+	opts.match = MPORT_QUERY_MATCH_GLOB;
+	opts.patterns = patterns;
+	opts.pattern_count = 1;
+	opts.expression = "%v>=1.0";
+
+	ATF_REQUIRE_EQ(MPORT_OK, mport_query_installed(mport, &opts, &packs));
+	ATF_REQUIRE(packs != NULL);
+	ATF_REQUIRE(packs[0] != NULL);
+	ATF_REQUIRE_STREQ("alpha", packs[0]->name);
+	ATF_REQUIRE(packs[1] == NULL);
+
+	mport_pkgmeta_vec_free(packs);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(query_filters_patterns_and_expressions, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependency_first);
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependent_first);
+	ATF_TP_ADD_TC(tp, query_formats_installed_metadata);
+	ATF_TP_ADD_TC(tp, query_filters_patterns_and_expressions);
 
 	return atf_no_error();
 }

--- a/tests/mport_pkgmeta_test.c
+++ b/tests/mport_pkgmeta_test.c
@@ -276,7 +276,7 @@ ATF_TC_BODY(query_filters_patterns_and_expressions, tc)
 	mportInstance *mport;
 	mportPackageMeta **packs = NULL;
 	mportQueryOptions opts;
-	char *patterns[] = { "alp*" };
+	char *patterns[] = { "*" };
 
 	(void)tc;
 
@@ -289,7 +289,7 @@ ATF_TC_BODY(query_filters_patterns_and_expressions, tc)
 	opts.match = MPORT_QUERY_MATCH_GLOB;
 	opts.patterns = patterns;
 	opts.pattern_count = 1;
-	opts.expression = "%v>=1.0";
+	opts.expression = "%n='alpha'&&%v>=1.0||%n='missing'";
 
 	ATF_REQUIRE_EQ(MPORT_OK, mport_query_installed(mport, &opts, &packs));
 	ATF_REQUIRE(packs != NULL);


### PR DESCRIPTION
## Summary

- add a reusable libmport query API for installed package selection and formatting
- add the `mport query` command with exact, glob, regex, and expression filters
- document the command and libmport interface, plus tests for query metadata output

## Validation

- `make`
- `kyua test -k Kyuafile` from `tests/`: 50/50 passed
- `./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh`
- `./skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh`
- `make -C mport`
- `git diff --cached --check` before commit
- smoke: `mport -U query -g '%n|%o|%sh|%#C' 'gma*'` returned `gmake|devel/gmake|1.5 MiB|1`

## Summary by Sourcery

Add a reusable libmport query API and expose it via a new `mport query` command with pkg-query–style formatting and filtering.

New Features:
- Introduce libmport query APIs for selecting installed packages and formatting their metadata.
- Add a new `mport query` CLI subcommand supporting exact, glob, regex, and expression-based filters with pkg-query–style format strings.

Enhancements:
- Document the new query interfaces and format spec in libmport and mport manpages, plus a standalone specification file.
- Extend tests to cover query metadata formatting and pattern/expression filtering.
- Adjust libmport source formatting and minor scripts to align with style and tooling expectations.

Tests:
- Add ATF tests verifying query output formatting and filter behavior for installed packages.