### PR TITLE
[codex] Track package-created directories

### DIFF
--- a/libmport/Makefile
+++ b/libmport/Makefile
@@ -10,7 +10,7 @@ SRCS=	asset.c bundle_write.c bundle_read.c plist.c color.c create_primative.c db
     	fetch.c index.c index_depends.c install.c clean.c setting.c  \
    		stats.c update.c upgrade.c verify.c lock.c mkdir.c import_export.c \
    		annotation.c autoremove.c audit.c ping.c message.c service.c list.c \
-		query.c lua.c lua_scripts.c age.c
+		query.c lua.c lua_scripts.c age.c mtree.c
 INCS=	mport.h
 
 CFLAGS+=	-I${.CURDIR} -I ../external/tllist/ -I ../external/lua/src/ -I/usr/include/private/ucl -I/usr/include/ucl -I/usr/include/private/zstd

--- a/libmport/bundle_read_install_pkg.c
+++ b/libmport/bundle_read_install_pkg.c
@@ -87,8 +87,8 @@ static int create_sample_file(mportInstance *mport, char *cwd, const char *file)
 
 static int create_dir_asset_fd(mportInstance *, const char *, const char *, mode_t, int *);
 static int apply_dir_asset_attrs(int, mportAssetListEntry *, uid_t, gid_t);
-static int insert_autodir_assets(
-    mportInstance *, sqlite3_stmt *, mportPackageMeta *, mportAssetList *, const char *);
+static int insert_autodir_assets(mportInstance *, sqlite3_stmt *, mportPackageMeta *,
+    mportAssetList *, mportAssetList *, const char *);
 
 static char **parse_sample(char *input);
 
@@ -717,6 +717,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	int filefd = -1;
 	char file[FILENAME_MAX], cwd[FILENAME_MAX];
 	sqlite3_stmt *insert = NULL;
+	mportAssetList *autodirs = NULL;
 
 	/* sadly, we can't just use abs pathnames, because it will break hardlinks */
 	orig_cwd = getcwd(NULL, 0);
@@ -727,6 +728,9 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	mport_call_progress_init_cb(mport, "Installing %s-%s", pkg->name, pkg->version);
 
 	if (mport_bundle_read_get_assetlist(mport, pkg, &alist, ACTUALINSTALL) != MPORT_OK)
+		goto ERROR;
+
+	if ((autodirs = mport_assetlist_new()) == NULL)
 		goto ERROR;
 
 	if (create_package_row(mport, pkg) != MPORT_OK)
@@ -863,7 +867,8 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 				}
 			}
 
-			if (insert_autodir_assets(mport, insert, pkg, alist, file) != MPORT_OK)
+			if (insert_autodir_assets(mport, insert, pkg, alist, autodirs, file) !=
+			    MPORT_OK)
 				goto ERROR;
 
 			/*
@@ -1262,6 +1267,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 	(mport->progress_free_cb)();
 	(void)mport_chdir(NULL, orig_cwd);
 	free(orig_cwd);
+	mport_assetlist_free(autodirs);
 	mport_assetlist_free(alist);
 	return (MPORT_OK);
 
@@ -1271,6 +1277,7 @@ ERROR:
 	sqlite3_finalize(insert);
 	(mport->progress_free_cb)();
 	free(orig_cwd);
+	mport_assetlist_free(autodirs);
 	mport_assetlist_free(alist);
 
 	RETURN_CURRENT_ERROR;
@@ -1347,6 +1354,13 @@ path_under_prefix(const char *path, const char *prefix)
 		return false;
 
 	prefix_len = strlen(prefix);
+	if (prefix_len == 0)
+		return false;
+	while (prefix_len > 1 && prefix[prefix_len - 1] == '/')
+		prefix_len--;
+	if (prefix_len == 1 && prefix[0] == '/')
+		return path[0] == '/' && path[1] != '\0';
+
 	return strncmp(path, prefix, prefix_len) == 0 && path[prefix_len] == '/';
 }
 
@@ -1379,26 +1393,6 @@ asset_list_has_dir(mportAssetList *alist, const char *prefix, const char *dir)
 	return false;
 }
 
-static bool
-asset_db_has_dir(mportInstance *mport, const char *pkgname, const char *dir)
-{
-	sqlite3_stmt *stmt = NULL;
-	int count = 0;
-
-	if (mport_db_prepare(mport->db, &stmt,
-		"SELECT count(*) FROM assets WHERE pkg=%Q and type in (%d, %d, %d, %d, %d) "
-		"and data=%Q",
-		pkgname, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
-		ASSET_AUTODIR, dir) != MPORT_OK)
-		return true;
-
-	if (sqlite3_step(stmt) == SQLITE_ROW)
-		count = sqlite3_column_int(stmt, 0);
-	sqlite3_finalize(stmt);
-
-	return count > 0;
-}
-
 static int
 insert_autodir(mportInstance *mport, sqlite3_stmt *insert, const char *dir)
 {
@@ -1423,18 +1417,42 @@ insert_autodir(mportInstance *mport, sqlite3_stmt *insert, const char *dir)
 }
 
 static int
+autodir_seen_add(mportAssetList *autodirs, const char *dir)
+{
+	mportAssetListEntry *entry;
+
+	entry = calloc(1, sizeof(mportAssetListEntry));
+	if (entry == NULL)
+		return MPORT_ERR_FATAL;
+
+	entry->type = ASSET_AUTODIR;
+	entry->data = strdup(dir);
+	if (entry->data == NULL) {
+		free(entry);
+		return MPORT_ERR_FATAL;
+	}
+
+	STAILQ_INSERT_TAIL(autodirs, entry, next);
+	return MPORT_OK;
+}
+
+static int
 insert_autodir_assets(mportInstance *mport, sqlite3_stmt *insert, mportPackageMeta *pkg,
-    mportAssetList *alist, const char *physical_file)
+    mportAssetList *alist, mportAssetList *autodirs, const char *physical_file)
 {
 	char logical_file[FILENAME_MAX];
 	char dir[FILENAME_MAX];
 	size_t root_len;
+	size_t physical_len;
 
-	if (mport == NULL || pkg == NULL || pkg->prefix == NULL || physical_file == NULL)
+	if (mport == NULL || pkg == NULL || pkg->prefix == NULL || physical_file == NULL ||
+	    autodirs == NULL)
 		return MPORT_OK;
 
 	root_len = strlen(mport->root);
-	if (root_len > 0 && strncmp(physical_file, mport->root, root_len) == 0)
+	physical_len = strlen(physical_file);
+	if (root_len > 0 && physical_len >= root_len &&
+	    strncmp(physical_file, mport->root, root_len) == 0)
 		(void)strlcpy(logical_file, physical_file + root_len, sizeof(logical_file));
 	else
 		(void)strlcpy(logical_file, physical_file, sizeof(logical_file));
@@ -1449,7 +1467,9 @@ insert_autodir_assets(mportInstance *mport, sqlite3_stmt *insert, mportPackageMe
 	while (path_under_prefix(dir, pkg->prefix)) {
 		if (!mport_is_system_mtree_dir(dir) &&
 		    !asset_list_has_dir(alist, pkg->prefix, dir) &&
-		    !asset_db_has_dir(mport, pkg->name, dir)) {
+		    !asset_list_has_dir(autodirs, pkg->prefix, dir)) {
+			if (autodir_seen_add(autodirs, dir) != MPORT_OK)
+				return MPORT_ERR_FATAL;
 			if (insert_autodir(mport, insert, dir) != MPORT_OK)
 				return MPORT_ERR_FATAL;
 		}

--- a/libmport/bundle_read_install_pkg.c
+++ b/libmport/bundle_read_install_pkg.c
@@ -87,6 +87,8 @@ static int create_sample_file(mportInstance *mport, char *cwd, const char *file)
 
 static int create_dir_asset_fd(mportInstance *, const char *, const char *, mode_t, int *);
 static int apply_dir_asset_attrs(int, mportAssetListEntry *, uid_t, gid_t);
+static int insert_autodir_assets(
+    mportInstance *, sqlite3_stmt *, mportPackageMeta *, mportAssetList *, const char *);
 
 static char **parse_sample(char *input);
 
@@ -861,6 +863,9 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 				}
 			}
 
+			if (insert_autodir_assets(mport, insert, pkg, alist, file) != MPORT_OK)
+				goto ERROR;
+
 			/*
 			 * Open the freshly extracted file with O_NOFOLLOW before
 			 * touching its ownership or mode. Operating on the file
@@ -1175,7 +1180,7 @@ do_actual_install(mportInstance *mport, mportBundleRead *bundle, mportPackageMet
 				}
 			}
 		} else if (e->type == ASSET_DIR || e->type == ASSET_DIRRM ||
-		    e->type == ASSET_DIRRMTRY) {
+		    e->type == ASSET_DIRRMTRY || e->type == ASSET_DIR_OWNER_MODE) {
 			/* if data starts with /, it's most likely an absolute path. Don't prepend
 			 * cwd */
 			if (e->data != NULL && e->data[0] == '/')
