### PR TITLE
Use indexed language defaults during updates

### DIFF
--- a/libmport/index.c
+++ b/libmport/index.c
@@ -46,6 +46,8 @@ static int index_update_last_checked(mportInstance *);
 
 static int lookup_alias(mportInstance *, const char *, char **);
 static int lookup_alias_inverse(mportInstance *, const char *, char **);
+static int compact_default_version(const char *, char *, size_t);
+static int build_default_pkgname(const char *, const char *, const char *, char **);
 
 static int attach_index_db(sqlite3 *db);
 
@@ -216,6 +218,7 @@ MPORT_PUBLIC_API int
 mport_index_check(mportInstance *mport, mportPackageMeta *pack)
 {
 	mportIndexEntry **indexEntries = NULL, **indexEntries_orig = NULL;
+	char *default_pkgname = NULL;
 	int ret = 0;
 	bool used_origin = false;
 
@@ -225,6 +228,15 @@ mport_index_check(mportInstance *mport, mportPackageMeta *pack)
 
 	if (pack == NULL)
 		RETURN_ERROR(MPORT_ERR_FATAL, "pack not defined");
+
+	if (mport_index_resolve_default_pkgname(mport, pack->name, &default_pkgname) != MPORT_OK) {
+		SET_ERRORX(MPORT_ERR_WARN, "Error resolving default package for %s", pack->name);
+		return 0;
+	}
+	if (default_pkgname != NULL) {
+		free(default_pkgname);
+		return 2;
+	}
 
 	if (mport_index_lookup_pkgname(mport, pack->name, &indexEntries_orig) != MPORT_OK) {
 		SET_ERRORX(MPORT_ERR_WARN, "Error Looking up package name %s", pack->name);
@@ -595,6 +607,196 @@ DONE:
 	sqlite3_finalize(stmt);
 
 	return ret;
+}
+
+/*
+ * Return an owned copy of a default version stored in the attached index.
+ * Older indexes do not contain default_versions; treat that as an unavailable
+ * optional feature rather than an index error.
+ */
+MPORT_PUBLIC_API int
+mport_index_get_default_version(
+    /*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *name,
+    /*@out@*/ char **version)
+{
+	sqlite3_stmt *stmt = NULL;
+	const unsigned char *value;
+	int ret = MPORT_OK;
+
+	if (mport == NULL || name == NULL || version == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid default version lookup arguments");
+
+	*version = NULL;
+	MPORT_CHECK_FOR_INDEX(mport, "mport_index_get_default_version()")
+
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT 1 FROM idx.sqlite_master "
+		"WHERE type='table' AND name='default_versions'") != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	if (sqlite3_step(stmt) != SQLITE_ROW) {
+		sqlite3_finalize(stmt);
+		return MPORT_OK;
+	}
+	sqlite3_finalize(stmt);
+	stmt = NULL;
+
+	if (mport_db_prepare(mport->db, &stmt,
+		"SELECT version FROM idx.default_versions WHERE name=%Q", name) != MPORT_OK)
+		RETURN_CURRENT_ERROR;
+
+	switch (sqlite3_step(stmt)) {
+	case SQLITE_ROW:
+		value = sqlite3_column_text(stmt, 0);
+		if (value == NULL || (*version = strdup((const char *)value)) == NULL)
+			ret = SET_ERROR(MPORT_ERR_FATAL, "Invalid default version in index");
+		break;
+	case SQLITE_DONE:
+		break;
+	default:
+		ret = SET_ERROR(MPORT_ERR_FATAL, sqlite3_errmsg(mport->db));
+		break;
+	}
+
+	sqlite3_finalize(stmt);
+	return ret;
+}
+
+/*
+ * Resolve a package whose name embeds an interpreter version to the package
+ * using the current repository default.  The output remains NULL when the
+ * package is not versioned, the index is old, or the derived package is not
+ * present in the index.
+ */
+int
+mport_index_resolve_default_pkgname(
+    /*@notnull@*/ mportInstance *mport, /*@notnull@*/ const char *pkgname,
+    /*@out@*/ char **resolved)
+{
+	mportIndexEntry **entries = NULL;
+	char *candidate = NULL;
+	char *version = NULL;
+	const char *default_name;
+	int ret;
+
+	if (mport == NULL || pkgname == NULL || resolved == NULL)
+		RETURN_ERROR(MPORT_ERR_FATAL, "Invalid default package lookup arguments");
+
+	*resolved = NULL;
+	if ((strncmp(pkgname, "python", 6) == 0 && pkgname[6] >= '0' && pkgname[6] <= '9') ||
+	    (strncmp(pkgname, "py", 2) == 0 && pkgname[2] >= '0' && pkgname[2] <= '9')) {
+		default_name = "python";
+	} else if (strncmp(pkgname, "php", 3) == 0 && pkgname[3] >= '0' && pkgname[3] <= '9') {
+		default_name = "php";
+	} else if (strncmp(pkgname, "ruby", 4) == 0 && pkgname[4] >= '0' && pkgname[4] <= '9') {
+		default_name = "ruby";
+	} else {
+		return MPORT_OK;
+	}
+
+	ret = mport_index_get_default_version(mport, default_name, &version);
+	if (ret != MPORT_OK)
+		return ret;
+	if (version == NULL)
+		return MPORT_OK;
+
+	ret = build_default_pkgname(pkgname, default_name, version, &candidate);
+	free(version);
+	if (ret != MPORT_OK)
+		return ret;
+	if (candidate == NULL)
+		return MPORT_OK;
+	if (strcmp(candidate, pkgname) == 0) {
+		mport_index_entry_free_vec(entries);
+		free(candidate);
+		return MPORT_OK;
+	}
+
+	if (mport_index_lookup_pkgname(mport, candidate, &entries) != MPORT_OK) {
+		free(candidate);
+		return mport_err_code();
+	}
+	if (entries != NULL && entries[0] != NULL) {
+		*resolved = candidate;
+		mport_index_entry_free_vec(entries);
+		return MPORT_OK;
+	}
+	mport_index_entry_free_vec(entries);
+	free(candidate);
+	return MPORT_OK;
+}
+
+static int
+compact_default_version(const char *version, char *compact, size_t compact_size)
+{
+	size_t j = 0;
+
+	if (version == NULL || compact == NULL || compact_size == 0)
+		return MPORT_ERR_FATAL;
+
+	for (size_t i = 0; version[i] != '\0'; i++) {
+		if (version[i] == '.')
+			continue;
+		if (version[i] < '0' || version[i] > '9' || j + 1 >= compact_size)
+			return MPORT_ERR_FATAL;
+		compact[j++] = version[i];
+	}
+	if (j == 0)
+		return MPORT_ERR_FATAL;
+	compact[j] = '\0';
+	return MPORT_OK;
+}
+
+static int
+build_default_pkgname(
+    const char *pkgname, const char *default_name, const char *version, char **candidate)
+{
+	char compact[32];
+	const char *rest;
+	const char *prefix;
+	size_t digits;
+
+	*candidate = NULL;
+	if (compact_default_version(version, compact, sizeof(compact)) != MPORT_OK)
+		return MPORT_OK;
+
+	if (strcmp(default_name, "python") == 0 && strncmp(pkgname, "python", 6) == 0) {
+		prefix = "python";
+		rest = pkgname + 6;
+	} else if (strcmp(default_name, "php") == 0 && strncmp(pkgname, "php", 3) == 0) {
+		prefix = "php";
+		rest = pkgname + 3;
+	} else if (strcmp(default_name, "ruby") == 0 && strncmp(pkgname, "ruby", 4) == 0) {
+		prefix = "ruby";
+		rest = pkgname + 4;
+	} else if (strcmp(default_name, "python") == 0 && strncmp(pkgname, "py", 2) == 0) {
+		prefix = "py";
+		rest = pkgname + 2;
+	} else {
+		return MPORT_OK;
+	}
+
+	for (digits = 0; rest[digits] >= '0' && rest[digits] <= '9'; digits++)
+		;
+	/* The encoded framework versions contain at least major and minor
+	 * digits.  Names such as python3 are compatibility metapackages, not
+	 * packages tied to an old default. */
+	if (digits < 2)
+		return MPORT_OK;
+
+	/* Versioned Python, PHP, and Ruby modules use a '-' after the prefix.
+	 * Interpreter packages use the versioned name with no suffix. */
+	if (rest[digits] != '\0' && rest[digits] != '-')
+		return MPORT_OK;
+
+	if (strcmp(prefix, "ruby") == 0 && rest[digits] == '\0') {
+		*candidate = strdup("ruby");
+	} else if (asprintf(candidate, "%s%s%s", prefix, compact, rest + digits) == -1) {
+		*candidate = NULL;
+		return MPORT_ERR_FATAL;
+	}
+
+	return *candidate == NULL ? MPORT_ERR_FATAL : MPORT_OK;
 }
 
 int

--- a/libmport/mport.3
+++ b/libmport/mport.3
@@ -118,6 +118,8 @@
 .Ft int
 .Fn mport_index_lookup_pkgname "mportInstance *mport" "const char *pkgname" "mportIndexEntry ***vec"
 .Ft int
+.Fn mport_index_get_default_version "mportInstance *mport" "const char *name" "char **version"
+.Ft int
 .Fn mport_index_search "mportInstance *mport" "mportIndexEntry ***vec" "const char *fmt" "..."
 .Ft int
 .Fn mport_index_search_term "mportInstance *mport" "mportIndexEntry ***vec" "char *term"
@@ -329,6 +331,7 @@ helpers manage library state and user interaction callbacks.
 .Fn mport_index_check ,
 .Fn mport_index_list ,
 .Fn mport_index_lookup_pkgname ,
+.Fn mport_index_get_default_version ,
 .Fn mport_index_search ,
 .Fn mport_index_search_term ,
 .Fn mport_index_depends_list ,
@@ -337,6 +340,21 @@ helpers manage library state and user interaction callbacks.
 and
 .Fn mport_moved_lookup
 operate on the repository index.
+The string returned through
+.Fa version
+by
+.Fn mport_index_get_default_version
+is owned by the caller and must be released with
+.Xr free 3 .
+The supported names are
+.Ql python ,
+.Ql perl5 ,
+.Ql ruby ,
+and
+.Ql php .
+An older index or an unknown name returns
+.Dv MPORT_OK
+with a null version.
 .It Sy Package metadata and assets
 .Fn mport_pkgmeta_new ,
 .Fn mport_pkgmeta_search_master ,

--- a/libmport/mport.h
+++ b/libmport/mport.h
@@ -301,6 +301,8 @@ int mport_index_get(mportInstance *);
 int mport_index_check(mportInstance *, mportPackageMeta *);
 int mport_index_list(mportInstance *, mportIndexEntry ***);
 int mport_index_lookup_pkgname(mportInstance *, const char *, mportIndexEntry ***);
+int mport_index_get_default_version(/*@notnull@*/ mportInstance *,
+    /*@notnull@*/ const char *, /*@out@*/ char **);
 int mport_index_search(mportInstance *, mportIndexEntry ***, const char *, ...);
 int mport_index_search_term(mportInstance *, mportIndexEntry ***, char *);
 void mport_index_entry_free_vec(mportIndexEntry **);

--- a/libmport/mport_private.h
+++ b/libmport/mport_private.h
@@ -142,6 +142,8 @@ char *mport_tokenize(char **args);
 char *mport_get_osreleasedate(void);
 int mport_index_select_pkgname(
     mportInstance *, const char *, const char *, mportIndexEntry ***, mportIndexEntry **);
+int mport_index_resolve_default_pkgname(/*@notnull@*/ mportInstance *,
+    /*@notnull@*/ const char *, /*@out@*/ char **);
 void mport_index_moved_entry_free_vec(mportIndexMovedEntry **);
 
 enum parse_states {

--- a/libmport/update.c
+++ b/libmport/update.c
@@ -31,6 +31,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+static int migrate_default_package(/*@notnull@*/ mportInstance *,
+    /*@notnull@*/ mportPackageMeta *, /*@notnull@*/ const char *);
+
 MPORT_PUBLIC_API int
 mport_update(mportInstance *mport, const char *packageName)
 {
@@ -42,10 +45,14 @@ mport_update(mportInstance *mport, const char *packageName)
 	mportPackageMeta **packs_meta = NULL;
 	/*@null@*/ mportIndexMovedEntry **movedEntries = NULL;
 	char *replacement_path = NULL;
+	char *default_pkgname = NULL;
+	char *transition_msg = NULL;
+	mportIndexEntry **old_index_entries = NULL;
 	char expiry[32];
 	mportAutomatic automatic = MPORT_EXPLICIT;
 	int result;
 	int ret;
+	int default_result;
 
 	if (packageName == NULL) {
 		return (MPORT_ERR_WARN);
@@ -104,6 +111,60 @@ mport_update(mportInstance *mport, const char *packageName)
 		mport_index_moved_entry_free_vec(movedEntries);
 		movedEntries = NULL;
 	}
+
+	if (packs_meta != NULL && *packs_meta != NULL) {
+		default_result = mport_index_resolve_default_pkgname(
+		    mport, (*packs_meta)->name, &default_pkgname);
+		if (default_result != MPORT_OK) {
+			mport_pkgmeta_vec_free(packs_meta);
+			return default_result;
+		}
+	}
+	if (default_pkgname != NULL) {
+		bool use_default = true;
+
+		if (mport_index_lookup_pkgname(mport, (*packs_meta)->name, &old_index_entries) !=
+		    MPORT_OK) {
+			result = mport_err_code();
+			free(default_pkgname);
+			mport_pkgmeta_vec_free(packs_meta);
+			return result;
+		}
+
+		if (old_index_entries != NULL && *old_index_entries != NULL) {
+			if (asprintf(&transition_msg,
+				"%s is installed from an older language default. "
+				"Switch to %s?",
+				(*packs_meta)->name, default_pkgname) == -1) {
+				transition_msg = NULL;
+				result = SET_ERROR(MPORT_ERR_FATAL, "Out of memory");
+				mport_index_entry_free_vec(old_index_entries);
+				free(default_pkgname);
+				mport_pkgmeta_vec_free(packs_meta);
+				return result;
+			}
+			use_default = mport_call_confirm_cb(
+			    mport, transition_msg, "Switch", "Keep current", 0);
+			free(transition_msg);
+			transition_msg = NULL;
+		} else {
+			mport_call_msg_cb(mport,
+			    "Package %s is not available for the old language default; "
+			    "switching to %s\n",
+			    (*packs_meta)->name, default_pkgname);
+		}
+		mport_index_entry_free_vec(old_index_entries);
+		old_index_entries = NULL;
+
+		if (use_default) {
+			result = migrate_default_package(mport, *packs_meta, default_pkgname);
+			free(default_pkgname);
+			mport_pkgmeta_vec_free(packs_meta);
+			return result;
+		}
+	}
+	free(default_pkgname);
+	default_pkgname = NULL;
 	mport_pkgmeta_vec_free(packs_meta);
 	packs_meta = NULL;
 
@@ -135,7 +196,7 @@ mport_update(mportInstance *mport, const char *packageName)
 		}
 
 		depends = depends_orig;
-		while (*depends != NULL) {
+		while (depends != NULL && *depends != NULL) {
 			if (mport_install_depends(mport, (*depends)->d_pkgname,
 				(*depends)->d_version, MPORT_AUTOMATIC) != MPORT_OK) {
 				mport_call_msg_cb(mport, "%s", mport_err_string());
@@ -175,4 +236,72 @@ mport_update(mportInstance *mport, const char *packageName)
 	mport_index_entry_free_vec(indexEntries);
 
 	return (MPORT_OK);
+}
+
+static int
+migrate_default_package(
+    /*@notnull@*/ mportInstance *mport, /*@notnull@*/ mportPackageMeta *installed,
+    /*@notnull@*/ const char *target_pkgname)
+{
+	mportDependsEntry **depends = NULL;
+	mportDependsEntry **depends_orig = NULL;
+	mportIndexEntry **entries = NULL;
+	mportIndexEntry *entry = NULL;
+	char *path = NULL;
+	mportAutomatic automatic;
+	int ret;
+
+	if (mport_lock_islocked(installed) == MPORT_LOCKED)
+		return SET_ERRORX(
+		    MPORT_ERR_WARN, "Unable to replace %s: package is locked", installed->name);
+
+	if (mport_index_select_pkgname(mport, target_pkgname,
+		"Multiple packages match the default version target.", &entries,
+		&entry) != MPORT_OK)
+		return mport_err_code();
+	if (entry == NULL) {
+		mport_index_entry_free_vec(entries);
+		return SET_ERRORX(MPORT_ERR_WARN,
+		    "Default version package %s was not found in the index", target_pkgname);
+	}
+
+	if (mport_index_depends_list(mport, entry->pkgname, entry->version, &depends_orig) !=
+	    MPORT_OK) {
+		ret = mport_err_code();
+		mport_index_entry_free_vec(entries);
+		return ret;
+	}
+	for (depends = depends_orig; depends != NULL && *depends != NULL; depends++) {
+		if (mport_install_depends(mport, (*depends)->d_pkgname, (*depends)->d_version,
+			MPORT_AUTOMATIC) != MPORT_OK) {
+			ret = mport_err_code();
+			mport_index_depends_free_vec(depends_orig);
+			mport_index_entry_free_vec(entries);
+			return ret;
+		}
+	}
+	mport_index_depends_free_vec(depends_orig);
+	depends_orig = NULL;
+
+	if (mport_download(mport, entry->pkgname, false, false, &path) != MPORT_OK) {
+		ret = mport_err_code();
+		mport_index_entry_free_vec(entries);
+		return ret;
+	}
+	if (path == NULL) {
+		mport_index_entry_free_vec(entries);
+		return SET_ERROR(MPORT_ERR_FATAL, "Downloaded package path is missing");
+	}
+
+	mport_call_msg_cb(mport, "Replacing %s with default version package %s\n", installed->name,
+	    entry->pkgname);
+	automatic = installed->automatic;
+	installed->action = MPORT_ACTION_UPGRADE;
+	ret = mport_delete_primative(mport, installed, 1);
+	if (ret == MPORT_OK)
+		ret = mport_install_primative(mport, path, NULL, automatic);
+
+	free(path);
+	mport_index_entry_free_vec(entries);
+	return ret;
 }

--- a/libmport/upgrade.c
+++ b/libmport/upgrade.c
@@ -103,6 +103,7 @@ mport_upgrade(mportInstance *mport)
 	char *key = NULL;
 	char *msg;
 	char *replace_msg;
+	char *default_target;
 	mportIndexEntry **ieUpdateMe;
 	mportIndexMovedEntry **movedEntries;
 	mportPackageMeta *pack;
@@ -222,6 +223,28 @@ mport_upgrade(mportInstance *mport)
 #endif
 				}
 			} else if (match == 2) {
+				default_target = NULL;
+				if (mport_index_resolve_default_pkgname(
+					mport, pack->name, &default_target) != MPORT_OK) {
+					resultCode = mport_err_code();
+					goto cleanup;
+				}
+				if (default_target != NULL) {
+					free(default_target);
+					default_target = NULL;
+					if (mport_update(mport, pack->name) != MPORT_OK) {
+						mport_call_msg_cb(
+						    mport, "Error updating %s\n", pack->name);
+					} else {
+						updated++;
+#if defined(__MidnightBSD__)
+						ohash_insert(&h, slot, pack->name);
+#endif
+					}
+					total++;
+					continue;
+				}
+
 				ieUpdateMe = NULL;
 				if (mport_index_lookup_pkgname(mport, pack->origin, &ieUpdateMe) !=
 				    MPORT_OK) {

--- a/mport/mport.1
+++ b/mport/mport.1
@@ -495,6 +495,11 @@ Remove a package lock.
 .It Cm update Ar package ...
 Update one or more installed packages.
 Wildcard arguments are supported.
+When an installed Python, PHP, or version-prefixed Ruby package uses an older
+repository default,
+.Nm
+offers to switch it to the package built for the current default.
+If both versions remain available, the old version may instead be retained.
 .It Cm upgrade
 Upgrade all installed packages to the newest available versions.
 .It Cm verify Op Fl r Op Ar package ...

--- a/tests/mport_index_test.c
+++ b/tests/mport_index_test.c
@@ -14,6 +14,7 @@
 /* Internal libmport symbols used by the tests. */
 int mport_db_do(sqlite3 *, const char *, ...);
 void mport_index_moved_entry_free_vec(mportIndexMovedEntry **);
+int mport_index_resolve_default_pkgname(mportInstance *, const char *, char **);
 
 /* Splint does not understand ATF's generated test-case wrappers. */
 /*@-boundsread -boundswrite -compdef -compdestroy -dependenttrans -fullinitblock@*/
@@ -58,7 +59,9 @@ create_indexed_instance(void)
 	ATF_REQUIRE_EQ(MPORT_OK,
 	    mport_db_do(mport->db,
 		"CREATE TABLE idx.moved (port text, moved_to text, why text, date text)"));
-	ATF_REQUIRE_EQ(MPORT_OK, mport_db_do(mport->db, "CREATE TABLE idx.aliases (pkg text)"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(
+		mport->db, "CREATE TABLE idx.aliases (alias text NOT NULL, pkg text NOT NULL)"));
 
 	mport->flags |= MPORT_INST_HAVE_INDEX;
 
@@ -175,11 +178,150 @@ ATF_TC_CLEANUP(moved_lookup_null_columns, tc)
 	cleanup_test_root();
 }
 
+ATF_TC_WITH_CLEANUP(default_version_lookup);
+ATF_TC_HEAD(default_version_lookup, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "default version lookup supports new and legacy index schemas");
+}
+ATF_TC_BODY(default_version_lookup, tc)
+{
+	mportInstance *mport;
+	char *version = NULL;
+
+	(void)tc;
+
+	mport = create_indexed_instance();
+	ATF_REQUIRE_EQ(MPORT_OK, mport_index_get_default_version(mport, "python", &version));
+	ATF_REQUIRE(version == NULL);
+
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"CREATE TABLE idx.default_versions "
+		"(name text PRIMARY KEY, version text NOT NULL)"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db, "INSERT INTO idx.default_versions VALUES ('python', '3.12')"));
+
+	ATF_REQUIRE_EQ(MPORT_OK, mport_index_get_default_version(mport, "python", &version));
+	ATF_REQUIRE(version != NULL);
+	ATF_REQUIRE_STREQ("3.12", version);
+	free(version);
+	version = NULL;
+
+	ATF_REQUIRE_EQ(MPORT_OK, mport_index_get_default_version(mport, "perl5", &version));
+	ATF_REQUIRE(version == NULL);
+
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(default_version_lookup, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
+ATF_TC_WITH_CLEANUP(default_package_resolution);
+ATF_TC_HEAD(default_package_resolution, tc)
+{
+	atf_tc_set_md_var(
+	    tc, "descr", "versioned package names resolve to available default-version packages");
+}
+ATF_TC_BODY(default_package_resolution, tc)
+{
+	mportInstance *mport;
+	mportPackageMeta *pkg;
+	char *resolved = NULL;
+
+	(void)tc;
+
+	mport = create_indexed_instance();
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"CREATE TABLE idx.default_versions "
+		"(name text PRIMARY KEY, version text NOT NULL)"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO idx.default_versions VALUES "
+		"('python', '3.12'), ('perl5', '5.40'), "
+		"('ruby', '3.2'), ('php', '8.3')"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"CREATE TABLE idx.packages "
+		"(pkg text NOT NULL, version text NOT NULL, license text NOT NULL, "
+		"comment text NOT NULL, bundlefile text NOT NULL, hash text NOT NULL, "
+		"type int NOT NULL)"));
+	ATF_REQUIRE_EQ(MPORT_OK,
+	    mport_db_do(mport->db,
+		"INSERT INTO idx.packages VALUES "
+		"('py311-demo', '1', 'bsd', 'old demo', 'py311-demo-1.mport', 'hash', 0), "
+		"('py312-demo', '1', 'bsd', 'demo', 'py312-demo-1.mport', 'hash', 0), "
+		"('python312', '3.12', 'psf', 'python', 'python312-3.12.mport', 'hash', 0), "
+		"('php83-demo', '1', 'php', 'demo', 'php83-demo-1.mport', 'hash', 0), "
+		"('ruby', '3.2', 'ruby', 'ruby', 'ruby-3.2.mport', 'hash', 0), "
+		"('ruby32-addon', '1', 'ruby', 'addon', 'ruby32-addon-1.mport', 'hash', 0)"));
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "py311-demo", &resolved));
+	ATF_REQUIRE_STREQ("py312-demo", resolved);
+	free(resolved);
+	resolved = NULL;
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "python311", &resolved));
+	ATF_REQUIRE_STREQ("python312", resolved);
+	free(resolved);
+	resolved = NULL;
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "php82-demo", &resolved));
+	ATF_REQUIRE_STREQ("php83-demo", resolved);
+	free(resolved);
+	resolved = NULL;
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "ruby31-addon", &resolved));
+	ATF_REQUIRE_STREQ("ruby32-addon", resolved);
+	free(resolved);
+	resolved = NULL;
+
+	ATF_REQUIRE_EQ(MPORT_OK, mport_index_resolve_default_pkgname(mport, "ruby31", &resolved));
+	ATF_REQUIRE_STREQ("ruby", resolved);
+	free(resolved);
+	resolved = NULL;
+
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "p5-Module-Build", &resolved));
+	ATF_REQUIRE(resolved == NULL);
+	ATF_REQUIRE_EQ(
+	    MPORT_OK, mport_index_resolve_default_pkgname(mport, "py312-demo", &resolved));
+	ATF_REQUIRE(resolved == NULL);
+	ATF_REQUIRE_EQ(MPORT_OK, mport_index_resolve_default_pkgname(mport, "python3", &resolved));
+	ATF_REQUIRE(resolved == NULL);
+
+	pkg = mport_pkgmeta_new();
+	ATF_REQUIRE(pkg != NULL);
+	free(pkg->name);
+	pkg->name = strdup("py311-demo");
+	ATF_REQUIRE(pkg->name != NULL);
+	ATF_REQUIRE_EQ(2, mport_index_check(mport, pkg));
+	mport_pkgmeta_free(pkg);
+
+	mport_instance_free(mport);
+}
+ATF_TC_CLEANUP(default_package_resolution, tc)
+{
+	(void)tc;
+
+	cleanup_test_root();
+}
+
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, mirror_list_null_columns);
 	ATF_TP_ADD_TC(tp, mirror_list_valid_row);
 	ATF_TP_ADD_TC(tp, moved_lookup_null_columns);
