### PR TITLE
Fix TOCTOU issues in mport_copy_file and mport_mkdir

### DIFF
--- a/libmport/util.c
+++ b/libmport/util.c
@@ -320,33 +320,54 @@ mport_rmtree(const char *filename)
 
 /*
  * Copy file fromname to toname
+ * Uses O_NOFOLLOW to prevent symlink attacks (TOCTOU mitigation)
  */
+/*@requires fromName != NULL && toName != NULL @*/
+/*@ensures result == MPORT_OK || result == MPORT_ERR_FATAL @*/
 int
-mport_copy_file(const char *fromName, const char *toName)
+mport_copy_file(/*@notnull@*/ /*@observer@*/ const char *fromName,
+    /*@notnull@*/ /*@observer@*/ const char *toName)
 {
 	char buf[BUFSIZ];
-	size_t size;
+	ssize_t size;
+	int from_fd = -1;
+	int to_fd = -1;
+	int ret = MPORT_OK;
 
-	FILE *fsrc = fopen(fromName, "re");
-	if (fsrc == NULL)
+	from_fd = open(fromName, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	if (from_fd == -1) {
 		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't open source file for copying %s: %s",
 		    fromName, strerror(errno));
+	}
 
-	FILE *fdest = fopen(toName, "we");
-	if (fdest == NULL) {
-		fclose(fsrc);
+	to_fd = open(toName, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, 0644);
+	if (to_fd == -1) {
+		close(from_fd);
 		RETURN_ERRORX(MPORT_ERR_FATAL, "Couldn't open destination file for copying %s: %s",
 		    toName, strerror(errno));
 	}
 
-	while ((size = fread(buf, 1, BUFSIZ, fsrc)) > 0) {
-		fwrite(buf, 1, size, fdest);
+	while ((size = read(from_fd, buf, BUFSIZ)) > 0) {
+		if (write(to_fd, buf, size) != size) {
+			ret = SET_ERRORX(MPORT_ERR_FATAL, "Error writing to %s: %s",
+			    toName, strerror(errno));
+			goto cleanup;
+		}
 	}
 
-	fclose(fsrc);
-	fclose(fdest);
+	if (size == -1) {
+		ret = SET_ERRORX(MPORT_ERR_FATAL, "Error reading from %s: %s",
+		    fromName, strerror(errno));
+		goto cleanup;
+	}
 
-	return (MPORT_OK);
+cleanup:
+	if (from_fd != -1)
+		close(from_fd);
+	if (to_fd != -1)
+		close(to_fd);
+
+	return (ret);
 }
 
 int
@@ -373,10 +394,25 @@ mport_copy_fd(int from_fd, int to_fd)
 /*
  * create a directory with mode 755.  Do not fail if the
  * directory exists already.
+ * Uses lstat to check for symlinks before mkdir (TOCTOU mitigation)
  */
+/*@requires dir != NULL @*/
+/*@ensures result == MPORT_OK || result == MPORT_ERR_FATAL @*/
 int
-mport_mkdir(const char *dir)
+mport_mkdir(/*@notnull@*/ /*@observer@*/ const char *dir)
 {
+	struct stat sb;
+
+	/* Check if path exists and is a symlink - refuse to follow it */
+	if (lstat(dir, &sb) == 0) {
+		if (S_ISLNK(sb.st_mode)) {
+			RETURN_ERRORX(
+			    MPORT_ERR_FATAL, "Refusing to mkdir %s: path is a symlink", dir);
+		}
+		/* Path exists and is not a symlink - mkdir will fail with EEXIST */
+		return (MPORT_OK);
+	}
+
 	if (mkdir(dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) != 0) {
 		if (errno != EEXIST)
 			RETURN_ERRORX(


### PR DESCRIPTION
## Summary

This PR fixes two Time-of-Check to Time-of-Use (TOCTOU) vulnerabilities in the mport package manager's utility functions.

## Changes

### 1. mport_copy_file() (libmport/util.c)
- Replaced fopen()/fread()/fwrite()/fclose() with open()/read()/write()/close()
- Added O_NOFOLLOW | O_CLOEXEC flags to both source and destination file opens
- Properly handles file descriptor cleanup on errors using goto pattern
- Added Splint annotations for nullability and contracts

**Impact**: Prevents symlink attacks where an attacker could swap the source or destination file path with a symlink between check and use, causing unintended file reads or writes to sensitive locations.

### 2. mport_mkdir() (libmport/util.c)
- Added lstat() check before mkdir() to detect if the path is a symlink
- Returns error if path is a symlink: "Refusing to mkdir %s: path is a symlink"
- If path exists and is not a symlink, returns OK (mkdir would fail with EEXIST)
- Added Splint annotations for nullability and contracts

**Impact**: Prevents directory creation at symlink targets when an attacker replaces the target path with a symlink between check and use.

## Security Impact

Both vulnerabilities could potentially allow local privilege escalation when mport is run as root (which is typical for package installation). An attacker with write access to the filesystem could exploit these race conditions to:
- Read sensitive files (via symlink to source in copy_file)
- Write to sensitive files (via symlink to destination in copy_file)
- Create directories at sensitive locations (via symlink in mkdir)

## Note

There are existing callers of mport_mkdir() that do not check return values (lines 206, 207, 209, 570, 585 in bundle_read_install_pkg.c). With this change, these callers will silently ignore errors when a path is a symlink. This should be addressed in a follow-up to fully benefit from the TOCTOU fix.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>

## Summary by Sourcery

Mitigate TOCTOU vulnerabilities in mport’s file copy and directory creation utilities to prevent symlink-based attacks.

Bug Fixes:
- Harden mport_copy_file against symlink races by using non-following file descriptors and robust read/write error handling.
- Prevent mport_mkdir from creating directories via symlink targets by checking for existing symlinks before mkdir.

Enhancements:
- Add Splint nullability and contract annotations to mport_copy_file and mport_mkdir for improved static analysis.