### PR TITLE
libmport: update local package on offline install when file is newer

### DIFF
--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -37,8 +37,9 @@
 
 static char **get_dependencies(mportInstance *mport, mportPackageMeta *pack);
 static char *find_file_with_prefix(const char *dir, const char *prefix);
-static /*@only@*/ mportPackageMeta **lookup_current_os_installed(
-    /*@notnull@*/ mportInstance *, /*@notnull@*/ mportPackageMeta *);
+static /*@null@*/ /*@only@*/ mportPackageMeta **lookup_current_os_installed(
+    /*@notnull@*/ mportInstance *, /*@notnull@*/ mportPackageMeta *,
+    /*@out@*/ mportPackageMeta **);
 
 #define GOTO_CLEANUP_ON_MPORT_ERR(expr)         \
 	do {                                    \
@@ -146,30 +147,50 @@ find_file_with_prefix(const char *dir, const char *prefix)
 	return found_file;
 }
 
+/*
+ * Return the installed package(s) matching pkg->name, and set *match to the
+ * single entry whose os_release equals the running system's. The package name
+ * is not unique in the master DB (the same name can be installed under a
+ * different os_release), so scan every returned row rather than assuming the
+ * current-OS entry is first. Returns NULL (and sets *match to NULL) when the
+ * package is not installed under the current OS release; the caller owns the
+ * returned vector, and *match is an observer into it.
+ */
 static mportPackageMeta **
