### PR TITLE
Fix heap corruption in dependency vector handling on install failure

### DIFF
--- a/libmport/install.c
+++ b/libmport/install.c
@@ -265,11 +265,12 @@ mport_install_depends(
 			if (mport_install_depends(mport, (*dep)->d_pkgname, (*dep)->d_version,
 				MPORT_AUTOMATIC) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
-				mport_index_depends_free_vec(depends_orig);
-				depends_orig = NULL;
 				if (mport->ignoreMissing) {
 					continue;
 				}
+				mport_index_depends_free_vec(depends_orig);
+				depends_orig = NULL;
+				depends = NULL;
 				return mport_err_code();
 			}
 		}

--- a/libmport/update.c
+++ b/libmport/update.c
@@ -141,8 +141,10 @@ mport_update(mportInstance *mport, const char *packageName)
 			&depends_orig) != MPORT_OK) {
 			mport_call_msg_cb(mport, "Failed to get dependency list for %s: %s\n",
 			    packageName, mport_err_string());
+			result = mport_err_code();
 			mport_index_entry_free_vec(indexEntries);
-			return mport_err_code();
+			free(path);
+			return result;
 		}
 
 		depends = depends_orig;
@@ -150,8 +152,7 @@ mport_update(mportInstance *mport, const char *packageName)
 			if (mport_install_depends(mport, (*depends)->d_pkgname,
 				(*depends)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
-				mport_index_depends_free_vec(depends);
-				mport_index_entry_free_vec(indexEntries);
+
 				if (mport->ignoreMissing) {
 					mport_call_msg_cb(mport,
 					    "Ignoring missing dependency %s-%s\n",
@@ -159,7 +160,12 @@ mport_update(mportInstance *mport, const char *packageName)
 					depends++;
 					continue;
 				}
-				return mport_err_code();
+
+				result = mport_err_code();
+				mport_index_depends_free_vec(depends_orig);
+				mport_index_entry_free_vec(indexEntries);
+				free(path);
+				return result;
 			}
 			depends++;
 		}


### PR DESCRIPTION
## Problem

Both `mport_update()` and the recursive `mport_install_depends()` walk the NULL-terminated dependency vector with a cursor. On a dependency-install failure they freed the vector incorrectly, producing three distinct memory-safety bugs reachable during a normal `mport update` / `mport install` whenever a dependency past the first fails to install:

1. **Interior-pointer free (`libmport/update.c`).** The *advanced* cursor `depends` was passed to `mport_index_depends_free_vec()`, which ends by calling `free()` on exactly that pointer — an interior pointer into the `calloc`'d array. Heap corruption.
2. **Use-after-free (both files).** The vector was freed *before* the `ignoreMissing` check, then the loop `continue`d and dereferenced the freed depend entries (`(*depends)->d_pkgname`) and kept iterating the freed vector.
3. **Double free (`libmport/update.c`).** With `ignoreMissing`, `indexEntries` and the depends vector were later freed a second time on the normal exit path.

These run in the package manager as root.

## Fix

- Move the vector free **below** the `ignoreMissing` check, so the ignore path keeps iterating the still-valid vector.
- On the fatal path, free `depends_orig` (the base pointer), exactly once.
- Also free the leaked downloaded `path` string on `update.c`'s dependency error returns.

## Verification

- **AddressSanitizer harness** linked against the real `libmport`: the pre-fix control flow aborts (`heap-use-after-free` / invalid free), the post-fix flow completes cleanly.
- Full tree builds `-Werror` clean.
- `kyua` suite: **64/64 pass**.
- `cppcheck` clean on both files; `clang-format19` clean on the changed regions. Remaining `splint` output is the codebase's pre-existing NULL-terminated-vector bounds-analysis noise on unchanged lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent memory-safety issues when handling dependency vectors during install and update failures.

Bug Fixes:
- Ensure dependency vectors are freed using the original base pointer only on the fatal error path to avoid interior-pointer frees, use-after-free, and double frees.
- Preserve and return the correct error code while cleaning up resources on dependency resolution failures.
- Free the temporary download path string on dependency-related error returns to avoid memory leaks.
- Avoid further use of dependency pointers after they have been freed during recursive install failures.