@@ -1303,6 +1308,155 @@ mark_complete(mportInstance *mport, mportPackageMeta *pkg)
 	}
 
 	return (MPORT_OK);
+}
+
+static void
+normalize_dir_path(char *path)
+{
+	size_t len;
+
+	len = strlen(path);
+	while (len > 1 && path[len - 1] == '/') {
+		path[len - 1] = '\0';
+		len--;
+	}
+}
+
+static void
+parent_dir(char *path)
+{
+	char *slash;
+
+	normalize_dir_path(path);
+	if (strcmp(path, "/") == 0)
+		return;
+
+	slash = strrchr(path, '/');
+	if (slash == NULL || slash == path)
+		(void)strlcpy(path, "/", FILENAME_MAX);
+	else
+		*slash = '\0';
+}
+
+static bool
+path_under_prefix(const char *path, const char *prefix)
+{
+	size_t prefix_len;
+
+	if (path == NULL || prefix == NULL)
+		return false;
+
+	prefix_len = strlen(prefix);
+	return strncmp(path, prefix, prefix_len) == 0 && path[prefix_len] == '/';
+}
+
+static bool
+asset_list_has_dir(mportAssetList *alist, const char *prefix, const char *dir)
+{
+	mportAssetListEntry *asset = NULL;
+
+	STAILQ_FOREACH (asset, alist, next) {
+		char asset_dir[FILENAME_MAX];
+
+		if (asset == NULL)
+			continue;
+		if (asset->data == NULL)
+			continue;
+		if (asset->type != ASSET_DIR && asset->type != ASSET_DIRRM &&
+		    asset->type != ASSET_DIRRMTRY && asset->type != ASSET_DIR_OWNER_MODE &&
+		    asset->type != ASSET_AUTODIR)
+			continue;
+
+		if (asset->data[0] == '/')
+			(void)strlcpy(asset_dir, asset->data, sizeof(asset_dir));
+		else
+			(void)snprintf(asset_dir, sizeof(asset_dir), "%s/%s", prefix, asset->data);
+		normalize_dir_path(asset_dir);
+		if (strcmp(asset_dir, dir) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+static bool
+asset_db_has_dir(mportInstance *mport, const char *pkgname, const char *dir)
+{
+	sqlite3_stmt *stmt = NULL;
+	int count = 0;
+
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT count(*) FROM assets WHERE pkg=%Q and type in (%d, %d, %d, %d, %d) "
+		"and data=%Q",
+		pkgname, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
+		ASSET_AUTODIR, dir) != MPORT_OK)
+		return true;
+
+	if (sqlite3_step(stmt) == SQLITE_ROW)
+		count = sqlite3_column_int(stmt, 0);
+	sqlite3_finalize(stmt);
+
+	return count > 0;
+}
+
+static int
+insert_autodir(mportInstance *mport, sqlite3_stmt *insert, const char *dir)
+{
+	if (sqlite3_bind_int(insert, 1, ASSET_AUTODIR) != SQLITE_OK ||
+	    sqlite3_bind_text(insert, 2, dir, -1, SQLITE_STATIC) != SQLITE_OK ||
+	    sqlite3_bind_null(insert, 3) != SQLITE_OK ||
+	    sqlite3_bind_null(insert, 4) != SQLITE_OK ||
+	    sqlite3_bind_null(insert, 5) != SQLITE_OK ||
+	    sqlite3_bind_null(insert, 6) != SQLITE_OK) {
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		return MPORT_ERR_FATAL;
+	}
+
+	if (sqlite3_step(insert) != SQLITE_DONE) {
+		SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		return MPORT_ERR_FATAL;
+	}
+
+	sqlite3_clear_bindings(insert);
+	sqlite3_reset(insert);
+	return MPORT_OK;
+}
+
+static int
+insert_autodir_assets(mportInstance *mport, sqlite3_stmt *insert, mportPackageMeta *pkg,
+    mportAssetList *alist, const char *physical_file)
+{
+	char logical_file[FILENAME_MAX];
+	char dir[FILENAME_MAX];
+	size_t root_len;
+
+	if (mport == NULL || pkg == NULL || pkg->prefix == NULL || physical_file == NULL)
+		return MPORT_OK;
+
+	root_len = strlen(mport->root);
+	if (root_len > 0 && strncmp(physical_file, mport->root, root_len) == 0)
+		(void)strlcpy(logical_file, physical_file + root_len, sizeof(logical_file));
+	else
+		(void)strlcpy(logical_file, physical_file, sizeof(logical_file));
+
+	normalize_dir_path(logical_file);
+	if (!path_under_prefix(logical_file, pkg->prefix))
+		return MPORT_OK;
+
+	(void)strlcpy(dir, logical_file, sizeof(dir));
+	parent_dir(dir);
+
+	while (path_under_prefix(dir, pkg->prefix)) {
+		if (!mport_is_system_mtree_dir(dir) &&
+		    !asset_list_has_dir(alist, pkg->prefix, dir) &&
+		    !asset_db_has_dir(mport, pkg->name, dir)) {
+			if (insert_autodir(mport, insert, dir) != MPORT_OK)
+				return MPORT_ERR_FATAL;
+		}
+		parent_dir(dir);
+	}
+
+	return MPORT_OK;
 }
 
 static int

--- a/libmport/delete_primative.c
+++ b/libmport/delete_primative.c
@@ -71,39 +71,7 @@ static int run_pkg_deinstall(mportInstance *, mportPackageMeta *, const char *);
 static int delete_pkg_infra(mportInstance *, mportPackageMeta *);
 static int check_for_upwards_depends(mportInstance *, mportPackageMeta *);
 static void warn_ignored_rmdir_error(/*@notnull@*/ mportInstance *, /*@notnull@*/ const char *);
-static bool is_safe_to_delete_dir(mportInstance *, mportPackageMeta *, const char *);
-static bool is_system_dir(const char *path);
-
-static const char *system_dirs[] = {
-	"/boot",
-	_PATH_ETC,
-	"/etc/rc.d",
-	"/root",
-	_PATH_TMP,
-	"/usr/lib",
-	"/usr/bin",
-	"/usr/sbin",
-	_PATH_MAN,
-	_PATH_LOCALE,
-	_PATH_FIRMWARE,
-	"/usr/share",
-	"/usr/local",
-	"/usr/local/bin",
-	"/usr/local/sbin",
-	"/usr/local/share",
-	"/usr/local/lib",
-	"/usr/local/libexec",
-	"/usr/local/include",
-	"/var",
-	"/var/lib",
-	"/var/log",
-	"/var/spool",
-	"/var/empty",
-	_PATH_VARDB,
-	_PATH_VARRUN,
-	_PATH_VARTMP,
-	_PATH_MAILDIR,
-};
+static bool is_safe_to_delete_dir(mportInstance *, mportPackageMeta *, const char *, const char *);
 
 MPORT_PUBLIC_API int
 mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
@@ -167,8 +135,13 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 	if (run_pkg_deinstall(mport, pack, "DEINSTALL") != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
-	if (mport_db_prepare(mport->db, &stmt, "SELECT type,data,checksum FROM assets WHERE pkg=%Q",
-		pack->name) != MPORT_OK)
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT type,data,checksum FROM assets WHERE pkg=%Q "
+		"ORDER BY CASE WHEN type IN (%d, %d, %d, %d, %d) THEN 1 ELSE 0 END, "
+		"CASE WHEN type IN (%d, %d, %d, %d, %d) THEN length(data) ELSE 0 END DESC",
+		pack->name, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
+		ASSET_AUTODIR, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
+		ASSET_AUTODIR) != MPORT_OK)
 		RETURN_CURRENT_ERROR;
 
 	cwd = pack->prefix;