-lookup_current_os_installed(mportInstance *mport, mportPackageMeta *pkg)
+lookup_current_os_installed(mportInstance *mport, mportPackageMeta *pkg, mportPackageMeta **match)
 {
 	mportPackageMeta **installed = NULL;
 	char *system_os_release;
+	int i;
+
+	*match = NULL;
 
 	if (mport_pkgmeta_search_master(mport, &installed, "pkg=%Q", pkg->name) != MPORT_OK)
 		return NULL;
 	if (installed == NULL)
 		return NULL;
-	if (installed[0] == NULL) {
+
+	system_os_release = mport_get_osrelease(mport);
+	if (system_os_release == NULL) {
 		mport_pkgmeta_vec_free(installed);
 		return NULL;
 	}
 
-	system_os_release = mport_get_osrelease(mport);
-	if (system_os_release == NULL || installed[0]->os_release == NULL ||
-	    strcmp(installed[0]->os_release, system_os_release) != 0) {
-		free(system_os_release);
-		mport_pkgmeta_vec_free(installed);
-		return NULL;
+	for (i = 0; installed[i] != NULL; i++) {
+		if (installed[i]->os_release != NULL &&
+		    strcmp(installed[i]->os_release, system_os_release) == 0) {
+			*match = installed[i];
+			break;
+		}
 	}
 
 	free(system_os_release);
+
+	if (*match == NULL) {
+		mport_pkgmeta_vec_free(installed);
+		return NULL;
+	}
+
 	return installed;
 }
 
@@ -179,6 +200,7 @@ mport_install_primative(
 {
 	mportBundleRead *bundle = NULL;
 	mportPackageMeta **already_installed = NULL;
+	mportPackageMeta *current_installed = NULL;
 	mportPackageMeta **pkgs = NULL;
 	mportPackageMeta *pkg = NULL;
 	int i;
@@ -213,19 +235,26 @@ mport_install_primative(
 			goto cleanup;
 		}
 
-		already_installed = lookup_current_os_installed(mport, pkgs[0]);
-		if (already_installed != NULL && already_installed[0] != NULL) {
+		/*
+		 * Only packages installed under the current OS release are treated
+		 * as update/reinstall candidates here. A copy installed under a
+		 * different os_release is left for the normal install path below,
+		 * where MPORT_PRECHECK_INSTALLED considers a differing os_release to
+		 * be a distinct package (matching pre-existing --force behavior).
+		 */
+		already_installed = lookup_current_os_installed(mport, pkgs[0], &current_installed);
+		if (current_installed != NULL) {
 			int version_cmp =
-			    mport_version_cmp(already_installed[0]->version, pkgs[0]->version);
+			    mport_version_cmp(current_installed->version, pkgs[0]->version);
 
 			if (mport->force || version_cmp < 0) {
-				automatic = already_installed[0]->automatic;
+				automatic = current_installed->automatic;
 				if (version_cmp < 0) {
 					mport_call_msg_cb(mport, "Updating %s from %s to %s.",
-					    pkgs[0]->name, already_installed[0]->version,
+					    pkgs[0]->name, current_installed->version,
 					    pkgs[0]->version);
 				}
-				if (mport_delete_primative(mport, already_installed[0], 1) !=
+				if (mport_delete_primative(mport, current_installed, 1) !=
 				    MPORT_OK) {
 					ret = mport_err_code();
 					goto cleanup;

--- a/libmport/install_primative.c
+++ b/libmport/install_primative.c
@@ -37,6 +37,8 @@
 
 static char **get_dependencies(mportInstance *mport, mportPackageMeta *pack);
 static char *find_file_with_prefix(const char *dir, const char *prefix);
+static /*@only@*/ mportPackageMeta **lookup_current_os_installed(
+    /*@notnull@*/ mportInstance *, /*@notnull@*/ mportPackageMeta *);
 
 #define GOTO_CLEANUP_ON_MPORT_ERR(expr)         \
 	do {                                    \
@@ -144,6 +146,33 @@ find_file_with_prefix(const char *dir, const char *prefix)
 	return found_file;
 }
 
+static mportPackageMeta **
+lookup_current_os_installed(mportInstance *mport, mportPackageMeta *pkg)
+{
+	mportPackageMeta **installed = NULL;
+	char *system_os_release;
+
+	if (mport_pkgmeta_search_master(mport, &installed, "pkg=%Q", pkg->name) != MPORT_OK)
+		return NULL;
+	if (installed == NULL)
+		return NULL;
+	if (installed[0] == NULL) {
+		mport_pkgmeta_vec_free(installed);
+		return NULL;
+	}
+
+	system_os_release = mport_get_osrelease(mport);
+	if (system_os_release == NULL || installed[0]->os_release == NULL ||
+	    strcmp(installed[0]->os_release, system_os_release) != 0) {
+		free(system_os_release);
+		mport_pkgmeta_vec_free(installed);
+		return NULL;
+	}
+
+	free(system_os_release);
+	return installed;
+}
+
 MPORT_PUBLIC_API int
 mport_install_primative(
     mportInstance *mport, const char *filename, const char *prefix, mportAutomatic automatic)
@@ -184,19 +213,32 @@ mport_install_primative(
 			goto cleanup;
 		}
 
-		/* if we previously installed it and want to force, allow it.
-		   In this case, automatic flag from previous install not honored
-		*/
-		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_INSTALLED) !=
-		    MPORT_OK) {
-			if (mport->force) {
-				mport_delete_primative(mport, pkgs[0], 1);
+		already_installed = lookup_current_os_installed(mport, pkgs[0]);
+		if (already_installed != NULL && already_installed[0] != NULL) {
+			int version_cmp =
+			    mport_version_cmp(already_installed[0]->version, pkgs[0]->version);
+
+			if (mport->force || version_cmp < 0) {
+				automatic = already_installed[0]->automatic;
+				if (version_cmp < 0) {
+					mport_call_msg_cb(mport, "Updating %s from %s to %s.",
+					    pkgs[0]->name, already_installed[0]->version,
+					    pkgs[0]->version);
+				}
+				if (mport_delete_primative(mport, already_installed[0], 1) !=
+				    MPORT_OK) {
+					ret = mport_err_code();
+					goto cleanup;
+				}
 			} else {
 				mport_call_msg_cb(mport, "%s-%s: already installed.", pkgs[0]->name,
 				    pkgs[0]->version);
 				ret = MPORT_OK;
 				goto cleanup;
 			}
+
+			mport_pkgmeta_vec_free(already_installed);
+			already_installed = NULL;
 		}
 
 		if (mport_check_preconditions(mport, pkgs[0], MPORT_PRECHECK_CONFLICTS) !=

--- a/mport/mport.1
+++ b/mport/mport.1
@@ -247,6 +247,10 @@ package files.
 If
 .Fl A
 is specified, mark the installed package as automatic.
+If the package is already installed and the local package file contains a newer
+version,
+.Nm
+updates it by removing the installed package and installing the local file.
 For repository installs, use
 .Cm install .
 .It Cm annotate Op Fl a Op Fl q Fl S Ar package Ar tag


### PR DESCRIPTION
## Summary

For offline / local-file installs (`mport install <file.mport>`), if the same package is already installed on the **current OS release** and the local file carries a **newer** version, mport now removes the installed copy and installs the file — an in-place update — instead of refusing with "already installed". The previous `automatic` flag is preserved.

- Without `--force`, a same-or-older local file still reports `already installed` (unchanged behavior).
- With `--force`, it reinstalls regardless of version (unchanged behavior).
- New helper `lookup_current_os_installed()` only matches an installed package whose `os_release` equals the running system's, so a package from a different OS release is **not** treated as a version bump.
- Deletes the actually-installed package meta (not the bundle stub) before the conflict/installed prechecks.
- `mport.1` documents the new behavior.

## Verification

- Builds clean under `-Werror` (`cd libmport && make`).
- Traced memory: `already_installed` is freed on the success path and in `cleanup`, NULL'd after each free (no leak / no double-free). `mport_delete_primative` does not free its `pack` arg, so freeing the array afterward is safe.
- Version direction confirmed against `mport_version_cmp` contract (`-1` when first < second) and the existing `check_if_older_installed` usage.
- os_release gating is consistent with `check_if_installed`; `--force` cross-release installs are unaffected.
- Precommit cppcheck/splint: no new actionable findings (the one cppcheck warning at `install_primative.c:251` is pre-existing; splint out-of-bounds notes are the same false-positive class this file already emits).

## Not covered

No automated test exercises the new offline update-on-newer path — the ATF suite is registry-gated, so this path is verified by code tracing and a clean `-Werror` build rather than at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow offline installs from local package files to replace an already-installed package on the current OS release when the local file is newer, and document the behavior.

New Features:
- Support updating an already-installed package during offline/local-file installs when the provided package has a newer version on the current OS release.

Enhancements:
- Preserve the previous installation's automatic flag when performing an in-place update from a local package file.
- Restrict offline update checks to packages installed for the current OS release via a dedicated lookup helper.

Documentation:
- Document the new offline install behavior for updating installed packages with newer local package files in the mport(1) manual.