### PR TITLE
Fix rooted delete helpers and @info uninstall

### DIFF
--- a/libmport/delete_primative.c
+++ b/libmport/delete_primative.c
@@ -72,6 +72,8 @@ static int delete_pkg_infra(mportInstance *, mportPackageMeta *);
 static int check_for_upwards_depends(mportInstance *, mportPackageMeta *);
 static void warn_ignored_rmdir_error(/*@notnull@*/ mportInstance *, /*@notnull@*/ const char *);
 static bool is_safe_to_delete_dir(mportInstance *, mportPackageMeta *, const char *, const char *);
+static int build_info_dir_path(
+    /*@notnull@*/ mportPackageMeta *, /*@null@*/ const char *, /*@out@*/ char *, size_t);
 
 MPORT_PUBLIC_API int
 mport_delete_primative(mportInstance *mport, mportPackageMeta *pack, int force)
@@ -477,6 +479,48 @@ is_safe_to_delete_dir(
 }
 
 static int
+build_info_dir_path(
+    /*@notnull@*/ mportPackageMeta *pkg, /*@null@*/ const char *data, /*@out@*/ char *path,
+    size_t path_size)
+{
+	char info_path[FILENAME_MAX];
+	char path_copy[FILENAME_MAX];
+	char *dirpath;
+
+	if (pkg == NULL || path == NULL || path_size == 0)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid info asset path arguments.");
+
+	if (data == NULL) {
+		if (strlcpy(path, "/usr/local/share/info", path_size) >= path_size)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Info directory path is too long.");
+		return (MPORT_OK);
+	}
+
+	if (*data == '/') {
+		if (strlcpy(info_path, data, sizeof(info_path)) >= sizeof(info_path))
+			RETURN_ERROR(MPORT_ERR_FATAL, "Info asset path is too long.");
+	} else {
+		if (pkg->prefix == NULL)
+			RETURN_ERROR(MPORT_ERR_FATAL, "Package prefix is undefined for info asset.");
+		if (snprintf(info_path, sizeof(info_path), "%s/%s", pkg->prefix, data) >=
+		    (int)sizeof(info_path)) {
+			RETURN_ERROR(MPORT_ERR_FATAL, "Info asset path is too long.");
+		}
+	}
+
+	if (strlcpy(path_copy, info_path, sizeof(path_copy)) >= sizeof(path_copy))
+		RETURN_ERROR(MPORT_ERR_FATAL, "Info asset path is too long.");
+
+	dirpath = dirname(path_copy);
+	if (dirpath == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Unable to determine info directory.");
+
+	if (strlcpy(path, dirpath, path_size) >= path_size)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Info directory path is too long.");
+	return (MPORT_OK);
+}
+
+static int
 run_unldconfig(mportInstance *mport, mportPackageMeta *pkg)
 {
 	int ret;
@@ -551,7 +595,7 @@ run_special_unexec(mportInstance *mport, mportPackageMeta *pkg)
 {
 	int ret;
 	char cwd[FILENAME_MAX];
-	char in[FILENAME_MAX];
+	char info_dir[FILENAME_MAX];
 	sqlite3_stmt *assets = NULL;
 	sqlite3 *db;
 	const char *data;
@@ -592,21 +636,12 @@ run_special_unexec(mportInstance *mport, mportPackageMeta *pkg)
 			}
 			break;
 		case ASSET_INFO:
-			if (data != NULL) {
-				strlcpy(in, data, sizeof(in));
-			} else {
-				strlcpy(in, "/usr/local/share/info", sizeof(in));
-			}
-			char *abs_path = realpath(in, NULL);
-			if (abs_path == NULL)
+			if (build_info_dir_path(pkg, data, info_dir, sizeof(info_dir)) != MPORT_OK)
 				goto SPECIAL_ERROR;
-			char *info_dir = dirname(abs_path);
-			if (info_dir != NULL && mport_file_exists("/usr/local/bin/indexinfo") &&
+			if (mport_file_exists("/usr/local/bin/indexinfo") &&
 			    mport_exec_indexinfo(mport, info_dir) != MPORT_OK) {
-				free(abs_path);
 				goto SPECIAL_ERROR;
 			}
-			free(abs_path);
 			break;
 		case ASSET_KLD:
 			if (mport_exec_kldxref(mport, (const char *)data) != MPORT_OK) {
@@ -699,17 +734,23 @@ static int
 run_pkg_deinstall(mportInstance *mport, mportPackageMeta *pack, const char *mode)
 {
 	char file[FILENAME_MAX];
+	char command_file[FILENAME_MAX];
 	int ret;
 
-	(void)snprintf(file, FILENAME_MAX, "%s/%s-%s/%s", MPORT_INST_INFRA_DIR, pack->name,
-	    pack->version, MPORT_DEINSTALL_FILE);
+	if (mport_build_infrastructure_path(mport, pack, MPORT_DEINSTALL_FILE, true, file,
+		sizeof(file)) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	if (mport_build_infrastructure_path(mport, pack, MPORT_DEINSTALL_FILE, false,
+		command_file, sizeof(command_file)) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
 
 	if (mport_file_exists(file)) {
 		if (chmod(file, 755) != 0)
 			RETURN_ERRORX(MPORT_ERR_FATAL, "chmod(%s, 755): %s", file, strerror(errno));
 
-		if ((ret = mport_xsystem(mport, "PKG_PREFIX=%s %s %s %s", pack->prefix, file,
-			 pack->name, mode)) != 0)
+		if ((ret = mport_xsystem(mport, "PKG_PREFIX=%s %s %s %s", pack->prefix,
+			 command_file, pack->name, mode)) != 0)
 			RETURN_ERRORX(MPORT_ERR_FATAL, "%s %s returned non-zero: %i",
 			    MPORT_INSTALL_FILE, mode, ret);
 	}

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -120,6 +120,8 @@ int mport_mkdirp(char *, mode_t);
 int mport_removeflags(const char *, const char *);
 int mport_rmdir(const char *, int);
 bool mport_is_system_mtree_dir(const char *);
+int mport_build_infrastructure_path(
+    mportInstance *, mportPackageMeta *, const char *, bool, char *, size_t);
 int mport_chdir(mportInstance *, const char *);
 int mport_xsystem(mportInstance *, const char *, ...);
 int mport_exec_linux_ldconfig(mportInstance *, const char *);

--- a/libmport/util.c
+++ b/libmport/util.c
@@ -205,6 +205,27 @@ mport_starts_with(const char *pre, const char *str)
 	return strncmp(pre, str, strlen(pre)) == 0;
 }
 
+int
+mport_build_infrastructure_path(mportInstance *mport, mportPackageMeta *pkg, const char *name,
+    bool rooted, char *path, size_t path_size)
+{
+	int len;
+	const char *root;
+
+	if (pkg == NULL || pkg->name == NULL || pkg->version == NULL || name == NULL || path == NULL ||
+	    path_size == 0) {
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid infrastructure path arguments.");
+	}
+
+	root = (rooted && mport != NULL && mport->root != NULL) ? mport->root : "";
+	len = snprintf(path, path_size, "%s%s/%s-%s/%s", root, MPORT_INST_INFRA_DIR, pkg->name,
+	    pkg->version, name);
+	if (len < 0 || (size_t)len >= path_size)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Infrastructure path is too long.");
+
+	return (MPORT_OK);
+}
+
 /* mport_hash_file(const char * filename)
  *
  * Return a SHA256 hash of a file.  Must free result

--- a/tests/mport_pkgmeta_test.c
+++ b/tests/mport_pkgmeta_test.c
@@ -99,6 +99,21 @@ create_file(const char *path)
 	ATF_REQUIRE_EQ(0, close(fd));
 }
 
+static void
+create_file_with_contents(const char *path, const char *contents)
+{
+	int fd;
+	size_t len;
+	ssize_t written;
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	ATF_REQUIRE(fd >= 0);
+	len = strlen(contents);
+	written = write(fd, contents, len);
+	ATF_REQUIRE_EQ((ssize_t)len, written);
+	ATF_REQUIRE_EQ(0, close(fd));
+}
+
 static mportPackageMeta *
 create_delete_pack(const char *name)
 {
@@ -393,6 +408,81 @@ ATF_TC_CLEANUP(mtree_fallback_protects_system_dirs, tc)
 	cleanup_test_root();
 }
 
+ATF_TC_WITH_CLEANUP(delete_info_asset_keeps_post_uninstall_working);
+ATF_TC_HEAD(delete_info_asset_keeps_post_uninstall_working, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "delete handles @info assets after unlinking the info file");
+}
+ATF_TC_BODY(delete_info_asset_keeps_post_uninstall_working, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+
+	(void)tc;
+
+	mport = create_test_instance();
+	create_local_prefix_dirs();
+	create_dir(test_path("/usr/local/share/info"));
+	create_file(test_path("/usr/local/share/info/alpha.info"));
+	insert_delete_package(mport, "alpha");
+	insert_asset(mport, "alpha", ASSET_INFO, "/usr/local/share/info/alpha.info");
+
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_MSG(
+	    mport_delete_primative(mport, pack, 1) == MPORT_OK, "%s", mport_err_string());
+	ATF_REQUIRE_EQ(-1, access(test_path("/usr/local/share/info/alpha.info"), F_OK));
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(delete_info_asset_keeps_post_uninstall_working, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(rooted_infrastructure_path_uses_instance_root);
+ATF_TC_HEAD(rooted_infrastructure_path_uses_instance_root, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+	    "infrastructure helper resolves package files underneath the instance root");
+}
+ATF_TC_BODY(rooted_infrastructure_path_uses_instance_root, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pack;
+	char path[PATH_MAX];
+
+	(void)tc;
+
+	mport = create_test_instance();
+	pack = create_delete_pack("alpha");
+	ATF_REQUIRE_EQ(0, mkdir(test_path("/var/db/mport/infrastructure/alpha-1.0"), 0755));
+	create_file_with_contents(
+	    test_path("/var/db/mport/infrastructure/alpha-1.0/pkg-deinstall"), "#!/bin/sh\nexit 0\n");
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_build_infrastructure_path(mport, pack, MPORT_DEINSTALL_FILE, true,
+			   path, sizeof(path)));
+	ATF_REQUIRE_STREQ(test_path("/var/db/mport/infrastructure/alpha-1.0/pkg-deinstall"), path);
+	ATF_REQUIRE_EQ(0, access(path, F_OK));
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_build_infrastructure_path(mport, pack, MPORT_DEINSTALL_FILE, false,
+			   path, sizeof(path)));
+	ATF_REQUIRE_STREQ("/var/db/mport/infrastructure/alpha-1.0/pkg-deinstall", path);
+
+	mport_pkgmeta_free(pack);
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(rooted_infrastructure_path_uses_instance_root, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
 static void
 insert_query_package(mportInstance *mport, const char *name, const char *version,
     const char *origin, const char *comment, int automatic, int locked, int64_t flatsize)
@@ -648,6 +738,8 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, delete_explicit_dirrmtry_still_removes);
 	ATF_TP_ADD_TC(tp, mtree_fixture_protects_system_dirs);
 	ATF_TP_ADD_TC(tp, mtree_fallback_protects_system_dirs);
+	ATF_TP_ADD_TC(tp, delete_info_asset_keeps_post_uninstall_working);
+	ATF_TP_ADD_TC(tp, rooted_infrastructure_path_uses_instance_root);
 	ATF_TP_ADD_TC(tp, query_formats_installed_metadata);
 	ATF_TP_ADD_TC(tp, query_filters_patterns_and_expressions);
 


### PR DESCRIPTION
## Summary
- stop delete-time `@info` handling from calling `realpath()` on a file that was already unlinked
- resolve `pkg-deinstall` from the instance root for host-side existence/chmod checks while still executing the chroot-visible path
- add regression tests for `@info` uninstall and rooted infrastructure path resolution

## Testing
- `git diff --check --cached`
- `./skills/cppcheck-clang-format-precommit/scripts/precommit_c_sanity.sh` *(blocked: no clang-format found on this Linux host)*
- `./skills/splint-post-c-sanity/scripts/run_splint_on_staged.sh` *(blocked: splint not found in PATH on this Linux host)*
- full build/test run not attempted because this repository targets MidnightBSD and does not build on this Linux host

Closes #69 for the delete-path bugs addressed here.

## Summary by Sourcery

Fix info-file uninstall handling and ensure infrastructure helpers respect the instance root while adding regression coverage for these cases.

Bug Fixes:
- Prevent info-asset uninstall from relying on realpath() of files that may already be unlinked.
- Resolve pkg-deinstall scripts using the instance root for host-side checks while executing the chroot-visible path.

Enhancements:
- Introduce a reusable helper to build rooted infrastructure paths for package files.
- Improve computation of info-directory paths for indexinfo execution during package deletion.

Tests:
- Add regression tests covering @info asset uninstall behavior after file deletion.
- Add regression tests verifying rooted infrastructure helper path resolution under an instance root.