### PR TITLE
libmport: clear error when confirmation needs a tty but stdin is not one

### DIFF
--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -87,6 +87,24 @@ mport_is_color_terminal(void)
 	return colorterm_support || term_supports_color || term_is_256color || clicolor_support;
 }
 
+/*
+ * Refuse an interactive prompt when stdin is not a terminal, recording an
+ * actionable error. Shared by the confirm and select callbacks so both behave
+ * identically. Returns -1, a non-MPORT_OK value the callers already treat as
+ * "not confirmed" / "no selection".
+ */
+static int
+mport_refuse_non_tty_prompt(const char *what)
+{
+	(void)fprintf(stderr,
+	    "Cannot prompt for %s: stdin is not a terminal. "
+	    "Re-run with -y or set ASSUME_ALWAYS_YES=1 to proceed.\n",
+	    what);
+	mport_set_errx(MPORT_ERR_FATAL,
+	    "cannot prompt for %s: stdin is not a terminal; use -y or ASSUME_ALWAYS_YES", what);
+	return -1;
+}
+
 int
 mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int def)
 {
@@ -98,15 +116,8 @@ mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int d
 		return (MPORT_OK);
 	}
 
-	if (!isatty(fileno(stdin))) {
-		(void)fprintf(stderr,
-		    "%s\nCannot prompt for confirmation: stdin is not a terminal. "
-		    "Re-run with -y or set ASSUME_ALWAYS_YES=1 to proceed.\n",
-		    msg);
-		mport_set_errx(MPORT_ERR_FATAL,
-		    "stdin is not a terminal; use -y or ASSUME_ALWAYS_YES to confirm");
-		return mport_err_code();
-	}
+	if (!isatty(fileno(stdin)))
+		return mport_refuse_non_tty_prompt("confirmation");
 
 	if (color_terminal) {
 		(void)fprintf(stderr, "%s%s (Y/N) [%s]:%s ", KCYN, msg, def == 1 ? yes : no, KNRM);
@@ -165,14 +176,8 @@ mport_default_select_cb(const char *msg, mportIndexEntry **choices, int def)
 		return def >= 0 ? def : 0;
 	}
 
-	if (!isatty(fileno(stdin))) {
-		(void)fprintf(stderr,
-		    "Cannot prompt for a selection: stdin is not a terminal. "
-		    "Re-run with -y or set ASSUME_ALWAYS_YES=1 to pick the default.\n");
-		mport_set_errx(MPORT_ERR_FATAL,
-		    "stdin is not a terminal; use -y or ASSUME_ALWAYS_YES to select");
-		return -1;
-	}
+	if (!isatty(fileno(stdin)))
+		return mport_refuse_non_tty_prompt("a selection");
 
 	if (color_terminal) {
 		(void)fprintf(stderr, "%s%s%s\n", KCYN, msg, KNRM);

--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -88,13 +88,15 @@ mport_is_color_terminal(void)
 }
 
 /*
- * Refuse an interactive prompt when stdin is not a terminal, recording an
- * actionable error. Shared by the confirm and select callbacks so both behave
- * identically. Returns -1, a non-MPORT_OK value the callers already treat as
- * "not confirmed" / "no selection".
+ * Print an actionable error and record it when an interactive prompt is needed
+ * but stdin is not a terminal. Shared by the confirm and select callbacks for
+ * the message/error; each caller returns its own appropriate value afterwards
+ * (the confirm callback returns mport_err_code(), while the select callback
+ * must return -1 because its return value is a choice index where any
+ * non-negative value would be a valid selection).
  */
-static int
-mport_refuse_non_tty_prompt(const char *what)
+static void
+mport_warn_non_tty_prompt(const char *what)
 {
 	(void)fprintf(stderr,
 	    "Cannot prompt for %s: stdin is not a terminal. "
@@ -102,7 +104,6 @@ mport_refuse_non_tty_prompt(const char *what)
 	    what);
 	mport_set_errx(MPORT_ERR_FATAL,
 	    "cannot prompt for %s: stdin is not a terminal; use -y or ASSUME_ALWAYS_YES", what);
-	return -1;
 }
 
 int
