### PR TITLE
Match only the source path of two-argument sample assets in check-fake

### DIFF
--- a/libexec/mport.check-fake/mport.check-fake.c
+++ b/libexec/mport.check-fake/mport.check-fake.c
@@ -70,6 +70,7 @@ diag(const char *fmt, ...)
 #endif
 
 static void usage(void);
+static void truncate_at_whitespace(/*@notnull@*/ char *path);
 static int check_fake(/*@notnull@*/ mportAssetList *, /*@notnull@*/ const char *,
     /*@notnull@*/ const char *,
     /*@null@*/ const char *);
@@ -82,6 +83,26 @@ static int check_missing_from_plist(/*@null@*/ const char *path,
 static void check_for_missing_files(/*@notnull@*/ const char *destdir,
     /*@notnull@*/ const char *prefix,
     /*@notnull@*/ mportAssetList *assetlist);
+
+/*
+ * Sample assets may carry both a source and a destination in a single data
+ * field, separated by whitespace ("@sample source target").  Only the source
+ * names a file that exists in the stage directory, so trim anything from the
+ * first space or tab onwards.  libmport does the same in create_primative.c,
+ * bundle_read_install_pkg.c and check_preconditions.c.
+ */
+static void
+truncate_at_whitespace(char *path)
+{
+	char *sp;
+
+	for (sp = path; *sp != '\0'; sp++) {
+		if (*sp == ' ' || *sp == '\t') {
+			*sp = '\0';
+			break;
+		}
+	}
+}
 
 // Global variables to hold the destdir and assetlist for comparison
 static /*@null@*/ /*@observer@*/ const char *global_destdir;
@@ -255,6 +276,9 @@ check_fake(mportAssetList *assetlist, const char *destdir, const char *prefix, c
 			else
 				(void)snprintf(
 				    file, FILENAME_MAX, "%s%s/%s", destdir, cwd, e->data);
+
+			if (e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE)
+				truncate_at_whitespace(file);
 		}
 
 		if (e->type == ASSET_DIR) {
@@ -303,6 +327,9 @@ check_fake(mportAssetList *assetlist, const char *destdir, const char *prefix, c
 
 		if (lstat(file, &st) != 0) {
 			(void)snprintf(file, FILENAME_MAX, "%s/%s", cwd, e->data);
+
+			if (e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE)
+				truncate_at_whitespace(file);
 
 			if (lstat(file, &st) == 0) {
 				(void)printf("		%s installed in %s\n", e->data, cwd);
@@ -523,14 +550,26 @@ is_in_plist(const char *relative_path, const char *prefix)
 			continue; // Skip entries with NULL data
 		}
 
+		/*
+		 * A sample asset's data may be "source target"; only the source is
+		 * staged, so compare against that alone.  Without this, every
+		 * two-argument @sample entry reports its staged file as missing
+		 * from the plist.
+		 */
+		char data[FILENAME_MAX];
+		(void)strlcpy(data, e->data, sizeof(data));
+		if (e->type == ASSET_SAMPLE || e->type == ASSET_SAMPLE_OWNER_MODE) {
+			truncate_at_whitespace(data);
+		}
+
 		// Check for an exact match (absolute path)
-		if (strcmp(e->data, relative_path) == 0) {
+		if (strcmp(data, relative_path) == 0) {
 			return true;
 		}
 
 		// Check for a match relative to the prefix
 		char prefixed_path[FILENAME_MAX];
-		snprintf(prefixed_path, sizeof(prefixed_path), "%s/%s", prefix, e->data);
+		snprintf(prefixed_path, sizeof(prefixed_path), "%s/%s", prefix, data);
 		if (strcmp(prefixed_path, relative_path) == 0) {
 			return true;
 		}


### PR DESCRIPTION
`mport.check-fake` reported a staged file as missing from the plist for every port using the two-argument `@sample source target` form:

```
$ /usr/libexec/mport.check-fake -f work-php83/.PLIST.mktmp -d work-php83/fake-inst-amd64 -p /usr/local
    /usr/local/share/examples/roundcube/newsyslog.conf is missing from the plist
```

**The package was correct; only the diagnostic was wrong.** libmport already accounts for the two-argument form everywhere it resolves such an asset to a file on disk — `create_primative.c:212`, `bundle_read_install_pkg.c:833` and `check_preconditions.c:558` all truncate at the first space or tab, and `create_sample_file()` splits the pair with `parse_sample()` to copy source to target on install. `mport.check-fake` was the one place that did not.

## Changes

Three call sites, all using one helper that mirrors libmport's truncation:

1. **`is_in_plist()`** — compared the entire `"source target"` data field against the staged path with `strcmp()`, which can never match. This is what produced the warning above.
2. **Path construction in `check_fake()`** — `ASSET_SAMPLE` is deliberately skipped in the type filter, but `ASSET_SAMPLE_OWNER_MODE` is not. A two-argument `@sample(owner,group,mode) source target` therefore reached `lstat()` with an unusable path and reported `%s not installed` for the same underlying reason.
3. **The retry branch** in that loop rebuilds the path from raw `e->data`, so it needed the same treatment.

## Verification

| Check | Result |
|---|---|
| `mail/roundcube` staged tree | false positive gone; rest of output unchanged |
| 5 other staged ports (`py-email-validator`, `msmtp`, `mlmmj`, `bogofilter-bdb`, `groff`) | output byte-identical before/after |
| synthetic plist with both `@sample` forms | two-arg fixed, one-arg behaviour unchanged |
| build | clean under `-Werror` |
| `precommit_c_sanity.sh` | cppcheck clean |
| `run_splint_on_staged.sh` | stops at a parse error on `DIR *dir = opendir(file)` — **pre-existing**; the pristine `main` version produces the identical error |

Synthetic test, before and after:

```
plist:
  bin/demo
  @sample etc/demo.conf.sample
  @sample share/examples/demo/demo.conf etc/demo.conf.d/demo.conf

OLD:  /usr/local/share/examples/demo/demo.conf is missing from the plist
NEW:  (no output)
```

## Scope

28 ports in the mports tree use the two-argument form, so this clears a spurious warning across all of them. `mail/roundcube` is where it was reported.

## Not addressed here

The asset loop uses `break` rather than `continue` for `ASSET_CWD` and `ASSET_DIR` (lines 249 and 283), which ends the loop at the first such entry and skips the per-asset checks after it. That is deliberate: both keywords change the path that subsequent entries resolve against, and resolving them correctly means tracking that state. Left as-is — it is a separate change with a much wider blast radius, since it would surface warnings currently suppressed across the tree.

AI-Assisted-By: Claude Opus 5 (1M context)

## Summary by Sourcery

Adjust sample asset handling in mport.check-fake so staged file checks and plist matching work correctly for two-argument @sample entries.

Bug Fixes:
- Ensure file paths derived from ASSET_SAMPLE and ASSET_SAMPLE_OWNER_MODE assets ignore the destination part of two-argument @sample entries when checking staged files.
- Fix plist membership checks so two-argument @sample assets compare only their source path and no longer produce false "missing from the plist" diagnostics.

Enhancements:
- Introduce a shared helper to consistently truncate asset paths at the first whitespace, matching libmport’s handling of sample assets.