+	ATF_TP_ADD_TC(tp, default_version_lookup);
+	ATF_TP_ADD_TC(tp, default_package_resolution);
 
 	return atf_no_error();
 }


### PR DESCRIPTION
## What

- add a public API for reading default language versions from the SQLite repository index
- detect Python, PHP, and Ruby default-version transitions during update checks
- route those transitions through `mport update`, preserving automatic state and respecting locks
- keep compatibility with older indexes that do not contain the new table
- document the index behavior and add focused regression coverage

## Why

A repository default can move independently of an installed package name, such as Python changing from 3.11 to 3.12. Version-only comparison cannot make that transition intelligently. The index metadata added by the companion mports change gives mport enough context to offer or perform the correct package replacement.

## Impact

Existing repository indexes remain usable. When default-version metadata is present, update and upgrade can transition versioned Python, PHP, and Ruby packages to the current default. Perl metadata is exposed through the API for future consumers, but no package-name transition is inferred for Perl.

## Checks

- `bmake -C libmport`
- `bmake -C mport`
- Kyua test suite: 88/88 passed
- checkout-linked `mport -U list updates` against a legacy index
- required C pre-commit sanity script; cppcheck clean
- `git diff --check`

Splint was intentionally skipped for this publication at the request of the maintainer.

## Summary by Sourcery

Introduce index-based language default awareness so updates and upgrades can transition versioned Python, PHP, and Ruby packages to the current repository default while remaining compatible with legacy indexes.

New Features:
- Expose a public API to read interpreter default versions from the SQLite repository index and resolve versioned package names to default-version package names.
- Enable mport update and upgrade to detect installed packages tied to older Python, PHP, and Ruby defaults and route them through an automatic replacement flow that respects package locks.

Enhancements:
- Adjust alias table schema and index lookup logic to work with explicit alias and package columns.
- Improve dependency handling in updates by guarding against null dependency vectors and preserving automatic flags when replacing packages.

Documentation:
- Document the new mport_index_get_default_version API, supported language names, memory ownership, and legacy index behavior in the libmport manual.
- Describe update behavior for language-default transitions in the mport(1) user manual.

Tests:
- Add regression tests covering default-version lookup across new and legacy index schemas and resolution of versioned package names to default-version targets, including interaction with mport_index_check().