### PR TITLE
🧪 [testing improvement] Add tests for mport_directory and fix bug for top-level paths

### DIFF
--- a/libmport/util.c
+++ b/libmport/util.c
@@ -515,7 +515,13 @@ mport_directory(const char *path)
 			return NULL;
 		char *lastSlash = strrchr(dir, '/');
 		if (lastSlash != NULL) {
-			*lastSlash = '\0'; // Null-terminate at the last slash to get the directory
+			if (lastSlash == dir) {
+				// path is like "/mport" or "/"
+				*(lastSlash + 1) = '\0';
+			} else {
+				*lastSlash =
+				    '\0'; // Null-terminate at the last slash to get the directory
+			}
 			return dir;
 		} else {
 			free(dir);

--- a/tests/mport_util_test.c
+++ b/tests/mport_util_test.c
@@ -22,6 +22,7 @@ bool mport_check_answer_bool(char *);
 int mport_count_spaces(const char *);
 int mport_mkdir(const char *);
 int mport_rmdir(const char *, int);
+char *mport_directory(const char *);
 
 static void
 create_file(const char *filename, const void *data, size_t len)
@@ -391,6 +392,53 @@ ATF_TC_BODY(mport_rmdir_notfound_ignore, tc)
 	ATF_REQUIRE_EQ(MPORT_OK, mport_rmdir(test_dir, 1));
 }
 
+ATF_TC_WITHOUT_HEAD(mport_directory_null);
+ATF_TC_BODY(mport_directory_null, tc)
+{
+	(void)tc;
+
+	ATF_REQUIRE_EQ(NULL, mport_directory(NULL));
+}
+
+ATF_TC_WITHOUT_HEAD(mport_directory_absolute);
+ATF_TC_BODY(mport_directory_absolute, tc)
+{
+	char *dir;
+	(void)tc;
+
+	dir = mport_directory("/usr/local/bin/mport");
+	ATF_REQUIRE_STREQ("/usr/local/bin", dir);
+	free(dir);
+
+	dir = mport_directory("/mport");
+	ATF_REQUIRE_STREQ("/", dir);
+	free(dir);
+
+	dir = mport_directory("/");
+	ATF_REQUIRE_STREQ("/", dir);
+	free(dir);
+}
+
+ATF_TC_WITHOUT_HEAD(mport_directory_relative);
+ATF_TC_BODY(mport_directory_relative, tc)
+{
+	char *dir;
+	char cwd[PATH_MAX];
+	char expected[PATH_MAX];
+	(void)tc;
+
+	ATF_REQUIRE(getcwd(cwd, sizeof(cwd)) != NULL);
+
+	dir = mport_directory("mport");
+	ATF_REQUIRE_STREQ(cwd, dir);
+	free(dir);
+
+	dir = mport_directory("bin/mport");
+	snprintf(expected, sizeof(expected), "%s/bin", cwd);
+	ATF_REQUIRE_STREQ(expected, dir);
+	free(dir);
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, mport_check_answer_bool_null);
@@ -414,6 +462,9 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, mport_rmdir_nonempty_ignore);
 	ATF_TP_ADD_TC(tp, mport_rmdir_nonempty_noignore);
 	ATF_TP_ADD_TC(tp, mport_rmdir_notfound_ignore);
+	ATF_TP_ADD_TC(tp, mport_directory_null);
+	ATF_TP_ADD_TC(tp, mport_directory_absolute);
+	ATF_TP_ADD_TC(tp, mport_directory_relative);
 
 	return atf_no_error();
 }


### PR DESCRIPTION
I have implemented tests for the `mport_directory` function in `libmport/util.c` and fixed a bug identified during the testing process.

### 🎯 What
- **Testing Gap:** The `mport_directory` function was previously untested.
- **Bug Fix:** Discovered that `mport_directory` returned an empty string for files in the root directory (e.g., `/mport` -> `""`). Fixed it to return `/` instead.

### 📊 Coverage
The new test cases in `tests/mport_util_test.c` cover:
- `NULL` input.
- Absolute paths (deeply nested, top-level files like `/mport`, and the root directory `/`).
- Relative paths (simple filenames and paths with directories like `bin/mport`).

### ✨ Result
- Improved reliability of path manipulation in `libmport`.
- Increased test coverage in `tests/mport_util_test.c`.
- Fixed a bug that could lead to incorrect directory extraction for top-level files.

---
*PR created automatically by Jules for task [6107337161288742859](https://jules.google.com/task/6107337161288742859) started by @laffer1*

## Summary by Sourcery

Add test coverage for mport_directory and correct its behavior for absolute and relative paths, including root and top-level entries.

Bug Fixes:
- Fix mport_directory returning an empty string instead of "/" for paths in the root directory such as "/mport".

Tests:
- Add unit tests covering mport_directory behavior for NULL input, absolute paths (including root and top-level), and relative paths based on the current working directory.