@@ -366,13 +339,16 @@ mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
 		case ASSET_DIR:
 		case ASSET_DIRRM:
 		case ASSET_DIRRMTRY:
+		case ASSET_AUTODIR:
 		case ASSET_DIR_OWNER_MODE:
-			if (is_safe_to_delete_dir(mport, pack, file)) {
+			if (is_safe_to_delete_dir(mport, pack, file, data)) {
 				mport_removeflags(mport->root, file);
-				if (mport_rmdir(file, type == ASSET_DIRRMTRY ? 1 : 0) != MPORT_OK) {
+				if (mport_rmdir(file,
+					type == ASSET_DIRRMTRY || type == ASSET_AUTODIR ? 1 : 0) !=
+				    MPORT_OK) {
 					warn_ignored_rmdir_error(mport, file);
 				}
-			} else if (type != ASSET_DIRRMTRY) {
+			} else if (type != ASSET_DIRRMTRY && type != ASSET_AUTODIR) {
 				mport_call_msg_cb(
 				    mport, "Directory in use by another package? '%s'", file);
 			}
@@ -449,24 +425,14 @@ warn_ignored_rmdir_error(/*@notnull@*/ mportInstance *mport, /*@notnull@*/ const
 	mport_set_err(MPORT_OK, NULL);
 }
 
-static bool
-is_system_dir(const char *path)
-{
-	for (size_t i = 0; i < sizeof(system_dirs) / sizeof(system_dirs[0]); i++) {
-		if (strcmp(path, system_dirs[i]) == 0) {
-			return true;
-		}
-	}
-	return false;
-}
-
 bool
-is_safe_to_delete_dir(mportInstance *mport, mportPackageMeta *pack, const char *path)
+is_safe_to_delete_dir(
+    mportInstance *mport, mportPackageMeta *pack, const char *path, const char *asset_path)
 {
 	sqlite3_stmt *stmt;
 	int count;
 
-	if (mport == NULL || pack == NULL || path == NULL) {
+	if (mport == NULL || pack == NULL || path == NULL || asset_path == NULL) {
 		return false;
 	}
 
@@ -476,22 +442,23 @@ is_safe_to_delete_dir(mportInstance *mport, mportPackageMeta *pack, const char *
 		    mport, "Skipping removal of root (DESTDIR) directory: '%s'", path);
 		return false;
 	}
-	if (pack->prefix != NULL && strcmp(pack->prefix, path) == 0) {
+	if (pack->prefix != NULL &&
+	    (strcmp(pack->prefix, path) == 0 || strcmp(pack->prefix, asset_path) == 0)) {
 		mport_call_msg_cb(
 		    mport, "Skipping removal of package prefix directory: '%s'", path);
 		return false;
 	}
 
 	/* Check if the path is a system directory */
-	if (pack->type == MPORT_TYPE_APP && is_system_dir(path)) {
+	if (pack->type == MPORT_TYPE_APP && mport_is_system_mtree_dir(asset_path)) {
 		mport_call_msg_cb(mport, "Skipping removal of system directory: '%s'", path);
 		return false;
 	}
 
 	if (mport_db_prepare(mport->db, &stmt,
-		"SELECT count(*) from assets where pkg!=%Q and type in (%d, %d, %d, %d) and data=%Q",
+		"SELECT count(*) from assets where pkg!=%Q and type in (%d, %d, %d, %d, %d) and data=%Q",
 		pack->name, ASSET_DIR, ASSET_DIRRM, ASSET_DIRRMTRY, ASSET_DIR_OWNER_MODE,
-		path) != MPORT_OK) {
+		ASSET_AUTODIR, asset_path) != MPORT_OK) {
 		return false;
 	}
 

--- a/libmport/mport.h
+++ b/libmport/mport.h
@@ -163,7 +163,8 @@ enum _AssetListEntryType {
 	ASSET_KLD,
 	ASSET_DESKTOP_FILE_UTILS,
 	ASSET_INFO,
-	ASSET_TOUCH
+	ASSET_TOUCH,
+	ASSET_AUTODIR
 };
 
 typedef enum _AssetListEntryType mportAssetListEntryType;

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -119,6 +119,7 @@ int mport_mkdir(const char *);
 int mport_mkdirp(char *, mode_t);
 int mport_removeflags(const char *, const char *);
 int mport_rmdir(const char *, int);
+bool mport_is_system_mtree_dir(const char *);
 int mport_chdir(mportInstance *, const char *);
 int mport_xsystem(mportInstance *, const char *, ...);
 int mport_exec_linux_ldconfig(mportInstance *, const char *);

--- a/libmport/mtree.c
+++ b/libmport/mtree.c
@@ -58,6 +58,20 @@ static const char *fallback_system_dirs[] = {
 	_PATH_MAILDIR,
 };
 
+static const char *
+mtree_dir_path(void)
+{
+	const char *mtree_dir;
+
+	mtree_dir = getenv("MPORT_MTREE_DIR");
+	/*@-boundsread@*/
+	if (mtree_dir == NULL || *mtree_dir == '\0')
+		mtree_dir = "/etc/mtree";
+	/*@=boundsread@*/
+
+	return mtree_dir;
+}
+
 static /*@observer@*/ /*@null@*/ const char *
 mtree_root_for_file(const char *filename)
 {
@@ -144,8 +158,6 @@ list_add(mtree_dir_list *list, const char *path)
 	/*@-boundswrite@*/
 	list->items[list->count] = copy;
 	/*@=boundswrite@*/
-	if (list->items[list->count] == NULL)
-		return MPORT_ERR_FATAL;
 	list->count++;
 
 	return MPORT_OK;
@@ -282,11 +294,7 @@ load_mtree_dirs(mtree_dir_list *list)
 	struct dirent *de;
 	int loaded = 0;
 
-	mtree_dir = getenv("MPORT_MTREE_DIR");
-	/*@-boundsread@*/
-	if (mtree_dir == NULL || *mtree_dir == '\0')
-		mtree_dir = "/etc/mtree";
-	/*@=boundsread@*/
+	mtree_dir = mtree_dir_path();
 
 	dir = opendir(mtree_dir);
 	if (dir == NULL)
@@ -326,26 +334,37 @@ is_fallback_system_dir(const char *path)
 bool
 mport_is_system_mtree_dir(const char *path)
 {
-	mtree_dir_list list = { NULL, 0, 0 };
+	static mtree_dir_list list = { NULL, 0, 0 };
+	static bool loaded = false;
+	static bool using_fallback = false;
+	static char cached_mtree_dir[MAXPATHLEN];
 	char normalized[MAXPATHLEN];
-	bool protected;
+	const char *current_mtree_dir;
 
 	if (path == NULL)
 		return false;
 
+	current_mtree_dir = mtree_dir_path();
+	if (loaded && strcmp(cached_mtree_dir, current_mtree_dir) != 0) {
+		list_free(&list);
+		loaded = false;
+		using_fallback = false;
+	}
+
 	(void)strlcpy(normalized, path, sizeof(normalized));
 	normalize_path(normalized);
 
-	if (load_mtree_dirs(&list) != MPORT_OK) {
-		/*@-compdestroy@*/
-		list_free(&list);
-		/*@=compdestroy@*/
-		return is_fallback_system_dir(normalized);
+	if (!loaded) {
+		(void)strlcpy(cached_mtree_dir, current_mtree_dir, sizeof(cached_mtree_dir));
+		if (load_mtree_dirs(&list) != MPORT_OK) {
+			list_free(&list);
+			using_fallback = true;
+		}
+		loaded = true;
 	}
 
-	protected = list_contains(&list, normalized);
-	/*@-compdestroy@*/
-	list_free(&list);
-	/*@=compdestroy@*/
-	return protected;
+	if (using_fallback)
+		return is_fallback_system_dir(normalized);
+
+	return list_contains(&list, normalized);
 }

--- a/libmport/mtree.c
+++ b/libmport/mtree.c
@@ -1,0 +1,351 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2026 Lucas Holt
+ */
+
+#include <sys/cdefs.h>
+#include <sys/param.h>
+
+#include <ctype.h>
+#include <dirent.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mport.h"
+#include "mport_private.h"
+
+/* Splint does not model mtree_dir_list's growable buffer or BSD string APIs well. */
+/*@-boundsread -boundswrite -branchstate -compdef -compmempass -matchanyintegral@*/
+/*@-nullstate -unqualifiedtrans -unrecog -usereleased@*/
+
+typedef struct {
+	char **items;
+	size_t count;
+	size_t cap;
+} mtree_dir_list;
+
+static const char *fallback_system_dirs[] = {
+	"/boot",
+	_PATH_ETC,
+	"/etc/rc.d",
+	"/root",
+	_PATH_TMP,
+	"/usr/lib",
+	"/usr/bin",
+	"/usr/sbin",
+	_PATH_MAN,
+	_PATH_LOCALE,
+	_PATH_FIRMWARE,
+	"/usr/share",
+	"/usr/local",
+	"/usr/local/bin",
+	"/usr/local/sbin",
+	"/usr/local/share",
+	"/usr/local/lib",
+	"/usr/local/libexec",
+	"/usr/local/include",
+	"/var",
+	"/var/lib",
+	"/var/log",
+	"/var/spool",
+	"/var/empty",
+	_PATH_VARDB,
+	_PATH_VARRUN,
+	_PATH_VARTMP,
+	_PATH_MAILDIR,
+};
+
+static /*@observer@*/ /*@null@*/ const char *
+mtree_root_for_file(const char *filename)
+{
+	if (strcmp(filename, "BSD.root.dist") == 0 || strcmp(filename, "BSD.sendmail.dist") == 0)
+		return "/";
+	if (strcmp(filename, "BSD.var.dist") == 0)
+		return "/var";
+	if (strcmp(filename, "BSD.local.dist") == 0)
+		return "/usr/local";
+	if (strcmp(filename, "BSD.usr.dist") == 0 || strcmp(filename, "BSD.include.dist") == 0 ||
+	    strcmp(filename, "BSD.lib32.dist") == 0 || strcmp(filename, "BSD.debug.dist") == 0 ||
+	    strcmp(filename, "BSD.tests.dist") == 0 ||
+	    strncmp(filename, "BSD.x11", strlen("BSD.x11")) == 0)
+		return "/usr";
+
+	return NULL;
+}
+
+static void
+normalize_path(char *path)
+{
+	size_t len;
+
+	if (path == NULL)
+		return;
+
+	len = strlen(path);
+	while (len > 1 && path[len - 1] == '/') {
+		/*@-boundswrite@*/
+		path[len - 1] = '\0';
+		/*@=boundswrite@*/
+		len--;
+	}
+}
+
+static bool
+list_contains(const mtree_dir_list *list, const char *path)
+{
+	size_t i;
+
+	if (list == NULL || path == NULL)
+		return false;
+
+	for (i = 0; i < list->count; i++) {
+		/*@-boundsread@*/
+		if (strcmp(list->items[i], path) == 0)
+			return true;
+		/*@=boundsread@*/
+	}
+
+	return false;
+}
+
+static int
+list_add(mtree_dir_list *list, const char *path)
+{
+	char **items;
+	char *copy;
+	size_t pathlen;
+
+	if (list_contains(list, path))
+		return MPORT_OK;
+
+	if (list->count == list->cap) {
+		size_t newcap;
+
+		if (list->cap == 0)
+			newcap = 32;
+		else
+			newcap = list->cap * 2;
+		items = realloc(list->items, newcap * sizeof(char *));
+		if (items == NULL)
+			return MPORT_ERR_FATAL;
+		list->items = items;
+		list->cap = newcap;
+	}
+
+	pathlen = strlen(path) + 1;
+	copy = malloc(pathlen);
+	if (copy == NULL)
+		return MPORT_ERR_FATAL;
+	(void)strlcpy(copy, path, pathlen);
+
+	/*@-boundswrite@*/
+	list->items[list->count] = copy;
+	/*@=boundswrite@*/
+	if (list->items[list->count] == NULL)
+		return MPORT_ERR_FATAL;
+	list->count++;
+
+	return MPORT_OK;
+}
+
+static void
+list_free(mtree_dir_list *list)
+{
+	size_t i;
+
+	for (i = 0; i < list->count; i++) {
+		/*@-boundsread -unqualifiedtrans@*/
+		free(list->items[i]);
+		/*@=boundsread =unqualifiedtrans@*/
+	}
+	free(list->items);
+	list->items = NULL;
+	list->count = 0;
+	list->cap = 0;
+}
+
+static void
+path_pop(char *path)
+{
+	char *slash;
+
+	normalize_path(path);
+	if (strcmp(path, "/") == 0)
+		return;
+
+	slash = strrchr(path, '/');
+	if (slash == NULL || slash == path)
+		(void)strlcpy(path, "/", MAXPATHLEN);
+	else
+		*slash = '\0';
+}
+
+static void
+path_append(char *out, size_t outsz, const char *base, const char *entry)
+{
+	const char *name = entry;
+
+	/*@-boundsread@*/
+	while (name[0] == '.' && name[1] == '/')
+		name += 2;
+	while (*name == '/')
+		name++;
+	/*@=boundsread@*/
+
+	if (*name == '\0') {
+		(void)strlcpy(out, base, outsz);
+		normalize_path(out);
+		return;
+	}
+
+	if (strcmp(base, "/") == 0)
+		(void)snprintf(out, outsz, "/%s", name);
+	else {
+		/*@-boundswrite@*/
+		(void)snprintf(out, outsz, "%s/%s", base, name);
+		/*@=boundswrite@*/
+	}
+	normalize_path(out);
+}
+
+static int
+parse_mtree_file(const char *path, const char *root, mtree_dir_list *list)
+{
+	FILE *fp;
+	char line[MAXPATHLEN * 2];
+	char cwd[MAXPATHLEN];
+
+	fp = fopen(path, "re");
+	if (fp == NULL)
+		return MPORT_ERR_FATAL;
+
+	(void)strlcpy(cwd, root, sizeof(cwd));
+	normalize_path(cwd);
+	if (list_add(list, cwd) != MPORT_OK) {
+		(void)fclose(fp);
+		return MPORT_ERR_FATAL;
+	}
+
+	/*@-matchanyintegral@*/
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		/*@=matchanyintegral@*/
+		char *token;
+		char *p = line;
+		char child[MAXPATHLEN];
+
+		while (isspace((unsigned char)*p))
+			p++;
+		if (*p == '\0' || *p == '#')
+			continue;
+		if (strncmp(p, "/set", 4) == 0 || strncmp(p, "/unset", 6) == 0)
+			continue;
+
+		token = strsep(&p, " \t\r\n");
+		/*@-boundsread@*/
+		if (token == NULL || *token == '\0')
+			continue;
+		/*@=boundsread@*/
+		if (strcmp(token, ".") == 0) {
+			(void)strlcpy(cwd, root, sizeof(cwd));
+			normalize_path(cwd);
+			(void)list_add(list, cwd);
+			continue;
+		}
+		if (strcmp(token, "..") == 0) {
+			path_pop(cwd);
+			continue;
+		}
+
+		if (strchr(token, '/') != NULL)
+			path_append(child, sizeof(child), root, token);
+		else
+			path_append(child, sizeof(child), cwd, token);
+		if (list_add(list, child) != MPORT_OK) {
+			(void)fclose(fp);
+			return MPORT_ERR_FATAL;
+		}
+		(void)strlcpy(cwd, child, sizeof(cwd));
+	}
+
+	(void)fclose(fp);
+	return MPORT_OK;
+}
+
+static int
+load_mtree_dirs(mtree_dir_list *list)
+{
+	const char *mtree_dir;
+	DIR *dir;
+	struct dirent *de;
+	int loaded = 0;
+
+	mtree_dir = getenv("MPORT_MTREE_DIR");
+	/*@-boundsread@*/
+	if (mtree_dir == NULL || *mtree_dir == '\0')
+		mtree_dir = "/etc/mtree";
+	/*@=boundsread@*/
+
+	dir = opendir(mtree_dir);
+	if (dir == NULL)
+		return MPORT_ERR_FATAL;
+
+	while ((de = readdir(dir)) != NULL) {
+		const char *root = mtree_root_for_file(de->d_name);
+		char path[MAXPATHLEN];
+
+		if (root == NULL)
+			continue;
+
+		(void)snprintf(path, sizeof(path), "%s/%s", mtree_dir, de->d_name);
+		if (parse_mtree_file(path, root, list) == MPORT_OK)
+			loaded++;
+	}
+
+	(void)closedir(dir);
+	return loaded > 0 ? MPORT_OK : MPORT_ERR_FATAL;
+}
+
+static bool
+is_fallback_system_dir(const char *path)
+{
+	size_t i;
+
+	for (i = 0; i < sizeof(fallback_system_dirs) / sizeof(fallback_system_dirs[0]); i++) {
+		/*@-boundsread@*/
+		if (strcmp(path, fallback_system_dirs[i]) == 0)
+			return true;
+		/*@=boundsread@*/
+	}
+
+	return false;
+}
+
+bool
+mport_is_system_mtree_dir(const char *path)
+{
+	mtree_dir_list list = { NULL, 0, 0 };
+	char normalized[MAXPATHLEN];
+	bool protected;
+
+	if (path == NULL)
+		return false;
+
+	(void)strlcpy(normalized, path, sizeof(normalized));
+	normalize_path(normalized);
+
+	if (load_mtree_dirs(&list) != MPORT_OK) {
+		/*@-compdestroy@*/
+		list_free(&list);
+		/*@=compdestroy@*/
+		return is_fallback_system_dir(normalized);
+	}
+
+	protected = list_contains(&list, normalized);
+	/*@-compdestroy@*/
+	list_free(&list);
+	/*@=compdestroy@*/
+	return protected;
+}

--- a/tests/mport_pkgmeta_test.c
+++ b/tests/mport_pkgmeta_test.c
@@ -3,6 +3,8 @@
 
 #include <atf-c.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -16,8 +18,22 @@
 /*@-mustfreefresh -noeffect -nullpass -nullret -nullstate -paramuse@*/
 /*@-retvalint -retvalother -type -unrecog@*/
 
-#define TEST_ROOT "/tmp/mport-pkgmeta-test-root"
+#define TEST_ROOT_TEMPLATE "/tmp/mport-pkgmeta-test-root.XXXXXX"
 #define SORT_TEST_PACKAGE_COUNT 4
+
+static char test_root[PATH_MAX];
+
+static const char *
+test_path(const char *suffix)
+{
+	static char paths[8][PATH_MAX];
+	static unsigned int next_path;
+	char *path;
+
+	path = paths[next_path++ % 8];
+	(void)snprintf(path, PATH_MAX, "%s%s", test_root, suffix);
+	return path;
+}
 
 static void
 cleanup_test_root(void)
@@ -25,12 +41,13 @@ cleanup_test_root(void)
 	int cwd_fd;
 
 	cwd_fd = open(".", O_RDONLY | O_DIRECTORY);
-	if (access(TEST_ROOT, F_OK) == 0)
-		(void)mport_rmtree(TEST_ROOT);
+	if (test_root[0] != '\0' && access(test_root, F_OK) == 0)
+		(void)mport_rmtree(test_root);
 	if (cwd_fd >= 0) {
 		(void)fchdir(cwd_fd);
 		(void)close(cwd_fd);
 	}
+	test_root[0] = '\0';
 	(void)unsetenv("MPORT_MTREE_DIR");
 }
 
@@ -40,14 +57,15 @@ create_test_instance(void)
 	mportInstance *mport;
 
 	cleanup_test_root();
-	ATF_REQUIRE_EQ(0, mkdir(TEST_ROOT, 0755));
-	ATF_REQUIRE_EQ(0, mkdir(TEST_ROOT "/var", 0755));
-	ATF_REQUIRE_EQ(0, mkdir(TEST_ROOT "/var/db", 0755));
+	(void)strlcpy(test_root, TEST_ROOT_TEMPLATE, sizeof(test_root));
+	ATF_REQUIRE(mkdtemp(test_root) != NULL);
+	ATF_REQUIRE_EQ(0, mkdir(test_path("/var"), 0755));
+	ATF_REQUIRE_EQ(0, mkdir(test_path("/var/db"), 0755));
 
 	mport = mport_instance_new();
 	ATF_REQUIRE(mport != NULL);
 	ATF_REQUIRE_EQ(
-	    MPORT_OK, mport_instance_init(mport, TEST_ROOT, "root", false, MPORT_VQUIET));
+	    MPORT_OK, mport_instance_init(mport, test_root, "root", false, MPORT_VQUIET));
 
 	return mport;
 }
@@ -122,9 +140,9 @@ insert_delete_package(mportInstance *mport, const char *name)
 static void
 create_local_prefix_dirs(void)
 {
-	create_dir(TEST_ROOT "/usr");
-	create_dir(TEST_ROOT "/usr/local");
-	create_dir(TEST_ROOT "/usr/local/share");
+	create_dir(test_path("/usr"));
+	create_dir(test_path("/usr/local"));
+	create_dir(test_path("/usr/local/share"));
 }
 
 ATF_TC_WITH_CLEANUP(delete_removes_autodirs);
@@ -141,9 +159,9 @@ ATF_TC_BODY(delete_removes_autodirs, tc)
 
 	mport = create_test_instance();
 	create_local_prefix_dirs();
-	create_dir(TEST_ROOT "/usr/local/share/alpha");
-	create_dir(TEST_ROOT "/usr/local/share/alpha/nested");
-	create_file(TEST_ROOT "/usr/local/share/alpha/nested/file");
+	create_dir(test_path("/usr/local/share/alpha"));
+	create_dir(test_path("/usr/local/share/alpha/nested"));
+	create_file(test_path("/usr/local/share/alpha/nested/file"));
 	insert_delete_package(mport, "alpha");
 	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/alpha/nested/file");
 	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/alpha/nested");
@@ -152,13 +170,55 @@ ATF_TC_BODY(delete_removes_autodirs, tc)
 	pack = create_delete_pack("alpha");
 	ATF_REQUIRE_MSG(
 	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
-	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/alpha", F_OK));
-	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/share", F_OK));
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/alpha"), F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/share"), F_OK));
 
 	mport_pkgmeta_free(pack);
 	mport_instance_free(mport);
 }
 ATF_TC_CLEANUP(delete_removes_autodirs, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(delete_keeps_nonempty_autodirs);
+ATF_TC_HEAD(delete_keeps_nonempty_autodirs, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "delete succeeds while preserving non-empty auto directories");
+}
+ATF_TC_BODY(delete_keeps_nonempty_autodirs, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(test_path("/usr/local/share/alpha"));
+	create_dir(test_path("/usr/local/share/alpha/nested"));
+	create_file(test_path("/usr/local/share/alpha/nested/file"));
+	create_file(test_path("/usr/local/share/alpha/nested/untracked"));
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/alpha/nested/file");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/alpha/nested");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/alpha");
+
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/alpha/nested/file"), F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/share/alpha/nested/untracked"), F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/share/alpha/nested"), F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/share/alpha"), F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(delete_keeps_nonempty_autodirs, tc)
 {
 	(void)tc;
 
@@ -181,11 +241,11 @@ ATF_TC_BODY(delete_keeps_shared_autodirs, tc)
 
 	mport = create_test_instance();
 	create_local_prefix_dirs();
-	create_dir(TEST_ROOT "/usr/local/share/shared");
-	create_dir(TEST_ROOT "/usr/local/share/shared/alpha");
-	create_dir(TEST_ROOT "/usr/local/share/shared/beta");
-	create_file(TEST_ROOT "/usr/local/share/shared/alpha/file");
-	create_file(TEST_ROOT "/usr/local/share/shared/beta/file");
+	create_dir(test_path("/usr/local/share/shared"));
+	create_dir(test_path("/usr/local/share/shared/alpha"));
+	create_dir(test_path("/usr/local/share/shared/beta"));
+	create_file(test_path("/usr/local/share/shared/alpha/file"));
+	create_file(test_path("/usr/local/share/shared/beta/file"));
 	insert_delete_package(mport, "alpha");
 	insert_delete_package(mport, "beta");
 	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/shared/alpha/file");
@@ -199,12 +259,12 @@ ATF_TC_BODY(delete_keeps_shared_autodirs, tc)
 	beta = create_delete_pack("beta");
 	ATF_REQUIRE_MSG(
 	    mport_delete_primative(mport, alpha, 1) == MPORT_OK, "%s", mport_err_string());
-	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/shared/alpha", F_OK));
-	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/share/shared", F_OK));
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/shared/alpha"), F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/share/shared"), F_OK));
 
 	ATF_REQUIRE_MSG(
 	    mport_delete_primative(mport, beta, 1) == MPORT_OK, "%s", mport_err_string());
