### PR TITLE
🔒 Fix unsafe strcpy usage in mport_string_replace

### DIFF
--- a/libmport/util.c
+++ b/libmport/util.c
@@ -1396,7 +1396,7 @@ mport_string_replace(const char *str, const char *old, const char *new)
 		memcpy(r, new, newlen);
 		r += newlen;
 	}
-	strcpy(r, p);
+	strlcpy(r, p, (retlen + 1) - (r - ret));
 
 	return (ret);
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Replaced an unsafe `strcpy` with `strlcpy` in `mport_string_replace` function in `libmport/util.c`.

⚠️ **Risk:** The potential impact if left unfixed
The use of `strcpy` is inherently unsafe as it does not bound the copy length. An attacker or unexpected long string could potentially lead to a buffer overflow, which might corrupt memory, crash the process, or allow arbitrary code execution, especially in string replacement utilities.

🛡️ **Solution:** How the fix addresses the vulnerability
The call to `strcpy(r, p)` was replaced with `strlcpy(r, p, (retlen + 1) - (r - ret))`. Since `ret` is dynamically allocated to `retlen + 1`, and `r` is a pointer pointing to some position within `ret`, `(retlen + 1) - (r - ret)` correctly calculates the remaining size of the buffer. `strlcpy` respects this size limit and guarantees null-termination, preventing the potential buffer overflow.

---
*PR created automatically by Jules for task [3239950262956150778](https://jules.google.com/task/3239950262956150778) started by @laffer1*

## Summary by Sourcery

Bug Fixes:
- Guard against buffer overflows in mport_string_replace by using a length-limited string copy instead of an unbounded one.