@@ -116,8 +117,10 @@ mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int d
 		return (MPORT_OK);
 	}
 
-	if (!isatty(fileno(stdin)))
-		return mport_refuse_non_tty_prompt("confirmation");
+	if (!isatty(fileno(stdin))) {
+		mport_warn_non_tty_prompt("confirmation");
+		return mport_err_code();
+	}
 
 	if (color_terminal) {
 		(void)fprintf(stderr, "%s%s (Y/N) [%s]:%s ", KCYN, msg, def == 1 ? yes : no, KNRM);
@@ -176,8 +179,10 @@ mport_default_select_cb(const char *msg, mportIndexEntry **choices, int def)
 		return def >= 0 ? def : 0;
 	}
 
-	if (!isatty(fileno(stdin)))
-		return mport_refuse_non_tty_prompt("a selection");
+	if (!isatty(fileno(stdin))) {
+		mport_warn_non_tty_prompt("a selection");
+		return -1;
+	}
 
 	if (color_terminal) {
 		(void)fprintf(stderr, "%s%s%s\n", KCYN, msg, KNRM);

--- a/libmport/default_cbs.c
+++ b/libmport/default_cbs.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 #include "mport.h"
 #include "mport_private.h"
 
@@ -97,6 +98,16 @@ mport_default_confirm_cb(const char *msg, const char *yes, const char *no, int d
 		return (MPORT_OK);
 	}
 
+	if (!isatty(fileno(stdin))) {
+		(void)fprintf(stderr,
+		    "%s\nCannot prompt for confirmation: stdin is not a terminal. "
+		    "Re-run with -y or set ASSUME_ALWAYS_YES=1 to proceed.\n",
+		    msg);
+		mport_set_errx(MPORT_ERR_FATAL,
+		    "stdin is not a terminal; use -y or ASSUME_ALWAYS_YES to confirm");
+		return mport_err_code();
+	}
+
 	if (color_terminal) {
 		(void)fprintf(stderr, "%s%s (Y/N) [%s]:%s ", KCYN, msg, def == 1 ? yes : no, KNRM);
 	} else {
@@ -152,6 +163,15 @@ mport_default_select_cb(const char *msg, mportIndexEntry **choices, int def)
 
 	if (getenv("ASSUME_ALWAYS_YES") != NULL || getenv("MAGUS") != NULL) {
 		return def >= 0 ? def : 0;
+	}
+
+	if (!isatty(fileno(stdin))) {
+		(void)fprintf(stderr,
+		    "Cannot prompt for a selection: stdin is not a terminal. "
+		    "Re-run with -y or set ASSUME_ALWAYS_YES=1 to pick the default.\n");
+		mport_set_errx(MPORT_ERR_FATAL,
+		    "stdin is not a terminal; use -y or ASSUME_ALWAYS_YES to select");
+		return -1;
 	}
 
 	if (color_terminal) {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,10 +10,17 @@ CFLAGS+=	-I${.CURDIR}/../libmport \
 		-I/usr/include/private/zstd \
 		-I${LOCALBASE}/include
 
-ATF_TESTS_C+=	mport_fetch_test \
+ATF_TESTS_C+=	mport_confirm_test \
+		mport_fetch_test \
 		mport_osrelease_test \
 		mport_pkgmeta_test \
 		mport_util_test
+
+LDFLAGS.mport_confirm_test+=	-L${.CURDIR}/../libmport \
+				-L${LOCALBASE}/lib \
+				-Wl,-rpath,${.CURDIR}/../libmport \
+				-Wl,-rpath,${LOCALBASE}/lib
+LDADD.mport_confirm_test+=	-lmport -latf-c
 
 LDFLAGS.mport_fetch_test+=	-L${.CURDIR}/../libmport \
 				-L${LOCALBASE}/lib \

--- a/tests/mport_confirm_test.c
+++ b/tests/mport_confirm_test.c
@@ -1,0 +1,111 @@
+#include <sys/cdefs.h>
+
+#include <atf-c.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "../libmport/mport.h"
+
+/* Splint does not understand ATF's generated test-case wrappers. */
+/*@-boundsread -boundswrite -compdef -compdestroy -dependenttrans -fullinitblock@*/
+/*@-mustfreefresh -noeffect -nullderef -nullpass -nullret -nullstate@*/
+/*@-retvalint -retvalother -type -unrecog@*/
+
+/*
+ * Force stdin to a non-terminal so the confirmation/selection callbacks take
+ * their non-interactive path deterministically (ATF runs each test case in its
+ * own process, so reopening stdin here does not leak into other cases).
+ */
+static void
+make_stdin_non_tty(void)
+{
+	ATF_REQUIRE(freopen("/dev/null", "r", stdin) != NULL);
+	ATF_REQUIRE(!isatty(fileno(stdin)));
+}
+
+ATF_TC(confirm_assume_always_yes);
+ATF_TC_HEAD(confirm_assume_always_yes, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_default_confirm_cb returns MPORT_OK when ASSUME_ALWAYS_YES is set");
+}
+ATF_TC_BODY(confirm_assume_always_yes, tc)
+{
+	(void)tc;
+
+	(void)unsetenv("MAGUS");
+	ATF_REQUIRE_EQ(0, setenv("ASSUME_ALWAYS_YES", "1", 1));
+	ATF_REQUIRE_EQ(MPORT_OK, mport_default_confirm_cb("Proceed?", "Yes", "No", 0));
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+}
+
+ATF_TC(confirm_magus);
+ATF_TC_HEAD(confirm_magus, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_default_confirm_cb returns MPORT_OK when MAGUS is set");
+}
+ATF_TC_BODY(confirm_magus, tc)
+{
+	(void)tc;
+
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+	ATF_REQUIRE_EQ(0, setenv("MAGUS", "1", 1));
+	ATF_REQUIRE_EQ(MPORT_OK, mport_default_confirm_cb("Proceed?", "Yes", "No", 0));
+	(void)unsetenv("MAGUS");
+}
+
+ATF_TC(confirm_non_tty_aborts);
+ATF_TC_HEAD(confirm_non_tty_aborts, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+	    "mport_default_confirm_cb refuses (non-OK) on a non-terminal without assume-yes");
+}
+ATF_TC_BODY(confirm_non_tty_aborts, tc)
+{
+	(void)tc;
+
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+	(void)unsetenv("MAGUS");
+	make_stdin_non_tty();
+
+	/* Must not block on input and must not report confirmation. */
+	ATF_REQUIRE(mport_default_confirm_cb("Proceed?", "Yes", "No", 0) != MPORT_OK);
+	/* Default of 1 ("yes") must not flip a non-terminal into a confirmation. */
+	ATF_REQUIRE(mport_default_confirm_cb("Proceed?", "Yes", "No", 1) != MPORT_OK);
+}
+
+ATF_TC(select_non_tty_aborts);
+ATF_TC_HEAD(select_non_tty_aborts, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_default_select_cb returns -1 on a non-terminal without assume-yes");
+}
+ATF_TC_BODY(select_non_tty_aborts, tc)
+{
+	/*
+	 * On the non-terminal path the callback returns before any choice is
+	 * dereferenced, so a single non-NULL sentinel terminated by NULL is
+	 * enough to get past the empty-list guard.
+	 */
+	mportIndexEntry *choices[] = { (mportIndexEntry *)(void *)&choices, NULL };
+
+	(void)tc;
+
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+	(void)unsetenv("MAGUS");
+	make_stdin_non_tty();
+
+	ATF_REQUIRE_EQ(-1, mport_default_select_cb("Pick one", choices, 0));
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, confirm_assume_always_yes);
+	ATF_TP_ADD_TC(tp, confirm_magus);
+	ATF_TP_ADD_TC(tp, confirm_non_tty_aborts);
+	ATF_TP_ADD_TC(tp, select_non_tty_aborts);
+
+	return atf_no_error();
+}

--- a/tests/mport_confirm_test.c
+++ b/tests/mport_confirm_test.c
@@ -3,6 +3,7 @@
 #include <atf-c.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "../libmport/mport.h"
@@ -56,6 +57,40 @@ ATF_TC_BODY(confirm_magus, tc)
 	(void)unsetenv("MAGUS");
 }
 