-	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/shared", F_OK));
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/shared"), F_OK));
 
 	mport_pkgmeta_free(alpha);
 	mport_pkgmeta_free(beta);
@@ -231,8 +291,8 @@ ATF_TC_BODY(delete_explicit_dirrmtry_still_removes, tc)
 
 	mport = create_test_instance();
 	create_local_prefix_dirs();
-	create_dir(TEST_ROOT "/usr/local/share/explicit");
-	create_file(TEST_ROOT "/usr/local/share/explicit/file");
+	create_dir(test_path("/usr/local/share/explicit"));
+	create_file(test_path("/usr/local/share/explicit/file"));
 	insert_delete_package(mport, "alpha");
 	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/explicit/file");
 	insert_asset(mport, "alpha", ASSET_DIRRMTRY, "/usr/local/share/explicit");
@@ -240,7 +300,7 @@ ATF_TC_BODY(delete_explicit_dirrmtry_still_removes, tc)
 	pack = create_delete_pack("alpha");
 	ATF_REQUIRE_MSG(
 	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
-	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/explicit", F_OK));
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/explicit"), F_OK));
 
 	mport_pkgmeta_free(pack);
 	mport_instance_free(mport);
@@ -267,15 +327,15 @@ ATF_TC_BODY(mtree_fixture_protects_system_dirs, tc)
 
 	mport = create_test_instance();
 	create_local_prefix_dirs();
-	create_dir(TEST_ROOT "/mtree");
-	fd = open(TEST_ROOT "/mtree/BSD.local.dist", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	create_dir(test_path("/mtree"));
+	fd = open(test_path("/mtree/BSD.local.dist"), O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	ATF_REQUIRE(fd >= 0);
 	const char mtree[] = ".\n/set type=dir\nbin\n..\nshare\n..\n";
 	ATF_REQUIRE_EQ((ssize_t)strlen(mtree), write(fd, mtree, strlen(mtree)));
 	ATF_REQUIRE_EQ(0, close(fd));
-	ATF_REQUIRE_EQ(0, setenv("MPORT_MTREE_DIR", TEST_ROOT "/mtree", 1));
-	create_dir(TEST_ROOT "/usr/local/bin");
-	create_file(TEST_ROOT "/usr/local/bin/tool");
+	ATF_REQUIRE_EQ(0, setenv("MPORT_MTREE_DIR", test_path("/mtree"), 1));
+	create_dir(test_path("/usr/local/bin"));
+	create_file(test_path("/usr/local/bin/tool"));
 	insert_delete_package(mport, "alpha");
 	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/bin/tool");
 	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/bin");
@@ -284,12 +344,49 @@ ATF_TC_BODY(mtree_fixture_protects_system_dirs, tc)
 	pack = create_delete_pack("alpha");
 	ATF_REQUIRE_MSG(
 	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
-	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/bin", F_OK));
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/bin"), F_OK));
 
 	mport_pkgmeta_free(pack);
 	mport_instance_free(mport);
 }
 ATF_TC_CLEANUP(mtree_fixture_protects_system_dirs, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(mtree_fallback_protects_system_dirs);
+ATF_TC_HEAD(mtree_fallback_protects_system_dirs, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mtree fallback protects system directories");
+}
+ATF_TC_BODY(mtree_fallback_protects_system_dirs, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	ATF_REQUIRE_EQ(0, setenv("MPORT_MTREE_DIR", test_path("/missing-mtree"), 1));
+	create_dir(test_path("/usr/local/bin"));
+	create_file(test_path("/usr/local/bin/tool"));
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/bin/tool");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/bin");
+
+	ATF_REQUIRE(mport_is_system_mtree_dir("/usr/local/bin"));
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(0, access(test_path("/usr/local/bin"), F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(mtree_fallback_protects_system_dirs, tc)
 {
 	(void)tc;
 
@@ -456,8 +553,8 @@ ATF_TC_BODY(query_formats_installed_metadata, tc)
 		"INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) VALUES "
 		"('alpha', %d, '/usr/local/bin/alpha', '', '', '', '')",
 		ASSET_FILE));
-	ATF_REQUIRE_EQ(0, mkdir(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3", 0755));
-	int message_fd = open(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3/pkg-message",
+	ATF_REQUIRE_EQ(0, mkdir(test_path("/var/db/mport/infrastructure/alpha-1.2.3"), 0755));
+	int message_fd = open(test_path("/var/db/mport/infrastructure/alpha-1.2.3/pkg-message"),
 	    O_WRONLY | O_CREAT | O_TRUNC, 0644);
 	ATF_REQUIRE(message_fd >= 0);
 	ssize_t write_result = write(message_fd, "Read alpha notes", strlen("Read alpha notes"));
@@ -546,9 +643,11 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependency_first);
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependent_first);
 	ATF_TP_ADD_TC(tp, delete_removes_autodirs);
+	ATF_TP_ADD_TC(tp, delete_keeps_nonempty_autodirs);
 	ATF_TP_ADD_TC(tp, delete_keeps_shared_autodirs);
 	ATF_TP_ADD_TC(tp, delete_explicit_dirrmtry_still_removes);
 	ATF_TP_ADD_TC(tp, mtree_fixture_protects_system_dirs);
+	ATF_TP_ADD_TC(tp, mtree_fallback_protects_system_dirs);
 	ATF_TP_ADD_TC(tp, query_formats_installed_metadata);
 	ATF_TP_ADD_TC(tp, query_filters_patterns_and_expressions);
 

--- a/tests/mport_pkgmeta_test.c
+++ b/tests/mport_pkgmeta_test.c
@@ -16,22 +16,22 @@
 /*@-mustfreefresh -noeffect -nullpass -nullret -nullstate -paramuse@*/
 /*@-retvalint -retvalother -type -unrecog@*/
 
-#define TEST_ROOT "test-pkgmeta-root"
+#define TEST_ROOT "/tmp/mport-pkgmeta-test-root"
 #define SORT_TEST_PACKAGE_COUNT 4
 
 static void
 cleanup_test_root(void)
 {
-	(void)unlink(TEST_ROOT "/var/db/mport/master.db-wal");
-	(void)unlink(TEST_ROOT "/var/db/mport/master.db-shm");
-	(void)unlink(TEST_ROOT "/var/db/mport/master.db");
-	(void)unlink(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3/pkg-message");
-	(void)rmdir(TEST_ROOT "/var/db/mport/infrastructure/alpha-1.2.3");
-	(void)rmdir(TEST_ROOT "/var/db/mport/infrastructure");
-	(void)rmdir(TEST_ROOT "/var/db/mport");
-	(void)rmdir(TEST_ROOT "/var/db");
-	(void)rmdir(TEST_ROOT "/var");
-	(void)rmdir(TEST_ROOT);
+	int cwd_fd;
+
+	cwd_fd = open(".", O_RDONLY | O_DIRECTORY);
+	if (access(TEST_ROOT, F_OK) == 0)
+		(void)mport_rmtree(TEST_ROOT);
+	if (cwd_fd >= 0) {
+		(void)fchdir(cwd_fd);
+		(void)close(cwd_fd);
+	}
+	(void)unsetenv("MPORT_MTREE_DIR");
 }
 
 static mportInstance *
@@ -60,6 +60,240 @@ insert_package(mportInstance *mport, const char *name)
 		"INSERT INTO packages (pkg, version, origin, prefix, lang) VALUES "
 		"(%Q, '1.0', %Q, '/usr/local', '')",
 		name, name));
+}
+
+static void
+create_dir(const char *path)
+{
+	ATF_REQUIRE_EQ(0, mkdir(path, 0755));
+}
+
+static void
+create_file(const char *path)
+{
+	int fd;
+	ssize_t written;
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	ATF_REQUIRE(fd >= 0);
+	written = write(fd, "x", 1);
+	ATF_REQUIRE_EQ(1, written);
+	ATF_REQUIRE_EQ(0, close(fd));
+}
+
+static mportPackageMeta *
+create_delete_pack(const char *name)
+{
+	mportPackageMeta *pack;
+
+	pack = mport_pkgmeta_new();
+	ATF_REQUIRE(pack != NULL);
+	pack->name = strdup(name);
+	pack->version = strdup("1.0");
+	pack->prefix = strdup("/usr/local");
+	pack->origin = strdup(name);
+	pack->lang = strdup("");
+	pack->type = MPORT_TYPE_APP;
+	ATF_REQUIRE(pack->name != NULL);
+	ATF_REQUIRE(pack->version != NULL);
+	ATF_REQUIRE(pack->prefix != NULL);
+	ATF_REQUIRE(pack->origin != NULL);
+	ATF_REQUIRE(pack->lang != NULL);
+
+	return pack;
+}
+
+static void
+insert_asset(mportInstance *mport, const char *pkg, mportAssetListEntryType type, const char *data)
+{
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO assets (pkg, type, data, checksum, owner, grp, mode) "
+		"VALUES (%Q, %d, %Q, '', NULL, NULL, NULL)",
+		pkg, type, data));
+}
+
+static void
+insert_delete_package(mportInstance *mport, const char *name)
+{
+	insert_package(mport, name);
+}
+
+static void
+create_local_prefix_dirs(void)
+{
+	create_dir(TEST_ROOT "/usr");
+	create_dir(TEST_ROOT "/usr/local");
+	create_dir(TEST_ROOT "/usr/local/share");
+}
+
+ATF_TC_WITH_CLEANUP(delete_removes_autodirs);
+ATF_TC_HEAD(delete_removes_autodirs, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "delete removes empty package-created auto directories");
+}
+ATF_TC_BODY(delete_removes_autodirs, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(TEST_ROOT "/usr/local/share/alpha");
+	create_dir(TEST_ROOT "/usr/local/share/alpha/nested");
+	create_file(TEST_ROOT "/usr/local/share/alpha/nested/file");
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/alpha/nested/file");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/alpha/nested");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/alpha");
+
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/alpha", F_OK));
+	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/share", F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(delete_removes_autodirs, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(delete_keeps_shared_autodirs);
+ATF_TC_HEAD(delete_keeps_shared_autodirs, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "delete keeps auto directories still tracked by another package");
+}
+ATF_TC_BODY(delete_keeps_shared_autodirs, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *alpha;
+	mportPackageMeta *beta;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(TEST_ROOT "/usr/local/share/shared");
+	create_dir(TEST_ROOT "/usr/local/share/shared/alpha");
+	create_dir(TEST_ROOT "/usr/local/share/shared/beta");
+	create_file(TEST_ROOT "/usr/local/share/shared/alpha/file");
+	create_file(TEST_ROOT "/usr/local/share/shared/beta/file");
+	insert_delete_package(mport, "alpha");
+	insert_delete_package(mport, "beta");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/shared/alpha/file");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/shared/alpha");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/share/shared");
+	insert_asset(mport, "beta", ASSET_FILE, "/usr/local/share/shared/beta/file");
+	insert_asset(mport, "beta", ASSET_AUTODIR, "/usr/local/share/shared/beta");
+	insert_asset(mport, "beta", ASSET_AUTODIR, "/usr/local/share/shared");
+
+	alpha = create_delete_pack("alpha");
+	beta = create_delete_pack("beta");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, alpha, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/shared/alpha", F_OK));
+	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/share/shared", F_OK));
+
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, beta, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/shared", F_OK));
+
+	mport_pkgmeta_free(alpha);
+	mport_pkgmeta_free(beta);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(delete_keeps_shared_autodirs, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(delete_explicit_dirrmtry_still_removes);
+ATF_TC_HEAD(delete_explicit_dirrmtry_still_removes, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "explicit dirrmtry assets keep existing delete behavior");
+}
+ATF_TC_BODY(delete_explicit_dirrmtry_still_removes, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(TEST_ROOT "/usr/local/share/explicit");
+	create_file(TEST_ROOT "/usr/local/share/explicit/file");
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/share/explicit/file");
+	insert_asset(mport, "alpha", ASSET_DIRRMTRY, "/usr/local/share/explicit");
+
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(TEST_ROOT "/usr/local/share/explicit", F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(delete_explicit_dirrmtry_still_removes, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(mtree_fixture_protects_system_dirs);
+ATF_TC_HEAD(mtree_fixture_protects_system_dirs, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "mtree fixture protects system directories");
+}
+ATF_TC_BODY(mtree_fixture_protects_system_dirs, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+	int fd;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(TEST_ROOT "/mtree");
+	fd = open(TEST_ROOT "/mtree/BSD.local.dist", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	ATF_REQUIRE(fd >= 0);
+	const char mtree[] = ".\n/set type=dir\nbin\n..\nshare\n..\n";
+	ATF_REQUIRE_EQ((ssize_t)strlen(mtree), write(fd, mtree, strlen(mtree)));
+	ATF_REQUIRE_EQ(0, close(fd));
+	ATF_REQUIRE_EQ(0, setenv("MPORT_MTREE_DIR", TEST_ROOT "/mtree", 1));
+	create_dir(TEST_ROOT "/usr/local/bin");
+	create_file(TEST_ROOT "/usr/local/bin/tool");
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_FILE, "/usr/local/bin/tool");
+	insert_asset(mport, "alpha", ASSET_AUTODIR, "/usr/local/bin");
+
+	ATF_REQUIRE(mport_is_system_mtree_dir("/usr/local/bin"));
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(0, access(TEST_ROOT "/usr/local/bin", F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(mtree_fixture_protects_system_dirs, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
 }
 
 static void
@@ -311,6 +545,10 @@ ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependency_first);
 	ATF_TP_ADD_TC(tp, sort_dependencies_dependent_first);
+	ATF_TP_ADD_TC(tp, delete_removes_autodirs);
+	ATF_TP_ADD_TC(tp, delete_keeps_shared_autodirs);
+	ATF_TP_ADD_TC(tp, delete_explicit_dirrmtry_still_removes);
+	ATF_TP_ADD_TC(tp, mtree_fixture_protects_system_dirs);
 	ATF_TP_ADD_TC(tp, query_formats_installed_metadata);
 	ATF_TP_ADD_TC(tp, query_filters_patterns_and_expressions);
 


### PR DESCRIPTION
## Summary

- Add ASSET_AUTODIR to track parent directories created implicitly while package files are installed.
- Record auto-dir assets during install, skipping explicit directory assets, the package prefix, and mtree-protected system directories.
- Remove auto directories opportunistically on delete, deepest-first, while respecting shared ownership and empty/nonexistent directory behavior.
- Load protected system directories from /etc/mtree/*.dist with a conservative fallback list.

## Validation

- make
- kyua test -k tests/Kyuafile (55/55 passed)
- ./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh (cppcheck clean; script did not run clang-tidy due to its staged-file filter behavior)

## Notes

- Splint was not treated as blocking per request; staging these files still surfaces broad legacy diagnostics in existing install/delete code.

## Summary by Sourcery

Track implicitly created package directories as assets and adjust deletion logic to safely remove them while honoring system mtree protections.

New Features:
- Introduce ASSET_AUTODIR asset type to record package-created parent directories during install.
- Derive protected system directories from mtree metadata, with an environment-configurable source and a conservative fallback list.

Enhancements:
- Update install and delete routines to recognize ASSET_AUTODIR alongside existing directory asset types and delete auto-created directories deepest-first when safe.
- Refine safety checks for directory removal to consider package prefixes, shared directory ownership across packages, and mtree-defined system directories.
- Add a reusable helper to detect mtree-protected system directories and wire it into deletion logic.

Build:
- Include the new mtree.c implementation in the libmport build.

Tests:
- Extend pkgmeta tests to cover auto-directory creation/removal, shared auto-directory behavior, explicit dirrmtry semantics, and mtree-based system directory protection.
- Adjust test root handling to use a temporary filesystem path with recursive cleanup and mtree fixture environment setup.