### PR TITLE
Guard NULL/empty mirror URLs in mport_index_get_mirror_list

### DIFF
--- a/libmport/index.c
+++ b/libmport/index.c
@@ -371,7 +371,16 @@ mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size
 		ret = sqlite3_step(stmt);
 
 		if (ret == SQLITE_ROW) {
-			list[i] = strdup((const char *)sqlite3_column_text(stmt, 0));
+			const char *mirror = (const char *)sqlite3_column_text(stmt, 0);
+
+			/* Skip NULL or empty mirror URLs: they cannot be
+			 * fetched from and would only relocate the crash into
+			 * the URL-parsing consumer.
+			 */
+			if (mirror == NULL || mirror[0] == '\0')
+				continue;
+
+			list[i] = strdup(mirror);
 
 			if (list[i] == NULL) {
 				sqlite3_finalize(stmt);
@@ -381,6 +390,7 @@ mport_index_get_mirror_list(mportInstance *mport, char ***list_p, int *list_size
 			i++;
 		} else if (ret == SQLITE_DONE) {
 			list[i] = NULL;
+			*list_size = i;
 			break;
 		} else {
 			list[i] = NULL;


### PR DESCRIPTION
## Problem

`mport_index_get_mirror_list` (`libmport/index.c`) passes the `mirror`
column of the downloaded index DB straight to `strdup`:

```c
list[i] = strdup((const char *)sqlite3_column_text(stmt, 0));
```

`sqlite3_column_text` returns `NULL` for a SQL `NULL` column, and
`strdup(NULL)` dereferences a NULL pointer — a crash during
`mport_fetch_index` / `mport_fetch_bundle` (CWE-476). A malicious or
compromised mirror can serve a crafted index whose `mirrors` row has a
NULL `mirror` value to deny service to any fetch.

This is the same class of "tolerate NULL columns in downloaded index
data" hardening already applied elsewhere in `index.c`; this call site
was missed (the sibling `mport_index_mirror_list` and
`mport_moved_lookup` already guard their columns on `main`).

## Fix

- Capture the column once and **skip** rows whose URL is `NULL` or empty
  before `strdup` — an empty URL cannot be fetched from and would only
  relocate the failure into the URL-parsing consumer.
- Refine `*list_size` to the number of entries actually stored, so it
  stays consistent now that rows can be skipped. `*list_size` is still
  initialized (`= len`) before the loop, and the `calloc(len + 1)`
  buffer and its trailing NULL terminator are unaffected; both `fetch.c`
  consumers iterate to the NULL sentinel, not by the count.

Non-NULL, non-empty mirrors are stored byte-identically to before.

## Verification

This fix was developed against `ac69ac3` and rebased onto current
`main` (`7e90e91`); it applies cleanly. It was reviewed by an
independent verifier and an adversarial reviewer of the isolated diff
(no new attack path; the empty-mirror-list case falls through to the
existing bootstrap-index path, not an attacker-chosen fallback).

**Not runtime-tested:** the tree builds only on MidnightBSD (needs
`ucl_object_t` and related headers) and the test suite mocks this
function, so the behaviour argument rests on code review, not a test
run. `cppcheck` is clean on the changed region; `clang-format`/`splint`
were unavailable on the dev host, so the project's usual pre-commit
formatting/splint pass was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Guard mirror list construction against NULL or empty URLs when loading from the index database to avoid crashes and keep the reported list size consistent with the populated entries.

Bug Fixes:
- Prevent a NULL-pointer dereference in mport_index_get_mirror_list by skipping NULL or empty mirror URLs before duplicating them.
- Ensure the mirror list size output reflects the actual number of valid mirror entries stored after filtering.