+ATF_TC(confirm_assume_always_yes_non_tty);
+ATF_TC_HEAD(confirm_assume_always_yes_non_tty, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+	    "mport_default_confirm_cb returns MPORT_OK with ASSUME_ALWAYS_YES even on non-tty stdin");
+}
+ATF_TC_BODY(confirm_assume_always_yes_non_tty, tc)
+{
+	(void)tc;
+
+	(void)unsetenv("MAGUS");
+	ATF_REQUIRE_EQ(0, setenv("ASSUME_ALWAYS_YES", "1", 1));
+	make_stdin_non_tty();
+	ATF_REQUIRE_EQ(MPORT_OK, mport_default_confirm_cb("Proceed?", "Yes", "No", 0));
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+}
+
+ATF_TC(confirm_magus_non_tty);
+ATF_TC_HEAD(confirm_magus_non_tty, tc)
+{
+	atf_tc_set_md_var(tc, "descr",
+	    "mport_default_confirm_cb returns MPORT_OK with MAGUS even on non-tty stdin");
+}
+ATF_TC_BODY(confirm_magus_non_tty, tc)
+{
+	(void)tc;
+
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+	ATF_REQUIRE_EQ(0, setenv("MAGUS", "1", 1));
+	make_stdin_non_tty();
+	ATF_REQUIRE_EQ(MPORT_OK, mport_default_confirm_cb("Proceed?", "Yes", "No", 0));
+	(void)unsetenv("MAGUS");
+}
+
 ATF_TC(confirm_non_tty_aborts);
 ATF_TC_HEAD(confirm_non_tty_aborts, tc)
 {
@@ -85,13 +120,14 @@ ATF_TC_HEAD(select_non_tty_aborts, tc)
 ATF_TC_BODY(select_non_tty_aborts, tc)
 {
 	/*
-	 * On the non-terminal path the callback returns before any choice is
-	 * dereferenced, so a single non-NULL sentinel terminated by NULL is
-	 * enough to get past the empty-list guard.
+	 * Two zeroed entries are enough: the assume-yes and non-tty paths both
+	 * return before any entry field is dereferenced.
 	 */
-	mportIndexEntry *choices[] = { (mportIndexEntry *)(void *)&choices, NULL };
+	mportIndexEntry entries[2];
+	mportIndexEntry *choices[] = { &entries[0], &entries[1], NULL };
 
 	(void)tc;
+	(void)memset(entries, 0, sizeof(entries));
 
 	(void)unsetenv("ASSUME_ALWAYS_YES");
 	(void)unsetenv("MAGUS");
@@ -100,12 +136,56 @@ ATF_TC_BODY(select_non_tty_aborts, tc)
 	ATF_REQUIRE_EQ(-1, mport_default_select_cb("Pick one", choices, 0));
 }
 
+ATF_TC(select_assume_always_yes);
+ATF_TC_HEAD(select_assume_always_yes, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_default_select_cb returns the default with ASSUME_ALWAYS_YES set");
+}
+ATF_TC_BODY(select_assume_always_yes, tc)
+{
+	mportIndexEntry entries[2];
+	mportIndexEntry *choices[] = { &entries[0], &entries[1], NULL };
+
+	(void)tc;
+	(void)memset(entries, 0, sizeof(entries));
+
+	(void)unsetenv("MAGUS");
+	ATF_REQUIRE_EQ(0, setenv("ASSUME_ALWAYS_YES", "1", 1));
+	ATF_REQUIRE_EQ(1, mport_default_select_cb("Pick one", choices, 1));
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+}
+
+ATF_TC(select_magus);
+ATF_TC_HEAD(select_magus, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "mport_default_select_cb returns the default with MAGUS set");
+}
+ATF_TC_BODY(select_magus, tc)
+{
+	mportIndexEntry entries[2];
+	mportIndexEntry *choices[] = { &entries[0], &entries[1], NULL };
+
+	(void)tc;
+	(void)memset(entries, 0, sizeof(entries));
+
+	(void)unsetenv("ASSUME_ALWAYS_YES");
+	ATF_REQUIRE_EQ(0, setenv("MAGUS", "1", 1));
+	ATF_REQUIRE_EQ(1, mport_default_select_cb("Pick one", choices, 1));
+	(void)unsetenv("MAGUS");
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, confirm_assume_always_yes);
 	ATF_TP_ADD_TC(tp, confirm_magus);
