### PR TITLE
Remove stray replace.patch from the repo

### DIFF
--- a/replace.patch
+++ b/replace.patch
@@ -1,9 +1,0 @@
---- tests/mport_util_test.c
-+++ tests/mport_util_test.c
-@@ -3,6 +3,7 @@
-
- #include <atf-c.h>
- #include <stdio.h>
-+#include <ctype.h>
- #include <stdlib.h>
- #include <string.h>


### PR DESCRIPTION
`replace.patch` was a leftover diff artifact accidentally committed (in #162). It is not referenced by the build or tests, and its content is stale — it adds `<ctype.h>` to `tests/mport_util_test.c`, which uses no ctype functions and whose current include block no longer matches the patch context.

Removing it; nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Delete a stray patch artifact that is no longer used by the build or tests.