+	ATF_TP_ADD_TC(tp, confirm_assume_always_yes_non_tty);
+	ATF_TP_ADD_TC(tp, confirm_magus_non_tty);
 	ATF_TP_ADD_TC(tp, confirm_non_tty_aborts);
 	ATF_TP_ADD_TC(tp, select_non_tty_aborts);
+	ATF_TP_ADD_TC(tp, select_assume_always_yes);
+	ATF_TP_ADD_TC(tp, select_magus);
 
 	return atf_no_error();
 }


### PR DESCRIPTION
## Problem

A non-interactive `mport delete` (no controlling terminal, e.g. run from a
script or with stdin redirected) appears to do nothing: it prints the
deletion plan and exits non-zero, but with no visible reason.

Root cause: `mport_default_confirm_cb()` (and `mport_default_select_cb()`)
print a prompt to stderr and then call `fgetln(stdin, ...)`, which returns
`NULL` on a non-terminal. The error set via `mport_set_errx()` on that path
is discarded by callers such as `deleteMany()` (which just returns
`MPORT_ERR_WARN`), so the user sees no hint that `-y` / `ASSUME_ALWAYS_YES`
is how to proceed.

## Change

After the existing `ASSUME_ALWAYS_YES`/`MAGUS` checks, detect a non-terminal
stdin (`!isatty(fileno(stdin))`) and print an actionable message **directly
to stderr**, then abort:

```
Cannot prompt for confirmation: stdin is not a terminal. Re-run with -y or
set ASSUME_ALWAYS_YES=1 to proceed.
```

Safety is unchanged — mport still refuses to act without explicit consent
(it does not assume "yes" on a non-terminal). The same guard is applied to
`mport_default_select_cb()` for consistency.

## Tests

Adds `tests/mport_confirm_test.c` (ATF) covering, for both callbacks:
- `ASSUME_ALWAYS_YES` set → `MPORT_OK`
- `MAGUS` set → `MPORT_OK`
- non-tty without assume-yes → non-OK / `-1` (no block, no false confirmation)

All four cases pass; `cppcheck`/`clang-format` pre-commit sanity is clean.

## Summary by Sourcery

Improve mport confirmation and selection behavior when stdin is non-interactive by surfacing a clear fatal error instead of silently failing.

Bug Fixes:
- Prevent mport confirmation and selection callbacks from appearing to succeed when run without a terminal by detecting non-tty stdin and returning a fatal error.

Enhancements:
- Print explicit, user-facing guidance to stderr explaining how to proceed (-y or ASSUME_ALWAYS_YES) when stdin is not a terminal.

Tests:
- Add an ATF test suite for confirmation and selection callbacks covering ASSUME_ALWAYS_YES, MAGUS, and non-tty stdin behavior.